### PR TITLE
RUN-2962 adds ability to subscribe to future cross-runtime events

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -344,6 +344,7 @@ module.exports = (grunt) => {
             'src/browser/api_protocol/api_handlers/authorization.js',
             'src/browser/api_protocol/api_handlers/api_policy_processor.ts',
             'src/browser/api_protocol/api_handlers/mesh_middleware.ts',
+            'src/browser/pending_subscriptions.ts',
             'src/browser/port_discovery.ts',
             'src/browser/rvm/rvm_message_bus.js',
             'src/browser/rvm/runtime_initiated_topics/app_assets.js',

--- a/index.js
+++ b/index.js
@@ -56,6 +56,7 @@ import {
 
 import * as log from './src/browser/log';
 
+import { applyAllPendingSubscriptions } from './src/browser/pending_subscriptions';
 
 // locals
 let firstApp = null;
@@ -138,6 +139,8 @@ portDiscovery.on('runtime/launched', (portInfo) => {
             //one connected we broadcast our port discovery message.
             staggerPortBroadcast(myPortInfo);
             log.writeToLog('info', `Connected to runtime ${JSON.stringify(runtimePeer.portInfo)}`);
+
+            applyAllPendingSubscriptions(runtimePeer);
 
         }).catch(err => {
             log.writeToLog('info', `Failed to connect to runtime ${JSON.stringify(portInfo)}, ${JSON.stringify(errors.errorToPOJO(err))}`);

--- a/package.json
+++ b/package.json
@@ -19,12 +19,10 @@
   },
   "homepage": "https://github.com/openfin/openfin",
   "optionalDependencies": {
-    "openfin-sign": "git+ssh://git@github.com:openfin/openfin-sign.git#caee55ecbe6f81e6ed9630790781fe4d1835cb03",
-    "runtime-p2p": "git@github.com:openfin/runtime-p2p.git#95730ce170fca5fb56b35621923d16faf4f1cb86"
+      "openfin-sign": "git+ssh://git@github.com:openfin/openfin-sign.git#caee55ecbe6f81e6ed9630790781fe4d1835cb03",
+      "runtime-p2p": "git@github.com:openfin/runtime-p2p.git#95730ce170fca5fb56b35621923d16faf4f1cb86"
   },
   "devDependencies": {
-    "@types/mocha": "^2.2.39",
-    "@types/mockery": "^1.4.29",
     "@types/node": "^6.0.49",
     "@types/underscore": "^1.8.0",
     "asar": "^0.12.1",
@@ -37,12 +35,10 @@
     "grunt-contrib-jshint": "^0.11.3",
     "grunt-contrib-watch": "^1.0.0",
     "grunt-jsbeautifier": "^0.2.10",
-    "grunt-mocha-test": "^0.13.2",
     "grunt-ts": "^5.5.1",
     "grunt-tslint": "^3.3.0",
     "load-grunt-tasks": "^3.3.0",
     "mocha": "^3.0.2",
-    "mockery": "^2.0.0",
     "rewire": "^2.5.2",
     "should": "^11.1.0",
     "should-sinon": "^0.0.5",
@@ -50,7 +46,11 @@
     "tslint": "4.0.0-dev.0",
     "tslint-microsoft-contrib": "^2.0.13",
     "typescript": "~2.2.0",
-    "wrench": "^1.5.9"
+    "wrench": "^1.5.9",
+    "mockery": "^2.0.0",
+    "@types/mocha": "^2.2.39",
+    "@types/mockery": "^1.4.29",
+    "grunt-mocha-test": "^0.13.2"
   },
   "dependencies": {
     "minimist": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -19,11 +19,14 @@
   },
   "homepage": "https://github.com/openfin/openfin",
   "optionalDependencies": {
-      "openfin-sign": "git+ssh://git@github.com:openfin/openfin-sign.git#caee55ecbe6f81e6ed9630790781fe4d1835cb03",
-      "runtime-p2p": "git@github.com:openfin/runtime-p2p.git#95730ce170fca5fb56b35621923d16faf4f1cb86"
+    "openfin-sign": "git+ssh://git@github.com:openfin/openfin-sign.git#caee55ecbe6f81e6ed9630790781fe4d1835cb03",
+    "runtime-p2p": "git@github.com:openfin/runtime-p2p.git#95730ce170fca5fb56b35621923d16faf4f1cb86"
   },
   "devDependencies": {
+    "@types/mocha": "^2.2.39",
+    "@types/mockery": "^1.4.29",
     "@types/node": "^6.0.49",
+    "@types/underscore": "^1.8.0",
     "asar": "^0.12.1",
     "babel-preset-es2015": "^6.1.4",
     "electron-rebuild": "1.4.0",
@@ -34,10 +37,12 @@
     "grunt-contrib-jshint": "^0.11.3",
     "grunt-contrib-watch": "^1.0.0",
     "grunt-jsbeautifier": "^0.2.10",
+    "grunt-mocha-test": "^0.13.2",
     "grunt-ts": "^5.5.1",
     "grunt-tslint": "^3.3.0",
     "load-grunt-tasks": "^3.3.0",
     "mocha": "^3.0.2",
+    "mockery": "^2.0.0",
     "rewire": "^2.5.2",
     "should": "^11.1.0",
     "should-sinon": "^0.0.5",
@@ -45,11 +50,7 @@
     "tslint": "4.0.0-dev.0",
     "tslint-microsoft-contrib": "^2.0.13",
     "typescript": "~2.2.0",
-    "wrench": "^1.5.9",
-    "mockery": "^2.0.0",
-    "@types/mocha": "^2.2.39",
-    "@types/mockery": "^1.4.29",
-    "grunt-mocha-test": "^0.13.2"
+    "wrench": "^1.5.9"
   },
   "dependencies": {
     "minimist": "^1.2.0",

--- a/src/browser/connection_manager.ts
+++ b/src/browser/connection_manager.ts
@@ -107,7 +107,4 @@ interface ConnectionManager extends EventEmitter {
 
 
 export default connectionManager as ConnectionManager;
-export {
-    meshEnabled,
-    PeerRuntime
-};
+export { meshEnabled, PeerRuntime };

--- a/src/browser/connection_manager.ts
+++ b/src/browser/connection_manager.ts
@@ -11,7 +11,6 @@ Please contact OpenFin Inc. at sales@openfin.co to obtain a Commercial License.
 
 // built-in modules
 declare let process: any;
-const app = require('electron').app;
 import { EventEmitter } from 'events';
 import { Identity } from './api_protocol/transport_strategy/api_transport_base';
 
@@ -82,6 +81,7 @@ interface PeerRuntime {
     portInfo: PortInfo;
     fin: any;
     isDisconnected: boolean;
+    identity: Identity;
 }
 
 interface IdentityAddress {
@@ -107,4 +107,7 @@ interface ConnectionManager extends EventEmitter {
 
 
 export default connectionManager as ConnectionManager;
-export  { meshEnabled };
+export {
+    meshEnabled,
+    PeerRuntime
+};

--- a/src/browser/pending_subscriptions.ts
+++ b/src/browser/pending_subscriptions.ts
@@ -27,9 +27,9 @@ interface IPendingSubscriptionProps {
  * Shape of pending subscriptions
  */
 interface IPendingSubscription extends IPendingSubscriptionProps {
-    _id?: number; // ID of the subscription
-    isCleaned?: boolean; // helps prevents repetitive un-subscriptions
-    unSubscriptions?: { // a map of un-subscriptions assigned to runtime versions
+    _id: number; // ID of the subscription
+    isCleaned: boolean; // helps prevents repetitive un-subscriptions
+    unSubscriptions: { // a map of un-subscriptions assigned to runtime versions
         [runtimeVersion: string]: () => void
     };
 }
@@ -39,10 +39,11 @@ interface IPendingSubscription extends IPendingSubscriptionProps {
  */
 export function addPendingSubscription(subscriptionProps: IPendingSubscriptionProps): Promise<() => void> {
     return new Promise(resolve => {
-        const subscription: IPendingSubscription = _.clone(subscriptionProps);
-
-        subscription._id = getId();
-        subscription.unSubscriptions = {};
+        const subscription: IPendingSubscription = _.extend(_.clone(subscriptionProps), {
+            _id: getId(),
+            isCleaned: false,
+            unSubscriptions: {}
+        });
 
         connectionManager.resolveIdentity({
             uuid: subscription.uuid

--- a/src/browser/pending_subscriptions.ts
+++ b/src/browser/pending_subscriptions.ts
@@ -1,0 +1,168 @@
+/*
+Copyright 2017 OpenFin Inc.
+
+Licensed under OpenFin Commercial License you may not use this file except in compliance with your Commercial License.
+Please contact OpenFin Inc. at sales@openfin.co to obtain a Commercial License.
+*/
+
+import ofEvents from './of_events';
+import connectionManager, { PeerRuntime } from './connection_manager';
+import { System } from './api/system.js';
+
+let subscriptionIdCount = 0; // id count to generate IDs for subscriptions
+const pendingSubscriptions: IPendingSubscription[] = []; // all pending subscriptions are stored here
+
+/**
+ * Shape of pending subscriptions
+ */
+interface IPendingSubscription {
+    _id?: number; // ID of the subscription
+    uuid: string; // app uuid
+    name?: string; // window name
+    className: 'application'|'window'; // names of the class event emitters, used for subscriptions
+    eventName: string; // name of the type of the event to subscribe to
+    listenType: 'on'|'once'; // used to set up subscription type
+    fullEventPath: string; // full event name of the subscription (ex: window/connected/uuid-name)
+    isCleaned?: boolean; // helps prevents repetitive un-subscriptions
+    unSubscriptions?: { // a map of un-subscriptions assigned to runtime versions
+        [runtimeVersion: string]: () => void
+    };
+}
+
+/**
+ * Handles addition of a new pending subscription
+ */
+export function addPendingSubscription(subscription: IPendingSubscription) {
+    return new Promise(resolve => {
+        subscription._id = getId();
+        subscription.unSubscriptions = {};
+
+        connectionManager.resolveIdentity({
+            uuid: subscription.uuid
+
+        }).then((id) => {
+            // Found app/window in a remote runtime, subscribing
+            applyPendingSubscription(id.runtime, subscription);
+
+        }).catch(() => {
+            // App/window not found. We are assuming it will come up sometime in the future.
+            // For now, add the subscription to the list, and subscribe in all
+            // current connected runtimes
+            pendingSubscriptions.push(subscription);
+            connectionManager.connections.forEach((conn) => {
+                applyPendingSubscription(conn, subscription);
+            });
+
+        }).then(() => resolve());
+    });
+}
+
+/**
+ * Subscribe to an event in a remote runtime
+ */
+export function applyPendingSubscription(runtime: PeerRuntime, subscription: IPendingSubscription) {
+    const classEventEmitter = getClassEventEmitter(runtime, subscription);
+    const runtimeVersion = runtime.portInfo.version;
+    const {
+        eventName,
+        listenType,
+        fullEventPath
+    } = subscription;
+
+    function listener(data: any) {
+        ofEvents.emit(fullEventPath, data);
+
+        // As soon as the event listener fires, we know which runtime is a true
+        // subscription 'holder', all other runtimes should remove this subscription
+        cleanUpSubscription(subscription, runtime.portInfo.version);
+    }
+
+    // Subscribe to an event on a remote runtime
+    classEventEmitter[listenType](eventName, listener);
+
+    // Store a cleanup function for the added listener in
+    // un-subscription map, so that later we can remove extra subscriptions
+    subscription.unSubscriptions[runtimeVersion] = () => {
+        classEventEmitter.removeListener(eventName, listener);
+    };
+}
+
+/**
+ * Apply all pending subscriptions for a given runtime
+ */
+export function applyAllPendingSubscriptions(runtime: PeerRuntime) {
+    pendingSubscriptions.forEach(subscription => {
+        applyPendingSubscription(runtime, subscription);
+    });
+}
+
+/**
+ * Clean up a pending subscription.
+ *
+ * Clean up is done when one of the listener fires. This means at that moment
+ * we know which runtime is a true subscriptions holder. We then remove the
+ * subscription from other runtimes and from the list.
+ */
+export function cleanUpSubscription(subscription: IPendingSubscription, keepInRuntimeVersion?: string) {
+    if (!keepInRuntimeVersion) {
+        keepInRuntimeVersion = System.getVersion();
+    }
+
+    // Already been cleaned before
+    if (subscription.isCleaned) {
+        return;
+    }
+
+    // Cleanup subscriptions in all connected runtimes
+    connectionManager.connections.forEach((conn) => {
+        const runtimeVersion = conn.portInfo.version;
+        const runtimeUnSubscription = subscription.unSubscriptions[runtimeVersion];
+
+        // Don't un-subscribe in the runtime where we need to keep the subscription
+        if (runtimeVersion === keepInRuntimeVersion) {
+            return;
+        }
+
+        // Invoke un-subscribe function for runtimes that have that subscription
+        if (typeof runtimeUnSubscription === 'function') {
+            runtimeUnSubscription();
+        }
+    });
+
+    // Remove subscription from the list of pending subscriptions
+    const subscriptionIndex = pendingSubscriptions.findIndex(s => s._id === subscription._id);
+    pendingSubscriptions.splice(subscriptionIndex, 1);
+
+    // Indicate the cleaning is done, so that we don't unnecessarily repeat the cleanup
+    subscription.isCleaned = true;
+}
+
+/**
+ * Get event emitter of the class
+ */
+function getClassEventEmitter(runtime: PeerRuntime, subscription: IPendingSubscription) {
+    let classEventEmitter;
+    const {
+        uuid,
+        name,
+        className
+    } = subscription;
+
+    switch (className) {
+        case 'application':
+            classEventEmitter = runtime.fin.Application.wrap({uuid});
+            break;
+        case 'window':
+            classEventEmitter = runtime.fin.Window.wrap({uuid, name});
+            break;
+    }
+
+    return classEventEmitter;
+}
+
+/**
+ * Generates an unique ID for a subscription
+ */
+function getId() {
+    return ++subscriptionIdCount;
+}


### PR DESCRIPTION
This PR sets the base layer for supporting subscriptions to cross-runtime events for runtimes or apps that haven't been launched yet.

My next PR (programmatically launching apps via RVM) will depend on these code changes.

In the future it needs to be improved, but for now, it is known to work for needed events.

✅  [Tests OK](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5910c0105114ac10ca6db36e) (one is an inconsistent timeout, but doesn't come up when singled out)