### PR TITLE
RUN-3020: Normalize route string fabrication

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -72,12 +72,11 @@ const trans2TSFiles = [
     'src/browser/session.ts',
     'src/browser/transport.ts',
     'src/browser/window_group_transaction_tracker.ts',
-    'src/common/errors.ts',
-    'src/common/regex.ts',
+    'src/common/**/*.ts',
     'src/browser/port_discovery.ts',
-    'src/browser/api_protocol/**/**.ts',
+    'src/browser/api_protocol/**/*.ts',
     'src/browser/rvm/rvm_message_bus.ts',
-    'src/browser/api/**.ts',
+    'src/browser/api/*.ts', // notifications subdirectory excluded due to legacy linting errors
     'src/browser/rvm/runtime_initiated_topics/app_assets.ts'
 ];
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -385,8 +385,7 @@ module.exports = (grunt) => {
             'src/browser/transports/wm_copydata.ts',
             'src/browser/transports/base.ts',
             'src/browser/transports/chromium_ipc.ts',
-            'src/browser/transports/electron_ipc.ts',
-            'src/common/route.ts'
+            'src/browser/transports/electron_ipc.ts'
         ];
 
         // List of files that need to have some kind of license

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -385,7 +385,8 @@ module.exports = (grunt) => {
             'src/browser/transports/wm_copydata.ts',
             'src/browser/transports/base.ts',
             'src/browser/transports/chromium_ipc.ts',
-            'src/browser/transports/electron_ipc.ts'
+            'src/browser/transports/electron_ipc.ts',
+            'src/common/route.ts'
         ];
 
         // List of files that need to have some kind of license

--- a/index.js
+++ b/index.js
@@ -59,6 +59,7 @@ import * as log from './src/browser/log';
 import {
     applyAllRemoteSubscriptions
 } from './src/browser/remote_subscriptions';
+import route from './src/common/route';
 
 // locals
 let firstApp = null;
