### PR TITLE
RUN-2985 hotfix tray icon teardown

### DIFF
--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -60,6 +60,8 @@ let hasPlugins = false;
 let rvmBus;
 let MonitorInfo;
 var Application = {};
+let fetchingIcon = {};
+
 // var OfEvents = [
 //     'closed',
 //     'error',
@@ -392,7 +394,7 @@ Application.removeEventListener = function(identity, type, listener /*, callback
 };
 
 Application.removeTrayIcon = function(identity /*, callback, errorCallback*/ ) {
-    let app = Application.wrap(identity.uuid);
+    const app = Application.wrap(identity.uuid);
 
     removeTrayIcon(app);
 };
@@ -542,6 +544,9 @@ Application.run = function(identity, configUrl = '' /*, callback , errorCallback
     // app will need to consider remote connections shortly...
     ofEvents.once(`window/closed/${uuid}-${uuid}`, () => {
 
+        delete fetchingIcon[uuid];
+        removeTrayIcon(app);
+
         ofEvents.emit(eventRoute(uuid, 'closed'), {
             topic: 'application',
             type: 'closed',
@@ -560,8 +565,6 @@ Application.run = function(identity, configUrl = '' /*, callback , errorCallback
         appEventsForRVM.forEach(appEvent => {
             ofEvents.removeListener(eventRoute(uuid, appEvent), sendAppsEventsToRVMListener);
         });
-
-        removeTrayIcon(app);
 
         coreState.removeApp(app.id);
 
@@ -676,7 +679,19 @@ Application.setShortcuts = function(identity, config, callback, errorCallback) {
     }
 };
 
+
 Application.setTrayIcon = function(identity, iconUrl, callback, errorCallback) {
+    let {
+        uuid
+    } = identity;
+
+    if (fetchingIcon[uuid]) {
+        errorCallback(new Error('currently fetching icon'));
+        return;
+    }
+
+    fetchingIcon[uuid] = true;
+
     let app = Application.wrap(identity.uuid);
 
     // only one tray icon per app
@@ -740,6 +755,8 @@ Application.setTrayIcon = function(identity, iconUrl, callback, errorCallback) {
                 errorCallback(error);
             }
         }
+
+        fetchingIcon[uuid] = false;
     });
 };
 
@@ -890,10 +907,16 @@ Application.notifyOnAppConnected = function(target, identity) {
 
 
 function removeTrayIcon(app) {
+
     if (app && app.tray) {
-        subscriptionManager.removeSubscription(app.identity, TRAY_ICON_KEY);
-        app.tray.destroy();
-        app.tray = null;
+        try {
+            app.tray.destroy();
+            app.tray = null;
+            subscriptionManager.removeSubscription(app.identity, TRAY_ICON_KEY);
+
+        } catch (e) {
+            log.writeToLog(1, e, true);
+        }
     }
 }
 


### PR DESCRIPTION
This was a hotfix for 6.49.20.*, but wasn't merged into develop.

* RUN-2985 ensure teardown of icon before subscription teardown
* RUN-2985 ensure icon download has time to complete
* RUN-2985 update error type, move state var to top
* RUN-2985 make per app