### PR TITLE
RUN-2837 download id now generated at the renderer, prevents timing issues on subscription.

### DIFF
--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -522,16 +522,21 @@ module.exports.System = {
         return ofEvents.emit(eventName, eventArgs);
     },
     downloadAsset: function(identity, asset, cb) {
-        let appObject = coreState.getAppObjByUuid(identity.uuid);
-        let srcUrl = (appObject || {})._configUrl;
-        let downloadId = module.exports.System.generateGUID().toString('hex');
-        let rvmMessage = {
+        const appObject = coreState.getAppObjByUuid(identity.uuid);
+        const srcUrl = (appObject || {})._configUrl;
+        const downloadId = asset.downloadId;
+
+        //setup defaults.
+        asset.args = asset.args || '';
+
+        const rvmMessage = {
             type: 'download-asset',
             appConfig: srcUrl,
             showRvmProgressDialog: false,
             asset: asset,
             downloadId: downloadId
         };
+
         if (rvmBus.send('app-assets', JSON.stringify(rvmMessage))) {
             cb(null, downloadId);
 


### PR DESCRIPTION
@wenjunche @StevenEBarbaro @HarsimranSingh @joneit @whyn07m3 @datamadic 

* args no longer required 
* accept download id from the renderer.

[Test results](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5910bfda5114ac10ca6db36d) 
[related javascript-adapter PR](https://github.com/openfin/javascript-adapter/pull/303)