@@ -231,8 +232,8 @@ app.on('ready', function() {
             name: ofWindow._options.name,
             uuid: ofWindow._options.uuid
         };
-        const windowEvtName = `window/auth-requested/${identity.uuid}-${identity.name}`;
-        const appEvtName = `application/window-auth-requested/${identity.uuid}`;
+        const windowEvtName = route.window('auth-requested', identity.uuid, identity.name);
+        const appEvtName = route.application('window-auth-requested', identity.uuid);
 
         authenticationDelegate.addPendingAuthRequests(identity, authInfo, callback);
         if (ofEvents.listeners(windowEvtName).length < 1 && ofEvents.listeners(appEvtName).length < 1) {
@@ -267,26 +268,26 @@ app.on('ready', function() {
         }
     });
 
-    rvmBus.on('rvm-message-bus/broadcast/download-asset/progress', payload => {
+    rvmBus.on(route.rvmMessageBus('broadcast', 'download-asset', 'progress'), payload => {
         if (payload) {
-            ofEvents.emit(`system/asset-download-progress-${payload.downloadId}`, {
+            ofEvents.emit(route.system(`asset-download-progress-${payload.downloadId}`), {
                 totalBytes: payload.totalBytes,
                 downloadedBytes: payload.downloadedBytes
             });
         }
     });
 
-    rvmBus.on('rvm-message-bus/broadcast/download-asset/error', payload => {
+    rvmBus.on(route.rvmMessageBus('broadcast', 'download-asset', 'error'), payload => {
         if (payload) {
-            ofEvents.emit(`system/asset-download-error-${payload.downloadId}`, {
+            ofEvents.emit(route.system(`asset-download-error-${payload.downloadId}`), {
                 reason: payload.error,
                 err: errors.errorToPOJO(new Error(payload.error))
             });
         }
     });
-    rvmBus.on('rvm-message-bus/broadcast/download-asset/complete', payload => {
+    rvmBus.on(route.rvmMessageBus('broadcast', 'download-asset', 'complete'), payload => {
         if (payload) {
-            ofEvents.emit(`system/asset-download-complete-${payload.downloadId}`, {
+            ofEvents.emit(route.system(`asset-download-complete-${payload.downloadId}`), {
                 path: payload.path
             });
         }

--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -433,7 +433,6 @@ Application.run = function(identity, configUrl = '' /*, callback , errorCallback
     createAppObj(identity.uuid, null, configUrl);
 
     let uuid = identity.uuid,
-        emitToApp = type => ofEvents.emit(route.application(type, uuid), { topic: 'application', type, uuid }),
         app = Application.wrap(uuid),
         appState = coreState.appByUuid(uuid),
         mainWindowOpts = _.clone(app._options),
@@ -520,7 +519,7 @@ Application.run = function(identity, configUrl = '' /*, callback , errorCallback
             app._processInfo.getCpuUsage();
         }
 
-        emitToApp('connected');
+        ofEvents.emit(route.application('connected', uuid), { topic: 'application', type: 'connected', uuid });
     });
 
     // turn on plugins for the main window
@@ -543,7 +542,7 @@ Application.run = function(identity, configUrl = '' /*, callback , errorCallback
         delete fetchingIcon[uuid];
         removeTrayIcon(app);
 
-        emitToApp('closed');
+        ofEvents.emit(route.application('closed', uuid), { topic: 'application', type: 'closed', uuid });
 
         eventListenerStrings.forEach(eventString => {
             app.mainWindow.removeAllListeners(eventString);
@@ -592,21 +591,21 @@ Application.run = function(identity, configUrl = '' /*, callback , errorCallback
     });
 
     app.mainWindow.webContents.on('crashed', () => {
-        emitToApp('crashed');
-        emitToApp('out-of-memory');
+        ofEvents.emit(route.application('crashed', uuid), { topic: 'application', type: 'crashed', uuid });
+        ofEvents.emit(route.application('out-of-memory', uuid), { topic: 'application', type: 'out-of-memory', uuid });
     });
 
     app.mainWindow.on('responsive', () => {
-        emitToApp('responding');
+        ofEvents.emit(route.application('responding', uuid), { topic: 'application', type: 'responding', uuid });
     });
 
     app.mainWindow.on('unresponsive', () => {
-        emitToApp('not-responding');
+        ofEvents.emit(route.application('not-responding', uuid), { topic: 'application', type: 'not-responding', uuid });
     });
 
     coreState.setAppRunningState(uuid, true);
 
-    emitToApp('started');
+    ofEvents.emit(route.application('started', uuid), { topic: 'application', type: 'started', uuid });
 };
 
 /**

--- a/src/browser/api/external_application.ts
+++ b/src/browser/api/external_application.ts
@@ -6,18 +6,15 @@ Please contact OpenFin Inc. at sales@openfin.co to obtain a Commercial License.
 */
 
 import ofEvents from '../of_events';
-
 import { Identity } from '../../shapes';
-
 import * as ProcessTracker from '../process_tracker.js';
+import route from '../../common/route';
 
 const authenticatedConnections: any[] = [];
-const connectedEvent = 'external-application/connected';
-const disconnectedEvent = 'external-application/disconnected';
 
 export module ExternalApplication {
     export function addEventListener(identity: Identity, type: string, listener: Function) {
-        const evt = `external-application/${type}/${identity.uuid}`;
+        const evt = route.externalApplication(type, identity.uuid);
         ofEvents.on(evt, listener);
 
         return () => {
@@ -26,7 +23,7 @@ export module ExternalApplication {
     }
 
     export function removeEventListener(identity: Identity, type: string, listener: Function) {
-        ofEvents.removeListener(`external-application/${type}/${identity.uuid}`, listener);
+        ofEvents.removeListener(route.externalApplication(type, identity.uuid), listener);
     }
 
     export function getInfo(externalApp: Identity): ExternalProcessInfo {
@@ -43,10 +40,10 @@ export module ExternalApplication {
 
         //TODO: compare perf from this and a map.
         authenticatedConnections.push(externalConnObj);
-        ofEvents.emit(`${connectedEvent}/${externalConnObj.uuid}`, {
+        ofEvents.emit(route.externalApplication('connected', externalConnObj.uuid), {
             uuid
         });
-        ofEvents.emit(connectedEvent, {
+        ofEvents.emit(route.externalApplication('connected'), {
             uuid
         });
     }
@@ -66,11 +63,11 @@ export module ExternalApplication {
     export function removeExternalConnection(externalConnection: Identity) {
         authenticatedConnections.splice(authenticatedConnections.indexOf(externalConnection), 1);
 
-        ofEvents.emit(`${disconnectedEvent}/${externalConnection.uuid}`, {
+        ofEvents.emit(route.externalApplication('disconnected', externalConnection.uuid), {
             uuid: externalConnection.uuid
         });
 
-        ofEvents.emit(disconnectedEvent, {
+        ofEvents.emit(route.externalApplication('disconnected'), {
             uuid: externalConnection.uuid
         });
     }

--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -33,6 +33,7 @@ import {
 const log = require('../log.js');
 import ofEvents from '../of_events';
 const ProcessTracker = require('../process_tracker.js');
+import route from '../../common/route';
 
 const defaultProc = {
     getCpuUsage: function() {
@@ -77,15 +78,15 @@ electronApp.on('ready', function() {
     rvmBus = require('../rvm/rvm_message_bus').rvmMessageBus;
 
     MonitorInfo.on('monitor-info-changed', payload => {
-        ofEvents.emit('system/monitor-info-changed', payload);
+        ofEvents.emit(route.system('monitor-info-changed'), payload);
     });
 
     Session.on('session-changed', payload => {
-        ofEvents.emit('system/session-changed', payload);
+        ofEvents.emit(route.system('session-changed'), payload);
     });
 
     Session.on('idle-state-changed', payload => {
-        ofEvents.emit('system/idle-state-changed', payload);
+        ofEvents.emit(route.system('idle-state-changed'), payload);
     });
 
     defaultSession = session.defaultSession;
@@ -94,51 +95,51 @@ electronApp.on('ready', function() {
 electronApp.on('synth-desktop-icon-clicked', payload => {
     payload.topic = 'system';
     payload.type = 'desktop-icon-clicked';
-    ofEvents.emit('system/desktop-icon-clicked', payload);
+    ofEvents.emit(route.system('desktop-icon-clicked'), payload);
 });
 
-ofEvents.on('application/created/*', payload => {
-    ofEvents.emit('system/application-created', {
+ofEvents.on(route.application('created', '*'), payload => {
+    ofEvents.emit(route.system('application-created'), {
         topic: 'system',
         type: 'application-created',
         uuid: payload.source
     });
 });
 
-ofEvents.on('application/started/*', payload => {
-    ofEvents.emit('system/application-started', {
+ofEvents.on(route.application('started', '*'), payload => {
+    ofEvents.emit(route.system('application-started'), {
         topic: 'system',
         type: 'application-started',
         uuid: payload.source
     });
 });
 
-ofEvents.on('application/closed/*', payload => {
-    ofEvents.emit('system/application-closed', {
+ofEvents.on(route.application('closed', '*'), payload => {
+    ofEvents.emit(route.system('application-closed'), {
         topic: 'system',
         type: 'application-closed',
         uuid: payload.source
     });
 });
 
-ofEvents.on('application/crashed/*', payload => {
-    ofEvents.emit('system/application-crashed', {
+ofEvents.on(route.application('crashed', '*'), payload => {
+    ofEvents.emit(route.system('application-crashed'), {
         topic: 'system',
         type: 'application-crashed',
         uuid: payload.source
     });
 });
 
-ofEvents.on('external-application/connected', payload => {
-    ofEvents.emit('system/external-application-connected', {
+ofEvents.on(route.externalApplication('connected'), payload => {
+    ofEvents.emit(route.system('external-application-connected'), {
         topic: 'system',
         type: 'external-application-connected',
         uuid: payload.uuid
     });
 });
 
-ofEvents.on('external-application/disconnected', payload => {
-    ofEvents.emit('system/external-application-disconnected', {
+ofEvents.on(route.externalApplication('disconnected'), payload => {
+    ofEvents.emit(route.system('external-application-disconnected'), {
         topic: 'system',
         type: 'external-application-disconnected',
         uuid: payload.uuid
@@ -147,10 +148,10 @@ ofEvents.on('external-application/disconnected', payload => {
 
 module.exports.System = {
     addEventListener: function(type, listener) {
-        ofEvents.on(`system/${type}`, listener);
+        ofEvents.on(route.system(type), listener);
 
         var unsubscribe = () => {
-            ofEvents.removeListener(`system/${type}`, listener);
+            ofEvents.removeListener(route.system(type), listener);
         };
 
         return unsubscribe;
@@ -465,7 +466,7 @@ module.exports.System = {
         ProcessTracker.release(processUuid);
     },
     removeEventListener: function(type, listener) {
-        ofEvents.removeListener(`system/${type}`, listener);
+        ofEvents.removeListener(route.system(type), listener);
     },
     showDeveloperTools: function(applicationUuid, windowName) {
         let winName, openfinWindow;

--- a/src/browser/api_protocol/api_handlers/application.js
+++ b/src/browser/api_protocol/api_handlers/application.js
@@ -349,7 +349,7 @@ function ApplicationApiHandler() {
     function externalWindowAction(identity, message, ack) {
         /* jshint bitwise: false */
         let payload = message.payload;
-        const emitToExtWin = (type, data) => ofEvents.emit(route.externalWindow(type, payload.uuid, payload.name), data);
+        const { uuid, name } = payload;
 
         const SWP_HIDEWINDOW = 128;
         const SWP_SHOWWINDOW = 64;
@@ -360,27 +360,27 @@ function ApplicationApiHandler() {
         switch (payload.type) {
             case 2:
                 // WM_DESTROY
-                emitToExtWin('close');
+                ofEvents.emit(route.externalWindow('close', uuid, name));
                 break;
             case 7:
                 // WM_SETFOCUS
-                emitToExtWin('focus');
+                ofEvents.emit(route.externalWindow('focus', uuid, name));
                 break;
             case 8:
                 // WM__KILLFOCUS
-                emitToExtWin('blur');
+                ofEvents.emit(route.externalWindow('blur', uuid, name));
                 break;
             case 71:
                 // WM_WINDOWPOSCHANGED
                 let flags = payload.flags;
 
-                emitToExtWin('bounds-changed');
+                ofEvents.emit(route.externalWindow('bounds-changed', uuid, name));
 
                 // dispatch show and hide events
                 if (flags & SWP_SHOWWINDOW) {
-                    emitToExtWin('visibility-changed', true);
+                    ofEvents.emit(route.externalWindow('visibility-changed', uuid, name), true);
                 } else if (flags & SWP_HIDEWINDOW) {
-                    emitToExtWin('visibility-changed', false);
+                    ofEvents.emit(route.externalWindow('visibility-changed', uuid, name), false);
                 }
                 break;
             case 274:
@@ -394,26 +394,26 @@ function ApplicationApiHandler() {
                 /* falls through */
             case 163:
                 // WM_NCLBUTTONDBLCLK
-                emitToExtWin('state-change');
+                ofEvents.emit(route.externalWindow('state-change', uuid, name));
                 break;
             case 532:
                 // WM_SIZING
-                emitToExtWin('sizing');
+                ofEvents.emit(route.externalWindow('sizing', uuid, name));
                 break;
             case 534:
                 // WM_MOVING
-                emitToExtWin('moving');
+                ofEvents.emit(route.externalWindow('moving', uuid, name));
                 break;
             case 561:
                 // WM_ENTERSIZEMOVE
-                emitToExtWin('begin-user-bounds-change', {
+                ofEvents.emit(route.externalWindow('end-user-bounds-change', {
                     x: payload.mouseX,
                     y: payload.mouseY
-                });
+                }));
                 break;
             case 562:
                 // WM_EXITSIZEMOVE
-                emitToExtWin('end-user-bounds-change');
+                ofEvents.emit(route.externalWindow('end-user-bounds-change', uuid, name));
                 break;
             default:
                 // Do nothing

--- a/src/browser/api_protocol/api_handlers/authorization.js
+++ b/src/browser/api_protocol/api_handlers/authorization.js
@@ -15,6 +15,7 @@ let _ = require('underscore');
 let log = require('../../log');
 let socketServer = require('../../transports/socket_server').server;
 let ProcessTracker = require('../../process_tracker.js');
+import route from '../../../common/route';
 
 const successAck = {
     success: true
@@ -170,7 +171,7 @@ function AuthorizationApiHandler() {
         }
     }
 
-    socketServer.on('connection/close', id => {
+    socketServer.on(route.connection('close'), id => {
         var keyToDelete,
             externalConnection;
         for (var [key, value] of pendingAuthentications.entries()) {
@@ -184,7 +185,7 @@ function AuthorizationApiHandler() {
         externalConnection = ExternalApplication.getExternalConnectionById(id);
         if (externalConnection) {
             ExternalApplication.removeExternalConnection(externalConnection);
-            ofEvents.emit(`externalconn/closed`, ExternalApplication);
+            ofEvents.emit(route('externalconn', 'closed'), ExternalApplication);
         }
 
         if (coreState.shouldCloseRuntime()) {

--- a/src/browser/api_protocol/api_handlers/interappbus.js
+++ b/src/browser/api_protocol/api_handlers/interappbus.js
@@ -16,6 +16,7 @@ limitations under the License.
 let apiProtocolBase = require('./api_protocol_base.js');
 var InterApplicationBus = require('../../api/interappbus.js').InterApplicationBus;
 import ofEvents from '../../of_events';
+import route from '../../../common/route';
 
 function InterApplicationBusApiHandler() {
 
@@ -99,7 +100,7 @@ function InterApplicationBusApiHandler() {
 
             apiProtocolBase.registerSubscription(subscriptionObj.unsubscribe, ...subscriptionArgs);
 
-            ofEvents.once(`window/unload/${identity.uuid}/${identity.name}`, () => {
+            ofEvents.once(route.window('unload', identity.uuid, identity.name, false), () => {
                 apiProtocolBase.removeSubscription(...subscriptionArgs);
             });
         }
@@ -198,7 +199,7 @@ function InterApplicationBusApiHandler() {
     // As per 5.0 we blast out the subscriber-added and the subscriber-removed
     // envents. The following 2 hooks ensure that we continue to blast these out
     // for both external connections and js apps
-    ofEvents.on(`window/init-subscription-listeners`, (identity) => {
+    ofEvents.on(route.window('init-subscription-listeners'), (identity) => {
         initSubscriptionListeners(identity);
     });
 

--- a/src/browser/api_protocol/transport_strategy/ws_strategy.ts
+++ b/src/browser/api_protocol/transport_strategy/ws_strategy.ts
@@ -8,6 +8,7 @@ import { AckMessage,  AckFunc, AckPayload, NackPayload } from './ack';
 import { ApiTransportBase, MessagePackage, Identity } from './api_transport_base';
 import { default as RequestHandler } from './base_handler';
 import { Endpoint, ActionMap } from '../shapes';
+import route from '../../../common/route';
 
 declare var require: any;
 
@@ -44,7 +45,7 @@ export class WebSocketStrategy extends ApiTransportBase<MessagePackage> {
     }
 
     public registerMessageHandlers(): void {
-        socketServer.on('connection/message', this.onMessage.bind(this));
+        socketServer.on(route.connection('message'), this.onMessage.bind(this));
     }
 
     public send(externalConnection: any, payload: any): void {
@@ -52,11 +53,11 @@ export class WebSocketStrategy extends ApiTransportBase<MessagePackage> {
     }
 
     public onClientAuthenticated(cb: Function): void {
-        socketServer.on('connection/authenticated', cb);
+        socketServer.on(route.connection('authenticated'), cb);
     }
 
     public onClientDisconnect(cb: Function): void {
-        socketServer.on('connection/close', cb);
+        socketServer.on(route.connection('close'), cb);
     }
 
     protected onMessage(id: number, data: any): void {

--- a/src/browser/external_window_event_adapter.js
+++ b/src/browser/external_window_event_adapter.js
@@ -28,17 +28,15 @@ class ExternalWindowEventAdapter {
 
         let cachedState = null;
 
-        const routeExtWin = type => route.externalWindow(type, uuid, name);
-
-        ofEvents.on(routeExtWin('focus'), () => {
+        ofEvents.on(route.externalWindow('focus', uuid, name), () => {
             browserWindow.emit('focus');
         });
 
-        ofEvents.on(routeExtWin('blur'), () => {
+        ofEvents.on(route.externalWindow('blur', uuid, name), () => {
             browserWindow.emit('blur');
         });
 
-        ofEvents.on(routeExtWin('state-change'), () => {
+        ofEvents.on(route.externalWindow('state-change', uuid, name), () => {
             let prevState = cachedState || 'normal';
 
             let currState = 'normal';
@@ -61,15 +59,15 @@ class ExternalWindowEventAdapter {
             }
         });
 
-        ofEvents.on(routeExtWin('bounds-changed'), () => {
+        ofEvents.on(route.externalWindow('bounds-changed', uuid, name), () => {
             browserWindow.emit('bounds-changed');
         });
 
-        ofEvents.on(routeExtWin('visibility-changed'), (visibility) => {
+        ofEvents.on(route.externalWindow('visibility-changed', uuid, name), (visibility) => {
             browserWindow.emit('visibility-changed', {}, visibility);
         });
 
-        ofEvents.on(routeExtWin('begin-user-bounds-change'), (coordinates) => {
+        ofEvents.on(route.externalWindow('begin-user-bounds-change', uuid, name), (coordinates) => {
             if (!disabledFrameState.leftButtonDown && !browserWindow.isUserMovementEnabled()) {
                 // left mouse button is now in the down position
                 disabledFrameState.leftButtonDown = true;
@@ -86,7 +84,7 @@ class ExternalWindowEventAdapter {
             browserWindow.emit('begin-user-bounds-change');
         });
 
-        ofEvents.on(routeExtWin('end-user-bounds-change'), () => {
+        ofEvents.on(route.externalWindow('end-user-bounds-change', uuid, name), () => {
             if (disabledFrameState.leftButtonDown) {
                 if (disabledFrameState.changeType !== -1) {
                     browserWindow.emit('disabled-frame-bounds-changed', {}, browserWindow.getBounds(), disabledFrameState.changeType);
@@ -99,7 +97,7 @@ class ExternalWindowEventAdapter {
             browserWindow.emit('end-user-bounds-change');
         });
 
-        ofEvents.on(routeExtWin('sizing'), (bounds) => {
+        ofEvents.on(route.externalWindow('sizing', uuid, name), (bounds) => {
             if (disabledFrameState.leftButtonDown) {
                 // check if the position has also changed by checking whether the origins match up
                 if (disabledFrameState.changeType !== 2) {
@@ -112,7 +110,7 @@ class ExternalWindowEventAdapter {
             }
         });
 
-        ofEvents.on(routeExtWin('moving'), () => {
+        ofEvents.on(route.externalWindow('moving', uuid, name), () => {
             if (disabledFrameState.leftButtonDown) {
                 let bounds = browserWindow.getBounds();
                 let mousePosition = MonitorInfo.getMousePosition();
@@ -140,7 +138,7 @@ class ExternalWindowEventAdapter {
             }
         });
 
-        ofEvents.on(routeExtWin('close'), () => {
+        ofEvents.on(route.externalWindow('close', uuid, name), () => {
             browserWindow.emit('close');
             browserWindow.close();
             browserWindow.emit('closed');

--- a/src/browser/external_window_event_adapter.js
+++ b/src/browser/external_window_event_adapter.js
@@ -11,13 +11,13 @@ let MonitorInfo;
 electronApp.on('ready', () => {
     MonitorInfo = require('./monitor_info.js');
 });
+import route from '../common/route';
 
 class ExternalWindowEventAdapter {
     constructor(browserWindow) {
         let options = browserWindow && browserWindow._options;
         let uuid = options.uuid;
         let name = options.name;
-        let uuidname = `${uuid}-${name}`;
 
         let disabledFrameState = {
             leftButtonDown: false,
@@ -28,15 +28,17 @@ class ExternalWindowEventAdapter {
 
         let cachedState = null;
 
-        ofEvents.on(`external-window/focus/${uuidname}`, () => {
+        const routeExtWin = type => route.externalWindow(type, uuid, name);
+
+        ofEvents.on(routeExtWin('focus'), () => {
             browserWindow.emit('focus');
         });
 
-        ofEvents.on(`external-window/blur/${uuidname}`, () => {
+        ofEvents.on(routeExtWin('blur'), () => {
             browserWindow.emit('blur');
         });
 
-        ofEvents.on(`external-window/state-change/${uuidname}`, () => {
+        ofEvents.on(routeExtWin('state-change'), () => {
             let prevState = cachedState || 'normal';
 
             let currState = 'normal';
@@ -59,15 +61,15 @@ class ExternalWindowEventAdapter {
             }
         });
 
-        ofEvents.on(`external-window/bounds-changed/${uuidname}`, () => {
+        ofEvents.on(routeExtWin('bounds-changed'), () => {
             browserWindow.emit('bounds-changed');
         });
 
-        ofEvents.on(`external-window/visibility-changed/${uuidname}`, (visibility) => {
+        ofEvents.on(routeExtWin('visibility-changed'), (visibility) => {
             browserWindow.emit('visibility-changed', {}, visibility);
         });
 
-        ofEvents.on(`external-window/begin-user-bounds-change/${uuidname}`, (coordinates) => {
+        ofEvents.on(routeExtWin('begin-user-bounds-change'), (coordinates) => {
             if (!disabledFrameState.leftButtonDown && !browserWindow.isUserMovementEnabled()) {
                 // left mouse button is now in the down position
                 disabledFrameState.leftButtonDown = true;
@@ -84,7 +86,7 @@ class ExternalWindowEventAdapter {
             browserWindow.emit('begin-user-bounds-change');
         });
 
-        ofEvents.on(`external-window/end-user-bounds-change/${uuidname}`, () => {
+        ofEvents.on(routeExtWin('end-user-bounds-change'), () => {
             if (disabledFrameState.leftButtonDown) {
                 if (disabledFrameState.changeType !== -1) {
                     browserWindow.emit('disabled-frame-bounds-changed', {}, browserWindow.getBounds(), disabledFrameState.changeType);
@@ -97,7 +99,7 @@ class ExternalWindowEventAdapter {
             browserWindow.emit('end-user-bounds-change');
         });
 
-        ofEvents.on(`external-window/sizing/${uuidname}`, (bounds) => {
+        ofEvents.on(routeExtWin('sizing'), (bounds) => {
             if (disabledFrameState.leftButtonDown) {
                 // check if the position has also changed by checking whether the origins match up
                 if (disabledFrameState.changeType !== 2) {
@@ -110,7 +112,7 @@ class ExternalWindowEventAdapter {
             }
         });
 
-        ofEvents.on(`external-window/moving/${uuidname}`, () => {
+        ofEvents.on(routeExtWin('moving'), () => {
             if (disabledFrameState.leftButtonDown) {
                 let bounds = browserWindow.getBounds();
                 let mousePosition = MonitorInfo.getMousePosition();
@@ -138,7 +140,7 @@ class ExternalWindowEventAdapter {
             }
         });
 
-        ofEvents.on(`external-window/close/${uuidname}`, () => {
+        ofEvents.on(routeExtWin('close'), () => {
             browserWindow.emit('close');
             browserWindow.close();
             browserWindow.emit('closed');

--- a/src/browser/navigation_validation.ts
+++ b/src/browser/navigation_validation.ts
@@ -19,6 +19,7 @@ let SubScriptionManager:any = require('./subscription_manager.js').SubscriptionM
 let subScriptionManager:any = new SubScriptionManager();
 
 import ofEvents from "./of_events";
+import route from '../common/route';
 
 export function validateNavigation(webContents: any, identity:any, validator: () => any) {
     let willNavigateString = 'will-navigate';
@@ -61,7 +62,6 @@ export function validateNavigationRules(uuid: string, url: string, parentUuid: s
 }
 
 export function navigationValidator(uuid: string, name:string, id: number) {
-    const uuidname = `${uuid}-${name}`;
     return (event: any, url: string) => {
         let appObject = coreState.getAppObjByUuid(uuid);
         let appMetaInfo = coreState.appByUuid(uuid);
@@ -80,13 +80,13 @@ export function navigationValidator(uuid: string, name:string, id: number) {
                     }
                 }
             }
-            ofEvents.emit(`window/navigation-rejected/${uuidname}`, {
+            ofEvents.emit(route.window('navigation-rejected', uuid, name), {
                 name,
                 uuid,
                 url,
                 sourceName
             });
-            ofEvents.emit(`application/window-navigation-rejected/${uuid}`, {
+            ofEvents.emit(route.application('window-navigation-rejected', uuid), {
                 name,
                 uuid,
                 url,

--- a/src/browser/of_events.ts
+++ b/src/browser/of_events.ts
@@ -14,14 +14,15 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import { EventEmitter } from 'events';
+import route from '../common/route';
 
 class OFEvents extends EventEmitter {
     constructor() {
         super();
     }
 
-    public emit(route: string, ...data: any[]) {
-        const tokenizedRoute = route.split('/');
+    public emit(routeString: string, ...data: any[]) {
+        const tokenizedRoute = routeString.split('/');
 
         if (tokenizedRoute.length >= 2) {
             const [channel, topic] = tokenizedRoute;
@@ -29,18 +30,18 @@ class OFEvents extends EventEmitter {
             const envelope = {channel, topic, source, data};
 
             // Wildcard on all topics of a channel (such as on the system channel)
-            super.emit(`${channel}/*`, envelope);
+            super.emit(route(channel, '*'), envelope);
 
             if (source) {
                 // Wildcard on any source of a channel/topic (ex: 'window/bounds-changed/*')
-                super.emit(`${channel}/${topic}/*`, envelope);
+                super.emit(route(channel, topic, '*'), envelope);
 
                 // Wildcard on any channel/topic of a specified source (ex: 'window/*/myUUID-myWindow')
-                super.emit(`${channel}/*/${source}`, envelope);
+                super.emit(route(channel, '*', source), envelope);
             }
         }
 
-        return super.emit(route, ...data);
+        return super.emit(routeString, ...data);
     }
 }
 

--- a/src/browser/port_discovery.ts
+++ b/src/browser/port_discovery.ts
@@ -8,6 +8,7 @@ Please contact OpenFin Inc. at sales@openfin.co to obtain a Commercial License.
 import { WMCopyData, ChromiumIPC } from './transport';
 import { EventEmitter } from 'events';
 import * as log from './log';
+import route from '../common/route';
 
 const coreState = require('./core_state');
 const windowClassName = 'OPENFIN_ADAPTER_WINDOW';
@@ -42,7 +43,7 @@ export class PortDiscovery extends EventEmitter {
 
             this._copyDataTransport = new WMCopyData(windowClassName, windowClassName);
             this._copyDataTransport.on('message', (s: any, data: string) => {
-                this.emit('runtime/launched', JSON.parse(data));
+                this.emit(route.runtime('launched'), JSON.parse(data));
             });
         }
 

--- a/src/browser/process_tracker.js
+++ b/src/browser/process_tracker.js
@@ -21,6 +21,7 @@ let ExternalProcess = require('electron').externalProcess;
 let ProcessMonitor = require('electron').processMonitor;
 
 import ofEvents from './of_events';
+import route from '../common/route';
 
 const isWin32 = (process.platform === 'win32');
 
@@ -45,12 +46,12 @@ function ProcessTracker() {
             processUuid: uuid,
         };
 
-        ofEvents.emit(`external-application/exited/${uuid}`, Object.assign(result, {
+        ofEvents.emit(route.externalApplication('exited', uuid), Object.assign(result, {
             topic: 'external-application',
             type: 'exited'
         }));
 
-        ofEvents.emit(`window/external-process-exited/${winUuid}-${winName}`, Object.assign(result, {
+        ofEvents.emit(route.window('external-process-exited', winUuid, winName), Object.assign(result, {
             uuid: winUuid,
             name: winName,
             topic: 'window',
@@ -60,7 +61,7 @@ function ProcessTracker() {
         this._cleanup(pid, uuid);
     });
 
-    ofEvents.on('window/synth-close/*', payload => {
+    ofEvents.on(route.window('synth-close', '*'), payload => {
         if (this._windowToUuids[payload.source]) {
             let processes = this._windowToUuids[payload.source].slice(0);
             processes.forEach(uuid => {
@@ -79,17 +80,16 @@ ProcessTracker.prototype.launch = function(identity, options, errDataCallback) {
     let success = (data) => {
         var windowUuid = identity.uuid;
         var windowName = identity.name;
-        var windowUuidName = `${windowUuid}-${windowName}`;
 
         errDataCallback(undefined, data);
 
-        ofEvents.emit(`external-application/started/${data.uuid}`, {
+        ofEvents.emit(route.externalApplication('started', data.uuid), {
             uuid: data.uuid,
             topic: 'external-application',
             type: 'started'
         });
 
-        ofEvents.emit(`window/external-process-started/${windowUuidName}`, {
+        ofEvents.emit(route.window('external-process-started', windowUuid, windowName), {
             uuid: windowUuid,
             name: windowName,
             topic: 'window',

--- a/src/browser/remote_subscriptions.ts
+++ b/src/browser/remote_subscriptions.ts
@@ -25,6 +25,7 @@ Please contact OpenFin Inc. at sales@openfin.co to obtain a Commercial License.
 import ofEvents from './of_events';
 import connectionManager, { PeerRuntime } from './connection_manager';
 import { Identity } from '../shapes';
+import route from '../common/route';
 
 // id count to generate IDs for subscriptions
 let subscriptionIdCount = 0;
@@ -112,7 +113,9 @@ function applyRemoteSubscription(subscription: RemoteSubscription, runtime: Peer
     const classEventEmitter = getClassEventEmitter(subscription, runtime);
     const runtimeVersion = getRuntimeVersion(runtime);
     const { uuid, name, className, eventName, listenType, unSubscriptions } = subscription;
-    const fullEventName = `${className}/${eventName}/${uuid}${typeof name === 'string' ? `-${name}` : ''}`;
+    const fullEventName = (typeof name === 'string')
+        ? route(className, eventName, uuid, name, true)
+        : route(className, eventName, uuid);
 
     const listener = (data: any) => {
         ofEvents.emit(fullEventName, data);

--- a/src/browser/rvm/rvm_message_bus.ts
+++ b/src/browser/rvm/rvm_message_bus.ts
@@ -7,6 +7,7 @@ Please contact OpenFin Inc. at sales@openfin.co to obtain a Commercial License.
 import {WMCopyData} from '../transport';
 import {EventEmitter} from 'events';
 import * as log from '../log';
+import route from '../../common/route';
 
 // as to be require as we have added generateGUID, which is not on the ts definitions for app
 // i.e. error TS2339: Property 'generateGUID' does not exist on type 'typeof app'.
@@ -187,7 +188,7 @@ class RVMMessageBus extends EventEmitter  {
                         const action = dataObj.payload.action;
 
                         if (topic && payload && action) {
-                            this.emit('rvm-message-bus/broadcast/' + topic + '/' + action, payload);
+                            this.emit(route.rvmMessageBus('broadcast', topic, action), payload);
                         } else {
                             log.writeToLog(1, `RVMMessageBus received an invalid broadcast message: ${dataObj}`, true);
                         }

--- a/src/browser/subscription_manager.js
+++ b/src/browser/subscription_manager.js
@@ -15,6 +15,7 @@ limitations under the License.
 */
 var _ = require('underscore');
 import ofEvents from './of_events';
+import route from '../common/route';
 
 function SubscriptionManager() {
     var subscriptionList = new Map();
@@ -84,11 +85,11 @@ function SubscriptionManager() {
         subscriptionList.delete(identityKey);
     }
 
-    ofEvents.on(`window/closed`, identity => {
+    ofEvents.on(route.window('closed'), identity => {
         removeAllSubscriptions(identity);
     });
 
-    ofEvents.on(`externalconn/closed`, identity => {
+    ofEvents.on(route('externalconn', 'closed'), identity => {
         removeAllSubscriptions(identity);
     });
 

--- a/src/browser/transports/socket_server.js
+++ b/src/browser/transports/socket_server.js
@@ -7,6 +7,7 @@ Please contact OpenFin Inc. at sales@openfin.co to obtain a Commercial License.
 let http = require('http');
 let EventEmitter = require('events').EventEmitter;
 let util = require('util');
+import route from '../../common/route';
 
 
 let Server = function() {
@@ -25,7 +26,7 @@ let Server = function() {
 
     httpServer.on('error', function(err) {
         httpServerError = true;
-        me.emit('server/error', err);
+        me.emit(route.server('error'), err);
     });
 
     me.getPort = function() {
@@ -78,12 +79,12 @@ let Server = function() {
                 });
 
             wss.on('headers', function(headers) {
-                me.emit('server/headers', headers);
+                me.emit(route.server('headers'), headers);
             });
 
             wss.on('error', function(err) {
                 httpServerError = true;
-                me.emit('server/error', err);
+                me.emit(route.server('error'), err);
             });
 
             wss.on('connection', function connection(ws) {
@@ -94,33 +95,33 @@ let Server = function() {
                 // pong
 
                 ws.on('error', function(error) {
-                    me.emit('connection/error', id, error);
+                    me.emit(route.connection('error'), id, error);
                 });
 
                 ws.on('close', function( /*code,message*/ ) {
                     delete activeConnections[id];
                     idPool.release(id);
                     ws = null;
-                    me.emit('connection/close', id);
+                    me.emit(route.connection('close'), id);
                 });
 
                 ws.on('open', function( /*open*/ ) {
                     console.log('Opened ', id);
-                    me.emit('connection/open', id);
+                    me.emit(route.connection('open'), id);
                 });
 
                 ws.on('message', function incoming(data, flags) {
-                    me.emit('connection/message', id, JSON.parse(data), flags);
+                    me.emit(route.connection('message'), id, JSON.parse(data), flags);
                 });
             });
 
-            me.emit('server/open', me.getPort());
+            me.emit(route.server('open'), me.getPort());
         });
 
     };
 
     me.connectionAuthenticated = function(id, uuid) {
-        me.emit('connection/authenticated', {
+        me.emit(route.connection('authenticated'), {
             id,
             uuid
         });

--- a/src/common/route.ts
+++ b/src/common/route.ts
@@ -1,8 +1,17 @@
 /*
 Copyright 2017 OpenFin Inc.
 
-Licensed under OpenFin Commercial License you may not use this file except in compliance with your Commercial License.
-Please contact OpenFin Inc. at sales@openfin.co to obtain a Commercial License.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 */
 
 export type WindowRoute = (

--- a/src/common/route.ts
+++ b/src/common/route.ts
@@ -1,0 +1,92 @@
+/*
+Copyright 2017 OpenFin Inc.
+
+Licensed under OpenFin Commercial License you may not use this file except in compliance with your Commercial License.
+Please contact OpenFin Inc. at sales@openfin.co to obtain a Commercial License.
+*/
+
+type WindowRoute = (
+    type: string,
+    uuid?: string,
+    name?: string,
+    hyphenateUuidName?: boolean
+) => string;
+
+type AbbrRoute = (
+    type: string,
+    subtopic?: string,
+    subsubtopic?: string
+) => string;
+
+interface Route {
+    (
+        channel: string,
+        topic: string,
+        subtopic?: string,
+        subsubtopic?: string,
+        hyphenateUuidName?: boolean
+    ): string;
+
+    application: AbbrRoute;
+    externalApplication: AbbrRoute;
+    'external-application': AbbrRoute;
+
+    window: WindowRoute;
+    externalWindow: WindowRoute;
+    'external-window': WindowRoute;
+
+    system: AbbrRoute;
+    server: AbbrRoute;
+    connection: AbbrRoute;
+    runtime: AbbrRoute;
+
+    rvmMessageBus: AbbrRoute;
+    'rvm-message-bus': AbbrRoute;
+}
+
+interface Context { hyphenateUuidName: boolean }
+const HYPHEN: Context = { hyphenateUuidName: true };
+
+// returns 'channel/type' if only channel and type given
+// returns 'channel/type/subtopic' in only channel, type, and subtopic given
+// returns 'channel/type/subtopic/subsubtopic' if channel, type, subtopic, subsubtopic given and !(this && this.hyphenateUuidName)
+// returns 'channel/type/subtopic-subsubtopic' if channel, type, subtopic, subsubtopic given and !!(this && hyphenateUuidName)
+// note that this.hyphenateUuidName is overriden with hyphenateUuidName param when true or false
+function router(
+    channel: string,
+    type: string,
+    subtopic?: string,
+    subsubtopic?: string,
+    hyphenateUuidName?: boolean
+): string {
+    let result = `${channel}/${type}`;
+
+    if (subtopic) {
+        result += `/${subtopic}`;
+
+        if (subsubtopic) {
+            if (typeof hyphenateUuidName !== 'boolean') {
+                hyphenateUuidName = this && this.hyphenateUuidName;
+            }
+            result += hyphenateUuidName ? '-' : '/';
+            result += subsubtopic;
+        }
+    }
+    return result;
+}
+
+const route: Route = <Route>router.bind(null);
+
+route.application = <AbbrRoute>route.bind(null, 'application');
+route.externalApplication = route['external-application'] = <AbbrRoute>router.bind(null, 'external-application');
+
+route.window = <WindowRoute>router.bind(HYPHEN, 'window');
+route.externalWindow = route['external-window'] = <WindowRoute>router.bind(HYPHEN, 'external-window');
+
+route.system = <AbbrRoute>router.bind(null, 'system');
+route.rvmMessageBus = route['rvm-message-bus'] = <AbbrRoute>router.bind(null, 'rvm-message-bus');
+route.server = <AbbrRoute>router.bind(null, 'server');
+route.connection = <AbbrRoute>router.bind(null, 'connection');
+route.runtime = <AbbrRoute>router.bind(null, 'runtime');
+
+export default route;

--- a/src/common/route.ts
+++ b/src/common/route.ts
@@ -5,20 +5,20 @@ Licensed under OpenFin Commercial License you may not use this file except in co
 Please contact OpenFin Inc. at sales@openfin.co to obtain a Commercial License.
 */
 
-type WindowRoute = (
+export type WindowRoute = (
     type: string,
     uuid?: string,
     name?: string,
     hyphenateUuidName?: boolean
 ) => string;
 
-type AbbrRoute = (
+export type AbbrRoute = (
     type: string,
     subtopic?: string,
     subsubtopic?: string
 ) => string;
 
-interface Route {
+export interface Route {
     (
         channel: string,
         topic: string,

--- a/src/common/route.ts
+++ b/src/common/route.ts
@@ -21,7 +21,7 @@ export type WindowRoute = (
     hyphenateUuidName?: boolean
 ) => string;
 
-export type AbbrRoute = (
+export type SimpleRoute = (
     type: string,
     subtopic?: string,
     subsubtopic?: string
@@ -36,21 +36,21 @@ export interface Route {
         hyphenateUuidName?: boolean
     ): string;
 
-    application: AbbrRoute;
-    externalApplication: AbbrRoute;
-    'external-application': AbbrRoute;
+    application: SimpleRoute;
+    externalApplication: SimpleRoute;
+    'external-application': SimpleRoute;
 
     window: WindowRoute;
     externalWindow: WindowRoute;
     'external-window': WindowRoute;
 
-    system: AbbrRoute;
-    server: AbbrRoute;
-    connection: AbbrRoute;
-    runtime: AbbrRoute;
+    system: SimpleRoute;
+    server: SimpleRoute;
+    connection: SimpleRoute;
+    runtime: SimpleRoute;
 
-    rvmMessageBus: AbbrRoute;
-    'rvm-message-bus': AbbrRoute;
+    rvmMessageBus: SimpleRoute;
+    'rvm-message-bus': SimpleRoute;
 }
 
 interface Context { hyphenateUuidName: boolean; }
@@ -88,16 +88,16 @@ function router(
 
 const route: Route = <Route>router.bind(null);
 
-route.application = <AbbrRoute>route.bind(null, 'application');
-route.externalApplication = route['external-application'] = <AbbrRoute>router.bind(null, 'external-application');
+route.application = <SimpleRoute>route.bind(null, 'application');
+route.externalApplication = route['external-application'] = <SimpleRoute>router.bind(null, 'external-application');
 
 route.window = <WindowRoute>router.bind(HYPHEN, 'window');
 route.externalWindow = route['external-window'] = <WindowRoute>router.bind(HYPHEN, 'external-window');
 
-route.system = <AbbrRoute>router.bind(null, 'system');
-route.rvmMessageBus = route['rvm-message-bus'] = <AbbrRoute>router.bind(null, 'rvm-message-bus');
-route.server = <AbbrRoute>router.bind(null, 'server');
-route.connection = <AbbrRoute>router.bind(null, 'connection');
-route.runtime = <AbbrRoute>router.bind(null, 'runtime');
+route.system = <SimpleRoute>router.bind(null, 'system');
+route.rvmMessageBus = route['rvm-message-bus'] = <SimpleRoute>router.bind(null, 'rvm-message-bus');
+route.server = <SimpleRoute>router.bind(null, 'server');
+route.connection = <SimpleRoute>router.bind(null, 'connection');
+route.runtime = <SimpleRoute>router.bind(null, 'runtime');
 
 export default route;

--- a/src/common/route.ts
+++ b/src/common/route.ts
@@ -53,9 +53,10 @@ export interface Route {
     'rvm-message-bus': AbbrRoute;
 }
 
-interface Context { hyphenateUuidName: boolean }
+interface Context { hyphenateUuidName: boolean; }
 const HYPHEN: Context = { hyphenateUuidName: true };
 
+// NOTE: Always called bound to a context; see .bind() calls below.
 // returns 'channel/type' if only channel and type given
 // returns 'channel/type/subtopic' in only channel, type, and subtopic given
 // returns 'channel/type/subtopic/subsubtopic' if channel, type, subtopic, subsubtopic given and !(this && this.hyphenateUuidName)
@@ -75,6 +76,7 @@ function router(
 
         if (subsubtopic) {
             if (typeof hyphenateUuidName !== 'boolean') {
+                // tslint:disable-next-line:no-invalid-this (`this` is the bound context)
                 hyphenateUuidName = this && this.hyphenateUuidName;
             }
             result += hyphenateUuidName ? '-' : '/';

--- a/test/routes.test.ts
+++ b/test/routes.test.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import route, { Route, AbbrRoute, WindowRoute } from '../src/common/route';
+import route, { Route, SimpleRoute, WindowRoute } from '../src/common/route';
 import * as assert from 'assert';
 
 describe('route', () => {
@@ -59,12 +59,12 @@ shouldBeAbbrFunc('runtime');
 shouldBeAbbrFunc('rvmMessageBus', 'rvm-message-bus');
 shouldBeAbbrFunc('rvm-message-bus');
 
-interface AbbrRouteDict extends Route {
-    [funcName: string]: AbbrRoute;
+interface SimpleRouteDict extends Route {
+    [funcName: string]: SimpleRoute;
 }
 
 function shouldBeAbbrFunc(funcName: string, apiName?: string): void {
-    const abbrRoute: AbbrRoute = (<AbbrRouteDict>route)[funcName];
+    const abbrRoute: SimpleRoute = (<SimpleRouteDict>route)[funcName];
 
     apiName = apiName || funcName;
 

--- a/test/routes.test.ts
+++ b/test/routes.test.ts
@@ -1,0 +1,108 @@
+/*
+Copyright 2017 OpenFin Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import route, { Route, AbbrRoute, WindowRoute } from '../src/common/route';
+import * as assert from 'assert';
+
+describe('route', () => {
+    it('Should be a function', () => {
+        assert.equal(typeof route, 'function');
+    });
+
+    it('When called with 2 params, should return channel/topic', () => {
+        assert.equal(route('channel', 'topic'), 'channel/topic');
+    });
+
+    it('When called with 3 params, should return channel/topic/subtopic', () => {
+        assert.equal(route('channel', 'topic', 'subtopic'), 'channel/topic/subtopic');
+    });
+
+    it('When called with 4 params, should return channel/topic/subtopic/subsubtopic', () => {
+        assert.equal(route('channel', 'topic', 'subtopic', 'subsubtopic'), 'channel/topic/subtopic/subsubtopic');
+    });
+
+    it('When called with 4 string params and 5th param = false, should return channel/topic/subtopic/subsubtopic', () => {
+        assert.equal(route('channel', 'topic', 'subtopic', 'subsubtopic', false), 'channel/topic/subtopic/subsubtopic');
+    });
+
+    it('When called with 4 string params and 5th param = true, should return channel/topic/subtopic-subsubtopic', () => {
+        assert.equal(route('channel', 'topic', 'subtopic', 'subsubtopic', true), 'channel/topic/subtopic-subsubtopic');
+    });
+});
+
+shouldBeAbbrFunc('application');
+shouldBeAbbrFunc('externalApplication', 'external-application');
+shouldBeAbbrFunc('external-application');
+
+shouldBeWindowFunc('window');
+shouldBeWindowFunc('externalWindow', 'external-window');
+shouldBeWindowFunc('external-window');
+
+shouldBeAbbrFunc('system');
+shouldBeAbbrFunc('server');
+shouldBeAbbrFunc('connection');
+shouldBeAbbrFunc('runtime');
+
+shouldBeAbbrFunc('rvmMessageBus', 'rvm-message-bus');
+shouldBeAbbrFunc('rvm-message-bus');
+
+interface AbbrRouteDict extends Route {
+    [funcName: string]: AbbrRoute;
+}
+
+function shouldBeAbbrFunc(funcName: string, apiName?: string): void {
+    const abbrRoute: AbbrRoute = (<AbbrRouteDict>route)[funcName];
+
+    apiName = apiName || funcName;
+
+    describe(/\W/.test(funcName) ? `route['${funcName}']` : `route.${funcName}`, () => {
+        it('Should be a function', () => {
+            assert.equal(typeof abbrRoute, 'function');
+        });
+
+        it('When called with all 3 string params, should return channel/topic/subtopic/subsubtopic', () => {
+            assert.equal(abbrRoute('topic', 'subtopic', 'subsubtopic'), apiName + '/topic/subtopic/subsubtopic');
+        });
+    });
+}
+
+interface WindowRouteDict extends Route {
+    [funcName: string]: WindowRoute;
+}
+
+function shouldBeWindowFunc(funcName: string, apiName?: string): void {
+    const windowRoute: WindowRoute = (<WindowRouteDict>route)[funcName];
+
+    apiName = apiName || funcName;
+
+    describe(/\W/.test(funcName) ? `route['${funcName}']` : `route.${funcName}`, () => {
+        it('Should be a function', () => {
+            assert.equal(typeof windowRoute, 'function');
+        });
+
+        it('When called with 3 string params and 4th param omitted, should return channel/topic/subtopic-subsubtopic', () => {
+            assert.equal(windowRoute('topic', 'subtopic', 'subsubtopic'), apiName + '/topic/subtopic-subsubtopic');
+        });
+
+        it('When called with 3 string params and 4th param = false, should return channel/topic/subtopic/subsubtopic', () => {
+            assert.equal(windowRoute('topic', 'subtopic', 'subsubtopic', false), apiName + '/topic/subtopic/subsubtopic');
+        });
+
+        it('When called with 3 string params and 4th param = true, should return channel/topic/subtopic-subsubtopic', () => {
+            assert.equal(windowRoute('topic', 'subtopic', 'subsubtopic', true), apiName + '/topic/subtopic-subsubtopic');
+        });
+    });
+}


### PR DESCRIPTION
Yes, 21 files, but **Don't Panic!** because most of the edits one-to-one conversion from route literal to the new call.

I reviewed all the calls for accuracy. [Tested](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59275fc5998bc04e20cc6c8b) clean.

**Caveat:** The only literal route strings remaining in the code are in `src/renderer/api-decorator.js` (because of that file has no access to `require()`).

### New file: `src/common/routes.ts`
Generic route:
```js
'channel/topic/subtopic/subsubtopic'
```
Notes:
* Sometimes in our code "channel" is called `topic`; and "topic" is called `type`
* Window routes often end in `uuid/name`; they very occasionally end in `uuid-name`; and sometimes they end in something entirely different

### Features
* calling syntax designed for convenience/readability
* although `route` not a verb (or at least not intended to be so), I like it because it's short & sweet
* `useHyphen` param changes delimiter between 3rd and 4th parts from default to `'-'`
* note that default for `useHyphen` is `false` in general but is `true` for window (and external window)

In addition to the generic `route` function, I've defined several convenience subfunctions:
```js
route(channel, topic, subtopic, subsubtopic, useHyphen=false)
route.application(topic, subtopic, subsubtopic); // channel defaults to 'application'
route.window(topic, uuid, name, useHyphen=true); // channel defaults to 'window`, etc.
route.externalWindow(topic, uuid, name, useHyphen=true);
// etc. for route.system, .rvmMessageBus, .server, .connection, .runtime
```

Use the generic `route` function for:
* Programmaticaly fabricated routes where `channel` is indeterminate until execution time
* When the channel is not accommodated by one of the predefined subfunctions
```js
var extConnRoute = route('externalconn', 'closed'); // -> 'externalconn/closed'
```

Use the generic `route` function for:
* Programmaticaly fabricated routes where `channel` is indeterminate until execution time
* When the channel is not accommodated by one of the predefined subfunctions
```js
var extConnRoute = route('externalconn', 'closed'); // -> 'externalconn/closed'
```

### Examples
```js
// generic route calls default to NOT use hyphen (include true to use)
route('window', 'close-requested', uuid, name); // `notifications/listener/${uuid}/${name}`
route('window', 'unload', uuid, name, true); // `notifications/listener/${uuid}-${name}`

// window-specific routes use final hyphen by default (include false to not use)
route.window('close-requested', uuid, name); // `window/closed/${uuid}-${name}`
route.window('unload', uuid, name, false); // `window/unload/${uuid}/${name}`

// non-window routes never use final hyphen (4th param disallowed by TypeScript)
route.application('ready', uuid); // `application/ready/${uuid}`
route.application('ready', uuid, name); // `application/ready/${uuid}/${name}`

// following (not an actual route btw) would generate a TypeScript error
route.application('ready', uuid, name, true); // `application/ready/${uuid}-${name}`
```
For more, just see the diff. :wink:

### Local functions

```js
const routeExtWin = type => route.externalWindow(type, uuid, name);
routeExtWin('focus') // `external-window/focus/${uuid}-${name}`
```
Or:
```js
const emitToWin = (type, data) => ofEvents.emit(route.window(type, uuid, name), data);
emitToExtWin('close'); // ofEvents.emit(`external-window', type, uuid, name), data)
```
To make searching for route string easier (see next section), the naming convention for local rout functions is to always start with `route` or `emitTo`.

### Regex search arg
To locate all route strings, search the project using regular expression:
```regex
\b(route(\.\w+|\w+)?|emitTo\w+)\(
```

Lexeme|Meaning
---|---
`\b`|word boundary
`route`|literal
`\.\w+`|either: `route.somename`
`\|`|or
`\w+`|or: `routeSomeName`
`(...)?`|optional (just 'route' for generic route calls)
`\|`|or
`emitTo\w+`|or: `emitToSomeName`
`\(`|literal open parenthesis char (function in invocation)

### Unit tests
~I will contribute unit tests for `route` and it's subfunctions.~
Unit tests have been added for `route` and its subfunctions.