### PR TITLE
RUN-2807 reload breaks parenting model

### DIFF
--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -99,17 +99,17 @@ electronApp.on('ready', function() {
                 if (uuid) {
                     ofEvents.emit(eventRoute(uuid, 'manifest-changed'), sourceUrl, json);
                 } else {
-                    log.writeToLog(1, 'Received manifest-changed event from RVM, unable to determine uuid from source url though: ' + sourceUrl, true);
+                    log.writeToLog(1, `Received manifest-changed event from RVM, unable to determine uuid from source url though: ${sourceUrl}`, true);
                 }
             });
         } else {
-            log.writeToLog(1, 'Received manifest-changed event from RVM with invalid data object: ' + payload, true);
+            log.writeToLog(1, `Received manifest-changed event from RVM with invalid data object: ${payload}`, true);
         }
     });
 
 });
 
-Application.create = function(opts, configUrl = '', parentIdentify = {}) {
+Application.create = function(opts, configUrl = '', parentIdentity = {}) {
     //Hide Window until run is called
 
     let appUrl = opts.url;
@@ -138,7 +138,7 @@ Application.create = function(opts, configUrl = '', parentIdentify = {}) {
         throw new Error(`Application with specified UUID already exists: ${opts.uuid}`);
     }
 
-    let parentUuid = parentIdentify && parentIdentify.uuid;
+    let parentUuid = parentIdentity && parentIdentity.uuid;
     if (!validateNavigationRules(opts.uuid, appUrl, parentUuid, opts)) {
         throw new Error(`Application with specified URL is not allowed: ${opts.appUrl}`);
     }
@@ -150,10 +150,10 @@ Application.create = function(opts, configUrl = '', parentIdentify = {}) {
 
     let appObj = createAppObj(opts.uuid, opts, configUrl);
 
-    if (parentIdentify && parentIdentify.uuid) {
+    if (parentIdentity && parentIdentity.uuid) {
         let app = coreState.appByUuid(opts.uuid);
 
-        app.parentUuid = parentIdentify.uuid;
+        app.parentUuid = parentIdentity.uuid;
     }
 
     return appObj;

--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -84,7 +84,7 @@ electronApp.on('use-plugins-requested', event => {
 });
 
 electronApp.on('ready', function() {
-    console.log('RVM MESSAGE BUS READY');
+    log.writeToLog(1,'RVM MESSAGE BUS READY', true);
     rvmBus = require('../rvm/rvm_message_bus.js');
     MonitorInfo = require('../monitor_info.js');
 
@@ -99,11 +99,11 @@ electronApp.on('ready', function() {
                 if (uuid) {
                     ofEvents.emit(eventRoute(uuid, 'manifest-changed'), sourceUrl, json);
                 } else {
-                    console.log('Received manifest-changed event from RVM, unable to determine uuid from source url though:', sourceUrl);
+                    log.writeToLog(1,'Received manifest-changed event from RVM, unable to determine uuid from source url though: ' + sourceUrl, true);
                 }
             });
         } else {
-            console.log('Received manifest-changed event from RVM with invalid data object: ', payload);
+            log.writeToLog(1,'Received manifest-changed event from RVM with invalid data object: ' + payload, true);
         }
     });
 
@@ -149,8 +149,11 @@ Application.create = function(opts, configUrl = '', parentIdentify = {}) {
     }
 
     let appObj = createAppObj(opts.uuid, opts, configUrl);
+
     if (parentIdentify && parentIdentify.uuid) {
-        appObj.parentUuid = parentIdentify.uuid;
+        let app = coreState.appByUuid(opts.uuid);
+
+        app.parentUuid = parentIdentify.uuid;
     }
 
     return appObj;
@@ -298,10 +301,12 @@ Application.getManifest = function(identity, callback, errCallback) {
 };
 
 Application.getParentApplication = function(identity) {
-    let appObject = coreState.getAppObjByUuid(identity.uuid);
-    if (appObject && appObject.parentUuid) {
-        return appObject.parentUuid;
-    }
+    const app = coreState.appByUuid(identity.uuid);
+    const {
+        parentUuid
+    } = app || {};
+
+    return parentUuid;
 };
 
 Application.getShortcuts = function(identity, callback, errorCallback) {
@@ -857,6 +862,7 @@ function removeTrayIcon(app) {
 function createAppObj(uuid, opts, configUrl = '') {
     let appObj;
     let app = coreState.appByUuid(uuid);
+
     if (app && app.appObj) {
         appObj = app.appObj;
     } else {

--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -84,7 +84,7 @@ electronApp.on('use-plugins-requested', event => {
 });
 
 electronApp.on('ready', function() {
-    log.writeToLog(1,'RVM MESSAGE BUS READY', true);
+    log.writeToLog(1, 'RVM MESSAGE BUS READY', true);
     rvmBus = require('../rvm/rvm_message_bus.js');
     MonitorInfo = require('../monitor_info.js');
 
@@ -99,11 +99,11 @@ electronApp.on('ready', function() {
                 if (uuid) {
                     ofEvents.emit(eventRoute(uuid, 'manifest-changed'), sourceUrl, json);
                 } else {
-                    log.writeToLog(1,'Received manifest-changed event from RVM, unable to determine uuid from source url though: ' + sourceUrl, true);
+                    log.writeToLog(1, 'Received manifest-changed event from RVM, unable to determine uuid from source url though: ' + sourceUrl, true);
                 }
             });
         } else {
-            log.writeToLog(1,'Received manifest-changed event from RVM with invalid data object: ' + payload, true);
+            log.writeToLog(1, 'Received manifest-changed event from RVM with invalid data object: ' + payload, true);
         }
     });
 

--- a/src/browser/core_state.js
+++ b/src/browser/core_state.js
@@ -142,6 +142,7 @@ function getAppRestartingState(uuid) {
 
 function setAppRestartingState(uuid, restarting) {
     const app = appByUuid(uuid); // check if uuid is recognized
+
     if (app) {
         app.isRestarting = !!restarting;
     }
@@ -410,7 +411,7 @@ function getAllApplications() {
         return {
             isRunning: app.isRunning,
             uuid: app.uuid,
-            parentUuid: app.appObj && app.appObj.parentUuid
+            parentUuid: app.parentUuid
         };
     });
 }

--- a/src/browser/log.ts
+++ b/src/browser/log.ts
@@ -19,7 +19,7 @@ import {errorToPOJO} from '../common/errors';
 /**
  * Parses log messages and uses Electron's APIs to log them to console
  */
-export function writeToLog(level: any, message: any, debug?: boolean): any {
+export function writeToLog(level: number, message: any, debug?: boolean): any {
     let parsedMessage: string;
 
     // Parse log message

--- a/src/browser/log.ts
+++ b/src/browser/log.ts
@@ -19,7 +19,7 @@ import {errorToPOJO} from '../common/errors';
 /**
  * Parses log messages and uses Electron's APIs to log them to console
  */
-export function writeToLog(level: number, message: any, debug?: boolean): any {
+export function writeToLog(level: any, message: any, debug?: boolean): any {
     let parsedMessage: string;
 
     // Parse log message

--- a/src/browser/navigation_validation.ts
+++ b/src/browser/navigation_validation.ts
@@ -47,9 +47,9 @@ export function validateNavigationRules(uuid: string, url: string, parentUuid: s
         return false;
     } else if (parentUuid) {
         electronApp.vlog(1, `validateNavigationRules app ${uuid} check parent ${parentUuid}`);
-        let parentObject = coreState.getAppObjByUuid(parentUuid);
+        let parentObject = coreState.appByUuid(parentUuid);
         if (parentObject) {
-            let parentOpts = parentObject._options;
+            let parentOpts = parentObject.appObj._options;
             isAllowed = validateNavigationRules(uuid, url, parentObject.parentUuid,parentOpts);
         } else {
             electronApp.vlog(1, `validateNavigationRules missing parent ${parentUuid}`);
@@ -64,8 +64,9 @@ export function navigationValidator(uuid: string, name:string, id: number) {
     const uuidname = `${uuid}-${name}`;
     return (event: any, url: string) => {
         let appObject = coreState.getAppObjByUuid(uuid);
+        let appMetaInfo = coreState.appByUuid(uuid);
         let isMailTo = /^mailto:/i.test(url);
-        let allowed = isMailTo || validateNavigationRules(uuid, url, appObject.parentUuid, appObject._options);
+        let allowed = isMailTo || validateNavigationRules(uuid, url, appMetaInfo.parentUuid, appObject._options);
         if (!allowed) {
             console.log('Navigation is blocked ' + url);
             let self = coreState.getWinById(id);


### PR DESCRIPTION
For `executeJavaScript` you have to be in the parenting lineage of an app (or window). Restarting was breaking this because we were storing the parent info on the app obj that was being cleaned up on the close event. This PR moves the `parentUuid` up to the meta `app` object that persists through the close / restart.

[tests well](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/590b263d5114ac10ca6db32e)
[added test](https://testing-dashboard.openfin.co/#/app/tests/58b5e799b4be9d42a7399632/edit)