### PR TITLE
RUN-2846 license info from app launch / adapters

### DIFF
--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -329,7 +329,7 @@ Application.getShortcuts = function(identity, callback, errorCallback) {
         .catch(errorCallback);
 };
 
-Application.getInfo = function(identity, callback /*, errorCallback*/ ) {
+Application.getInfo = function(identity, callback) {
     const app = Application.wrap(identity.uuid);
 
     const response = {
@@ -345,17 +345,17 @@ Application.getWindow = function(identity) {
     return Window.wrap(uuid, uuid);
 };
 
-Application.grantAccess = function( /*action, callback, errorCallback*/ ) {
+Application.grantAccess = function() {
     console.warn('Deprecated');
 };
-Application.grantWindowAccess = function( /*action, windowName, callback, errorCallback*/ ) {
+Application.grantWindowAccess = function() {
     console.warn('Deprecated');
 };
-Application.isRunning = function(identity /*, callback, errorCallback*/ ) {
+Application.isRunning = function(identity) {
     let uuid = identity && identity.uuid;
     return uuid && coreState.getAppRunningState(uuid) && !coreState.getAppRestartingState(uuid);
 };
-Application.pingChildWindow = function( /*name, callback, errorCallback*/ ) {
+Application.pingChildWindow = function() {
     console.warn('Deprecated');
 };
 Application.registerCustomData = function(identity, data, callback, errorCallback) {
@@ -385,19 +385,19 @@ Application.registerCustomData = function(identity, data, callback, errorCallbac
 };
 
 //TODO:Ricardo: This should be deprecated.
-Application.removeEventListener = function(identity, type, listener /*, callback, errorCallback*/ ) {
+Application.removeEventListener = function(identity, type, listener) {
     var app = Application.wrap(identity.uuid);
 
     ofEvents.removeListener(eventRoute(app.id, type), listener);
 };
 
-Application.removeTrayIcon = function(identity /*, callback, errorCallback*/ ) {
+Application.removeTrayIcon = function(identity) {
     const app = Application.wrap(identity.uuid);
 
     removeTrayIcon(app);
 };
 
-Application.restart = function(identity /*, callback, errorCallback*/ ) {
+Application.restart = function(identity) {
     let uuid = identity.uuid;
     const appObj = coreState.getAppObjByUuid(uuid);
 
@@ -417,14 +417,17 @@ Application.restart = function(identity /*, callback, errorCallback*/ ) {
         throw err;
     }
 };
-Application.revokeAccess = function( /*action, callback, errorCallback*/ ) {
-    console.warn('Deprecated');
-};
-Application.revokeWindowAccess = function( /*action, windowName, callback, errorCallback*/ ) {
+
+Application.revokeAccess = function() {
     console.warn('Deprecated');
 };
 
-Application.run = function(identity, configUrl = '' /*, callback , errorCallback*/ ) {
+Application.revokeWindowAccess = function() {
+    console.warn('Deprecated');
+};
+
+Application.run = function(identity, configUrl = '') {
+
     if (!identity) {
         return;
     }
@@ -524,6 +527,24 @@ Application.run = function(identity, configUrl = '' /*, callback , errorCallback
             type: 'connected',
             uuid
         });
+
+        // const { parentUuid } = coreState.appByUuid(uuid);
+
+        const parentConfigUrl = coreState.getConfigUrlByUuid;
+
+        // TODO add correct info here..
+        rvmBus.registerLicenseInfo({
+            licenseKey: mainWindowOpts.licenseKey,
+            client: {
+                type: 'js',
+                pid
+            },
+            parentApp: {
+                sourceUrl: parentConfigUrl
+            },
+            sourceUrl
+        });
+
     });
 
     // turn on plugins for the main window
@@ -655,7 +676,7 @@ Application.runWithRVM = function(identity, manifestUrl) {
     });
 };
 
-Application.send = function( /*topic, message*/ ) {
+Application.send = function() {
     console.warn('Deprecated. Please use InterAppBus');
 };
 
@@ -823,7 +844,7 @@ Application.emitRunRequested = function(identity) {
     }
 };
 
-Application.wait = function( /*callback, errorCallback*/ ) {
+Application.wait = function() {
     console.warn('Awaiting native implementation');
 };
 

--- a/src/browser/rvm/rvm_message_bus.ts
+++ b/src/browser/rvm/rvm_message_bus.ts
@@ -145,6 +145,7 @@ export interface ApplicationEvent extends RvmMsgBase {
     topic: ApplicationEventTopic;
     type: EventType;
     sourceUrl: string;
+}
 
 export interface ExternalLicenseInfo {
     licenseKey?: string;

--- a/src/browser/rvm/rvm_message_bus.ts
+++ b/src/browser/rvm/rvm_message_bus.ts
@@ -147,7 +147,7 @@ export interface ApplicationEvent extends RvmMsgBase {
     sourceUrl: string;
 }
 
-export interface ExternalLicenseInfo {
+export interface LicenseInfo {
     licenseKey?: string;
     client?: {
         type: 'dotnet' | 'java' | 'air' | 'node' | 'js';
@@ -237,7 +237,7 @@ export class RVMMessageBus extends EventEmitter  {
         return this.transport.publish(envelope);
     }
 
-    public registerLicenseInfo(licInfo: ExternalLicenseInfo): boolean {
+    public registerLicenseInfo(licInfo: LicenseInfo): boolean {
         const payload = Object.assign({
             action: 'license-info',
             topic: 'application',

--- a/src/browser/rvm/rvm_message_bus.ts
+++ b/src/browser/rvm/rvm_message_bus.ts
@@ -145,6 +145,17 @@ export interface ApplicationEvent extends RvmMsgBase {
     topic: ApplicationEventTopic;
     type: EventType;
     sourceUrl: string;
+
+export interface ExternalLicenseInfo {
+    licenseKey?: string;
+    client?: {
+        type: 'dotnet' | 'java' | 'air' | 'node' | 'js';
+        version: string;
+    };
+    pid?: number;
+    parentApp?: {
+        sourceUrl: string;
+    };
 }
 
 /**
@@ -153,9 +164,10 @@ export interface ApplicationEvent extends RvmMsgBase {
  * 'broadcast' messages received from RVM(RVM initiated) will be broadcasted
  *
  **/
-class RVMMessageBus extends EventEmitter  {
+export class RVMMessageBus extends EventEmitter  {
     private messageIdToCallback: RvmCallbacks; // Tracks functions that we'll notify If a response is received
     private transport: WMCopyData;
+    public static sessionId = App.generateGUID();
 
     constructor() {
         super();
@@ -204,7 +216,7 @@ class RVMMessageBus extends EventEmitter  {
         });
     }
 
-    public publish(msg: RvmMsgBase, callback: Function) {
+    public publish(msg: RvmMsgBase, callback: (x: any) => any = ()  => undefined): boolean {
         const {topic, timeToLive} = msg;
         const payload: any = Object.assign({
             processId: process.pid,
@@ -222,7 +234,6 @@ class RVMMessageBus extends EventEmitter  {
         this.recordCallbackInfo(callback, timeToLive, envelope);
 
         return this.transport.publish(envelope);
-
     }
 
     /**

--- a/src/browser/rvm/rvm_message_bus.ts
+++ b/src/browser/rvm/rvm_message_bus.ts
@@ -237,6 +237,26 @@ export class RVMMessageBus extends EventEmitter  {
         return this.transport.publish(envelope);
     }
 
+    public registerLicenseInfo(licInfo: ExternalLicenseInfo): boolean {
+        const payload = Object.assign({
+            action: 'license-info',
+            topic: 'application',
+            sessionId: RVMMessageBus.sessionId,
+            parentApp: {
+                sourceUrl: null
+            },
+            sourceUrl: null,
+            licenseKey: null,
+            client: {
+                type: null,
+                version: null,
+                pid: null
+            }
+        }, licInfo);
+
+        return this.publish(payload);
+    }
+
     /**
      * recordCallbackInfo() - Records callback info based on messageId so we execute callback upon relevant RVM response.
      * Also sets up timetoLive if requested.

--- a/test/rvm_message_bus.test.ts
+++ b/test/rvm_message_bus.test.ts
@@ -40,6 +40,8 @@ describe('rvm message bus', () => {
 
         it('should send the correct payload when all members present', () => {
             const payloadShape: any = {
+                processId: 'test value',
+                runtimeVersion: 'test value',
                 action: 'license-info',
                 sessionId: RVMMessageBus.sessionId,
                 parentApp: {

--- a/test/rvm_message_bus.test.ts
+++ b/test/rvm_message_bus.test.ts
@@ -38,16 +38,17 @@ describe('rvm message bus', () => {
 
     describe('registerLiceneInfo', () => {
 
-        it('should send the correct payload when all members present', () => {
+        it('should send the correct base payload', () => {
             const payloadShape: any = {
-                processId: 'test value',
-                runtimeVersion: 'test value',
+                processId: 'processId',
+                runtimeVersion: 'runtimeVersion',
+
                 action: 'license-info',
                 sessionId: RVMMessageBus.sessionId,
                 parentApp: {
                     sourceUrl: null
                 },
-                sourceUrl: null, // if external conn, this will be the current --config-url as per runtime args
+                sourceUrl: null,
                 licenseKey: null,
                 client: {
                     type: null,
@@ -55,7 +56,49 @@ describe('rvm message bus', () => {
                     pid: null
                 }
             }
-            const {payload} = <any> rvmMessageBus.registerLiceneInfo(<ExternalLicenseInfo>{});
+            const {payload} = <any> rvmMessageBus.registerLicenseInfo(<ExternalLicenseInfo> {
+                processId: 'processId',
+                runtimeVersion: 'runtimeVersion'
+            });
+
+            assert.deepEqual(payloadShape, payload, 'shapes should match hommie');
+        });
+
+        it('should send the correct full payload', () => {
+
+            const payloadShape: any = {
+                processId: 'processId',
+                runtimeVersion: 'runtimeVersion',
+
+                action: 'license-info',
+                sessionId: RVMMessageBus.sessionId,
+                parentApp: {
+                    sourceUrl: 'parentApp.sourceUrl'
+                },
+                sourceUrl: 'sourceUrl',
+                licenseKey: 'licenseKey',
+                client: {
+                    type: 'js',
+                    version: 'version',
+                    pid: 999999999
+                }
+            }
+
+            const {payload} = <any> rvmMessageBus.registerLicenseInfo(<ExternalLicenseInfo> {
+                processId: 'processId',
+                runtimeVersion: 'runtimeVersion',
+                parentApp: {
+                    sourceUrl: 'parentApp.sourceUrl'
+                },
+                sourceUrl: 'sourceUrl',
+                licenseKey: 'licenseKey',
+                client: {
+                    type: 'js',
+                    version: 'version',
+                    pid: 999999999
+                }
+            });
+
             assert.deepEqual(payloadShape, payload, 'shapes should match');
         });
     });

--- a/test/rvm_message_bus.test.ts
+++ b/test/rvm_message_bus.test.ts
@@ -32,7 +32,7 @@ const mockWMCopyData  = {
 mockery.registerMock('../transport', mockWMCopyData);
 mockery.enable();
 
-import {rvmMessageBus, RVMMessageBus, ExternalLicenseInfo} from '../src/browser/rvm/rvm_message_bus';
+import {rvmMessageBus, RVMMessageBus, LicenseInfo} from '../src/browser/rvm/rvm_message_bus';
 
 describe('rvm message bus', () => {
 
@@ -56,7 +56,7 @@ describe('rvm message bus', () => {
                     pid: null
                 }
             }
-            const {payload} = <any> rvmMessageBus.registerLicenseInfo(<ExternalLicenseInfo> {
+            const {payload} = <any> rvmMessageBus.registerLicenseInfo(<LicenseInfo> {
                 processId: 'processId',
                 runtimeVersion: 'runtimeVersion'
             });
@@ -84,7 +84,7 @@ describe('rvm message bus', () => {
                 }
             }
 
-            const {payload} = <any> rvmMessageBus.registerLicenseInfo(<ExternalLicenseInfo> {
+            const {payload} = <any> rvmMessageBus.registerLicenseInfo(<LicenseInfo> {
                 processId: 'processId',
                 runtimeVersion: 'runtimeVersion',
                 parentApp: {

--- a/test/rvm_message_bus.test.ts
+++ b/test/rvm_message_bus.test.ts
@@ -1,0 +1,65 @@
+/*
+Copyright 2017 OpenFin Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import * as assert from 'assert';
+import * as mockery from 'mockery';
+import {EventEmitter} from 'events';
+const App = require('electron').app;
+
+App.generateGUID = Math.random;
+
+const mockWMCopyData  = {
+    WMCopyData: function(){
+        return {
+            on: (x: any) => x,
+            publish: (x: any ) => x
+        }
+    }
+}
+
+mockery.registerMock('../transport', mockWMCopyData);
+mockery.enable();
+
+import {rvmMessageBus, RVMMessageBus, ExternalLicenseInfo} from '../src/browser/rvm/rvm_message_bus';
+
+describe('rvm message bus', () => {
+
+    describe('registerLiceneInfo', () => {
+
+        it('should send the correct payload when all members present', () => {
+            const payloadShape: any = {
+                action: 'license-info',
+                sessionId: RVMMessageBus.sessionId,
+                parentApp: {
+                    sourceUrl: null
+                },
+                sourceUrl: null, // if external conn, this will be the current --config-url as per runtime args
+                licenseKey: null,
+                client: {
+                    type: null,
+                    version: null,
+                    pid: null
+                }
+            }
+            const {payload} = <any> rvmMessageBus.registerLiceneInfo(<ExternalLicenseInfo>{});
+            assert.deepEqual(payloadShape, payload, 'shapes should match');
+        });
+    });
+});
+
+after(() => {
+    mockery.deregisterAll();
+    mockery.disable();
+});


### PR DESCRIPTION
Send the license key as well as some predefined meta info upon app launch and external connection authorization. 

This is ahead of the RVM's ability to accept such info. Talking to Omer and Pat, this should not be an issue as these new messages will should be dropped upon arrival. 

Also some very basic local cleanup (removal of the /* callback, errorCallback */ silliness). 

No new end-to-end tests, basic shape checks are done with simple unit tests / mocks. 

[tests well](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/592f0d27998bc04e20cc6c94) 
Tests that fail are either pegged to the 7.53.21.* release (create from manifest...) or are failing even on fresh 7.53.20.20 for me (window navigation... )