### PR TITLE
RUN-2913 adds ability to launch apps from manifest programmatically

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,12 +19,10 @@
   },
   "homepage": "https://github.com/openfin/openfin",
   "optionalDependencies": {
-    "openfin-sign": "git+ssh://git@github.com:openfin/openfin-sign.git#caee55ecbe6f81e6ed9630790781fe4d1835cb03",
-    "runtime-p2p": "git@github.com:openfin/runtime-p2p.git#95730ce170fca5fb56b35621923d16faf4f1cb86"
+      "openfin-sign": "git+ssh://git@github.com:openfin/openfin-sign.git#caee55ecbe6f81e6ed9630790781fe4d1835cb03",
+      "runtime-p2p": "git@github.com:openfin/runtime-p2p.git#95730ce170fca5fb56b35621923d16faf4f1cb86"
   },
   "devDependencies": {
-    "@types/mocha": "^2.2.39",
-    "@types/mockery": "^1.4.29",
     "@types/node": "^6.0.49",
     "@types/underscore": "^1.8.0",
     "asar": "^0.12.1",
@@ -37,12 +35,10 @@
     "grunt-contrib-jshint": "^0.11.3",
     "grunt-contrib-watch": "^1.0.0",
     "grunt-jsbeautifier": "^0.2.10",
-    "grunt-mocha-test": "^0.13.2",
     "grunt-ts": "^5.5.1",
     "grunt-tslint": "^3.3.0",
     "load-grunt-tasks": "^3.3.0",
     "mocha": "^3.0.2",
-    "mockery": "^2.0.0",
     "rewire": "^2.5.2",
     "should": "^11.1.0",
     "should-sinon": "^0.0.5",
@@ -50,7 +46,11 @@
     "tslint": "4.0.0-dev.0",
     "tslint-microsoft-contrib": "^2.0.13",
     "typescript": "~2.2.0",
-    "wrench": "^1.5.9"
+    "wrench": "^1.5.9",
+    "mockery": "^2.0.0",
+    "@types/mocha": "^2.2.39",
+    "@types/mockery": "^1.4.29",
+    "grunt-mocha-test": "^0.13.2"
   },
   "dependencies": {
     "minimist": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -19,10 +19,12 @@
   },
   "homepage": "https://github.com/openfin/openfin",
   "optionalDependencies": {
-      "openfin-sign": "git+ssh://git@github.com:openfin/openfin-sign.git#caee55ecbe6f81e6ed9630790781fe4d1835cb03",
-      "runtime-p2p": "git@github.com:openfin/runtime-p2p.git#95730ce170fca5fb56b35621923d16faf4f1cb86"
+    "openfin-sign": "git+ssh://git@github.com:openfin/openfin-sign.git#caee55ecbe6f81e6ed9630790781fe4d1835cb03",
+    "runtime-p2p": "git@github.com:openfin/runtime-p2p.git#95730ce170fca5fb56b35621923d16faf4f1cb86"
   },
   "devDependencies": {
+    "@types/mocha": "^2.2.39",
+    "@types/mockery": "^1.4.29",
     "@types/node": "^6.0.49",
     "@types/underscore": "^1.8.0",
     "asar": "^0.12.1",
@@ -35,10 +37,12 @@
     "grunt-contrib-jshint": "^0.11.3",
     "grunt-contrib-watch": "^1.0.0",
     "grunt-jsbeautifier": "^0.2.10",
+    "grunt-mocha-test": "^0.13.2",
     "grunt-ts": "^5.5.1",
     "grunt-tslint": "^3.3.0",
     "load-grunt-tasks": "^3.3.0",
     "mocha": "^3.0.2",
+    "mockery": "^2.0.0",
     "rewire": "^2.5.2",
     "should": "^11.1.0",
     "should-sinon": "^0.0.5",
@@ -46,11 +50,7 @@
     "tslint": "4.0.0-dev.0",
     "tslint-microsoft-contrib": "^2.0.13",
     "typescript": "~2.2.0",
-    "wrench": "^1.5.9",
-    "mockery": "^2.0.0",
-    "@types/mocha": "^2.2.39",
-    "@types/mockery": "^1.4.29",
-    "grunt-mocha-test": "^0.13.2"
+    "wrench": "^1.5.9"
   },
   "dependencies": {
     "minimist": "^1.2.0",

--- a/src/browser/api_protocol/api_handlers/application.js
+++ b/src/browser/api_protocol/api_handlers/application.js
@@ -281,7 +281,7 @@ function ApplicationApiHandler() {
         const appIdentity = apiProtocolBase.getTargetApplicationIdentity(payload);
         const { uuid } = appIdentity;
         let pendingSubscriptionUnSubscribe;
-        const pendingSubscription = {
+        const remoteSubscription = {
             uuid,
             name: uuid,
             listenType: 'once',
@@ -306,7 +306,7 @@ function ApplicationApiHandler() {
         });
 
         if (manifestUrl) {
-            addPendingSubscription(pendingSubscription).then((unSubscribe) => {
+            addPendingSubscription(remoteSubscription).then((unSubscribe) => {
                 pendingSubscriptionUnSubscribe = unSubscribe;
                 Application.runWithRVM(identity, manifestUrl).catch(nack);
             });

--- a/src/browser/core_state.js
+++ b/src/browser/core_state.js
@@ -499,6 +499,19 @@ function getSocketServerState() {
     return socketServerState;
 }
 
+/**
+ * Get app's very first ancestor
+ */
+function getAppAncestor(descendantAppUuid) {
+    const app = appByUuid(descendantAppUuid);
+
+    if (app && app.appObj && app.appObj.parentUuid) {
+        return getAppAncestor(app.uuid);
+    } else {
+        return app;
+    }
+}
+
 // methods
 module.exports = {
     addApp,
@@ -511,6 +524,7 @@ module.exports = {
     getAllApplications,
     getAllAppObjects,
     getAllWindows,
+    getAppAncestor,
     getAppById,
     getAppByWin,
     getAppObj,

--- a/src/browser/core_state.js
+++ b/src/browser/core_state.js
@@ -505,8 +505,8 @@ function getSocketServerState() {
 function getAppAncestor(descendantAppUuid) {
     const app = appByUuid(descendantAppUuid);
 
-    if (app && app.appObj && app.appObj.parentUuid) {
-        return getAppAncestor(app.appObj.parentUuid);
+    if (app && app.parentUuid) {
+        return getAppAncestor(app.parentUuid);
     } else {
         return app;
     }

--- a/src/browser/core_state.js
+++ b/src/browser/core_state.js
@@ -506,7 +506,7 @@ function getAppAncestor(descendantAppUuid) {
     const app = appByUuid(descendantAppUuid);
 
     if (app && app.appObj && app.appObj.parentUuid) {
-        return getAppAncestor(app.uuid);
+        return getAppAncestor(app.appObj.parentUuid);
     } else {
         return app;
     }

--- a/src/browser/rvm/utils.ts
+++ b/src/browser/rvm/utils.ts
@@ -17,7 +17,7 @@ app.on('ready', function() {
 interface SendToRVMOpts {
     topic: 'application';
     action: string;
-    sourceUrl: string;
+    sourceUrl?: string;
     data?: any;
 }
 
@@ -67,21 +67,16 @@ export function sendToRVM(opts: SendToRVMOpts): Promise<any> {
                 return reject(new Error(rvmResponse.error));
             }
 
-            // Communication error
-            if (!rvmResponse.hasOwnProperty('payload')) {
-                return reject(new Error('Problem communicating with RVM'));
-            }
-
             // Action execution error
-            if (rvmResponse.payload.status === false) {
+            if (rvmResponse.payload && rvmResponse.payload.status === false) {
                 return reject(new Error(rvmResponse.payload.error));
             }
 
             // Prepare a clean response for the user
             let payload = Object.assign({}, rvmResponse.payload);
-            delete payload.action;
-            delete payload.status;
-            delete payload.error;
+            delete payload['action'];
+            delete payload['status'];
+            delete payload['error'];
             if (Object.keys(payload).length === 0) {
                 payload = undefined;
             }


### PR DESCRIPTION
ℹ️  This PR adds ability to launch app from a manifest programmatically. It supports multi-runtime app creation (you get a success callback once the app in another runtime launches).

✅  [Tests okay](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5910d6c45114ac10ca6db370)

👫  [Coupled with this PR in javascript-adapter](https://github.com/openfin/javascript-adapter/pull/304)

➕  New tests (will publish at the right time):
1. [Application.createFromManifest](https://testing-dashboard.openfin.co/#/app/tests/5911cbc55114ac10ca6db372/edit)
2. [Application.createFromManifest T2](https://testing-dashboard.openfin.co/#/app/tests/5910e1105114ac10ca6db371/edit)
3. [Application.run (for Application.createFromManifest)](https://testing-dashboard.openfin.co/#/app/tests/5911ccbe5114ac10ca6db373/edit)
4. [Application.run T2 (for Application.createFromManifest)](https://testing-dashboard.openfin.co/#/app/tests/5911da355114ac10ca6db375/edit)
5. [Application.run (multi-runtime for Application.createFromManifest)](https://testing-dashboard.openfin.co/#/app/tests/5911dba25114ac10ca6db376/edit)
6. [Application.run T2 (multi-runtime for Application.createFromManifest)](https://testing-dashboard.openfin.co/#/app/tests/5911dc045114ac10ca6db377/edit)