### PR TITLE
RUN-2985 Hotfix tray icon teardown

### DIFF
--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -532,6 +532,8 @@ Application.run = function(identity, configUrl = '' /*, callback , errorCallback
     // app will need to consider remote connections shortly...
     ofEvents.once(`window/closed/${uuid}-${uuid}`, () => {
 
+        removeTrayIcon(app);
+
         ofEvents.emit(eventRoute(uuid, 'closed'), {
             topic: 'application',
             type: 'closed',
@@ -550,8 +552,6 @@ Application.run = function(identity, configUrl = '' /*, callback , errorCallback
         appEventsForRVM.forEach(appEvent => {
             ofEvents.removeListener(eventRoute(uuid, appEvent), sendAppsEventsToRVMListener);
         });
-
-        removeTrayIcon(app);
 
         coreState.removeApp(app.id);
 
@@ -865,9 +865,14 @@ Application.notifyOnAppConnected = function(target, identity) {
 
 function removeTrayIcon(app) {
     if (app && app.tray) {
-        subscriptionManager.removeSubscription(app.identity, TRAY_ICON_KEY);
-        app.tray.destroy();
-        app.tray = null;
+        try {
+            app.tray.destroy();
+            app.tray = null;
+            subscriptionManager.removeSubscription(app.identity, TRAY_ICON_KEY);
+
+        } catch (e) {
+            log.writeToLog(1, e, true);
+        }
     }
 }
 

--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -650,7 +650,17 @@ Application.setShortcuts = function(identity, config, callback, errorCallback) {
     }
 };
 
+let fetchingIcon = false;
+
 Application.setTrayIcon = function(identity, iconUrl, callback, errorCallback) {
+
+    if (fetchingIcon) {
+        errorCallback('currently fetching icon');
+        return;
+    }
+
+    fetchingIcon = true;
+
     let app = Application.wrap(identity.uuid);
 
     // only one tray icon per app
@@ -714,6 +724,8 @@ Application.setTrayIcon = function(identity, iconUrl, callback, errorCallback) {
                 errorCallback(error);
             }
         }
+
+        fetchingIcon = false;
     });
 };
 

--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -60,6 +60,8 @@ let hasPlugins = false;
 let rvmBus;
 let MonitorInfo;
 var Application = {};
+let fetchingIcon = false;
+
 // var OfEvents = [
 //     'closed',
 //     'error',
@@ -650,12 +652,11 @@ Application.setShortcuts = function(identity, config, callback, errorCallback) {
     }
 };
 
-let fetchingIcon = false;
 
 Application.setTrayIcon = function(identity, iconUrl, callback, errorCallback) {
 
     if (fetchingIcon) {
-        errorCallback('currently fetching icon');
+        errorCallback(new Error('currently fetching icon'));
         return;
     }
 


### PR DESCRIPTION
@StevenEBarbaro @HarsimranSingh  @rdepena 

This fixes the double setTrayIcon crash as well as ensures that the icon teardown happens before any possible failures in the subscription unhook. The subscriptions not tearing down correctly should be looked at as a separate issue as it is just try/caught here.

[tests well](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/591376805114ac10ca6db382) all but notification/onshow and preload pass in isolation