### PR TITLE
moved from the js-adapter to the hadouken node-adapter.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/openfin/openfin",
   "optionalDependencies": {
     "openfin-sign": "git+ssh://git@github.com:openfin/openfin-sign.git#caee55ecbe6f81e6ed9630790781fe4d1835cb03",
-    "runtime-p2p": "git@github.com:openfin/runtime-p2p.git#91ed159a9e49be32fb794f4be3ef4a9e9f0f01b9"
+    "runtime-p2p": "git+ssh://git@github.com:openfin/runtime-p2p.git#2dc7945deac21ee5b632ed2dc8ba55efbbd343cf"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.39",


### PR DESCRIPTION
runtime-p2p updated from openfin/js-adapter to hadoukenio/node-adapter 