### PR TITLE
RUN-2846 Send licensing info

### DIFF
--- a/index.js
+++ b/index.js
@@ -475,20 +475,22 @@ function initServer() {
 //please see the discussion on https://github.com/openfin/runtime-core/pull/194
 function launchApp(argo, startExternalAdapterServer) {
     convertOptions.fetchOptions(argo, configuration => {
-        let {
+        const {
             configUrl,
-            configObject
+            configObject,
+            configObject: { licenseKey }
         } = configuration;
-        let openfinWinOpts = convertOptions.getWindowOptions(configObject);
-        let startUpApp = configObject.startup_app; /* jshint ignore:line */
-        let uuid = startUpApp && startUpApp.uuid;
-        let ofApp = Application.wrap(uuid);
-        let isRunning = Application.isRunning(ofApp);
+
+        const openfinWinOpts = convertOptions.getWindowOptions(configObject);
+        const startUpApp = configObject.startup_app; /* jshint ignore:line */
+        const uuid = startUpApp && startUpApp.uuid;
+        const ofApp = Application.wrap(uuid);
+        const isRunning = Application.isRunning(ofApp);
 
         if (openfinWinOpts && !isRunning) {
             //making sure that if a window is pressent we set the window name === to the uuid as per 5.0
             openfinWinOpts.name = uuid;
-            initFirstApp(openfinWinOpts, configUrl);
+            initFirstApp(openfinWinOpts, configUrl, licenseKey);
         } else if (uuid) {
             Application.run({
                 uuid,
@@ -517,10 +519,12 @@ function launchApp(argo, startExternalAdapterServer) {
 }
 
 
-function initFirstApp(options, configUrl) {
+function initFirstApp(options, configUrl, licenseKey) {
     try {
         // Needs proper configs
         firstApp = Application.create(options, configUrl);
+
+        coreState.setLicenseKey({ uuid: options.uuid }, licenseKey);
 
         Application.run({
             uuid: firstApp.uuid

--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -87,8 +87,9 @@ electronApp.on('use-plugins-requested', event => {
 });
 
 electronApp.on('ready', function() {
-    log.writeToLog(1, 'RVM MESSAGE BUS READY', true);
     rvmBus = require('../rvm/rvm_message_bus').rvmMessageBus;
+    log.writeToLog(1, 'RVM MESSAGE BUS READY', true);
+
     MonitorInfo = require('../monitor_info.js');
 
     // listen to and broadcast 'broadcast' messages from RVM as an openfin app event
@@ -116,47 +117,53 @@ Application.create = function(opts, configUrl = '', parentIdentity = {}) {
     //Hide Window until run is called
 
     let appUrl = opts.url;
+    const { uuid, name } = opts;
+
     if (appUrl === undefined && opts.mainWindowOptions) {
         appUrl = opts.mainWindowOptions.url;
     }
 
     // undefined or '' acceptable here (gets default in createAppObj); or non-empty string
-    let isValidUrl = appUrl === undefined || typeof appUrl === 'string';
+    const isValidUrl = appUrl === undefined || typeof appUrl === 'string';
     if (!isValidUrl) {
         throw new Error(`Invalid application URL: ${appUrl}`);
     }
 
-    let isValidUuid = isNonEmptyString(opts.uuid) && opts.uuid !== '*';
+    const isValidUuid = isNonEmptyString(uuid) && uuid !== '*';
     if (!isValidUuid) {
-        throw new Error(`Invalid application UUID: ${opts.uuid}`);
+        throw new Error(`Invalid application UUID: ${uuid}`);
     }
 
-    let isValidName = isNonEmptyString(opts.name) && opts.name !== '*';
+    const isValidName = isNonEmptyString(name) && name !== '*';
     if (!isValidName) {
-        throw new Error(`Invalid application name: ${opts.name}`);
+        throw new Error(`Invalid application name: ${name}`);
     }
 
-    let isAppRunning = coreState.getAppRunningState(opts.uuid);
+    const isAppRunning = coreState.getAppRunningState(uuid);
     if (isAppRunning) {
-        throw new Error(`Application with specified UUID already exists: ${opts.uuid}`);
+        throw new Error(`Application with specified UUID already exists: ${uuid}`);
     }
 
-    let parentUuid = parentIdentity && parentIdentity.uuid;
-    if (!validateNavigationRules(opts.uuid, appUrl, parentUuid, opts)) {
+    const parentUuid = parentIdentity && parentIdentity.uuid;
+    if (!validateNavigationRules(uuid, appUrl, parentUuid, opts)) {
         throw new Error(`Application with specified URL is not allowed: ${opts.appUrl}`);
     }
 
-    let existingApp = coreState.appByUuid(opts.uuid);
+    const existingApp = coreState.appByUuid(uuid);
     if (existingApp) {
         coreState.removeApp(existingApp.id);
     }
 
-    let appObj = createAppObj(opts.uuid, opts, configUrl);
+    const appObj = createAppObj(uuid, opts, configUrl);
 
     if (parentIdentity && parentIdentity.uuid) {
-        let app = coreState.appByUuid(opts.uuid);
 
-        app.parentUuid = parentIdentity.uuid;
+        // This is a reference to the meta `app` object that is stored in core state,
+        // not the actual `application` object created above. Here we are attaching the parent
+        // indentity to it.
+        const app = coreState.appByUuid(opts.uuid);
+
+        app.parentUuid = parentUuid;
     }
 
     return appObj;
@@ -341,7 +348,7 @@ Application.getShortcuts = function(identity, callback, errorCallback) {
         .catch(errorCallback);
 };
 
-Application.getInfo = function(identity, callback /*, errorCallback*/ ) {
+Application.getInfo = function(identity, callback) {
     const app = Application.wrap(identity.uuid);
 
     const response = {
@@ -357,17 +364,17 @@ Application.getWindow = function(identity) {
     return Window.wrap(uuid, uuid);
 };
 
-Application.grantAccess = function( /*action, callback, errorCallback*/ ) {
+Application.grantAccess = function() {
     console.warn('Deprecated');
 };
-Application.grantWindowAccess = function( /*action, windowName, callback, errorCallback*/ ) {
+Application.grantWindowAccess = function() {
     console.warn('Deprecated');
 };
-Application.isRunning = function(identity /*, callback, errorCallback*/ ) {
+Application.isRunning = function(identity) {
     let uuid = identity && identity.uuid;
     return uuid && coreState.getAppRunningState(uuid) && !coreState.getAppRestartingState(uuid);
 };
-Application.pingChildWindow = function( /*name, callback, errorCallback*/ ) {
+Application.pingChildWindow = function() {
     console.warn('Deprecated');
 };
 Application.registerCustomData = function(identity, data, callback, errorCallback) {
@@ -397,19 +404,19 @@ Application.registerCustomData = function(identity, data, callback, errorCallbac
 };
 
 //TODO:Ricardo: This should be deprecated.
-Application.removeEventListener = function(identity, type, listener /*, callback, errorCallback*/ ) {
+Application.removeEventListener = function(identity, type, listener) {
     var app = Application.wrap(identity.uuid);
 
     ofEvents.removeListener(route.application(type, app.id), listener);
 };
 
-Application.removeTrayIcon = function(identity /*, callback, errorCallback*/ ) {
+Application.removeTrayIcon = function(identity) {
     const app = Application.wrap(identity.uuid);
 
     removeTrayIcon(app);
 };
 
-Application.restart = function(identity /*, callback, errorCallback*/ ) {
+Application.restart = function(identity) {
     let uuid = identity.uuid;
     const appObj = coreState.getAppObjByUuid(uuid);
 
@@ -429,14 +436,17 @@ Application.restart = function(identity /*, callback, errorCallback*/ ) {
         throw err;
     }
 };
-Application.revokeAccess = function( /*action, callback, errorCallback*/ ) {
-    console.warn('Deprecated');
-};
-Application.revokeWindowAccess = function( /*action, windowName, callback, errorCallback*/ ) {
+
+Application.revokeAccess = function() {
     console.warn('Deprecated');
 };
 
-Application.run = function(identity, configUrl = '' /*, callback , errorCallback*/ ) {
+Application.revokeWindowAccess = function() {
+    console.warn('Deprecated');
+};
+
+Application.run = function(identity, configUrl = '') {
+
     if (!identity) {
         return;
     }
@@ -522,15 +532,43 @@ Application.run = function(identity, configUrl = '' /*, callback , errorCallback
 
     // fire the connected once the main window's dom is ready
     app.mainWindow.webContents.once('dom-ready', () => {
-        var pid = app.mainWindow.webContents.processId;
+        const pid = app.mainWindow.webContents.processId;
 
         if (pid) {
             app._processInfo = new ProcessInfo(pid);
+
             // Must call once to start measuring CPU usage
             app._processInfo.getCpuUsage();
         }
 
         ofEvents.emit(route.application('connected', uuid), { topic: 'application', type: 'connected', uuid });
+
+        const parentConfigUrl = coreState.getConfigUrlByUuid(uuid);
+
+        // First check the local option set for any license info, then check
+        // if any license info was stamped on the meta app obj (this is the case
+        // when the app was manifest launched), finally check the parent's meta
+        // obj. If any is found assign this to the current app's meta object. This
+        // will ensure it is carried forward to and descendant app launches.
+
+        let licenseKey = mainWindowOpts.licenseKey;
+
+        licenseKey = licenseKey || coreState.getLicenseKey({ uuid });
+        licenseKey = licenseKey || coreState.getLicenseKey({ uuid: appState.parentUuid });
+
+        coreState.setLicenseKey({ uuid }, licenseKey);
+
+        rvmBus.registerLicenseInfo({
+            licenseKey,
+            client: {
+                type: 'js',
+                pid
+            },
+            parentApp: {
+                sourceUrl: parentConfigUrl
+            },
+            sourceUrl
+        });
     });
 
     // turn on plugins for the main window
@@ -636,7 +674,7 @@ Application.runWithRVM = function(identity, manifestUrl) {
     });
 };
 
-Application.send = function( /*topic, message*/ ) {
+Application.send = function() {
     console.warn('Deprecated. Please use InterAppBus');
 };
 
@@ -804,7 +842,7 @@ Application.emitRunRequested = function(identity) {
     }
 };
 
-Application.wait = function( /*callback, errorCallback*/ ) {
+Application.wait = function() {
     console.warn('Awaiting native implementation');
 };
 

--- a/src/browser/core_state.js
+++ b/src/browser/core_state.js
@@ -124,6 +124,8 @@ function appByUuid(uuid) {
     return coreState.apps.find(app => uuid === app.uuid);
 }
 
+const getAppByUuid = appByUuid;
+
 function setAppRunningState(uuid, running) {
     const app = appByUuid(uuid);
     if (app) {
@@ -512,6 +514,30 @@ function getAppAncestor(descendantAppUuid) {
     }
 }
 
+function setLicenseKey(identity, licenseKey) {
+    const { uuid } = identity;
+    const app = getAppByUuid(uuid);
+
+    if (app) {
+        app.licenseKey = licenseKey;
+
+        return licenseKey;
+    } else {
+        return null;
+    }
+}
+
+function getLicenseKey(identity) {
+    const { uuid } = identity;
+    const app = getAppByUuid(uuid);
+
+    if (app) {
+        return app.licenseKey;
+    } else {
+        return null;
+    }
+}
+
 // methods
 module.exports = {
     addApp,
@@ -529,12 +555,14 @@ module.exports = {
     getAppByWin,
     getAppObj,
     getAppObjByUuid,
+    getAppByUuid,
     getUuidBySourceUrl,
     getConfigUrlByUuid,
     getAppRunningState,
     getAppRestartingState,
     getChildrenByApp,
     getChildrenByWinId,
+    getLicenseKey,
     getMainWindowOptions,
     getManifestProxySettings,
     getOfWindowByUuidName,
@@ -553,6 +581,7 @@ module.exports = {
     setAppOptions,
     setAppRunningState,
     setAppRestartingState,
+    setLicenseKey,
     setManifestProxySettings,
     setStartManifest,
     setWindowObj,

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -26,6 +26,7 @@ declare module 'electron' {
         export function getPath(str: string): string;
         export function getTickCount(): number;
         export function on(event: string, callback: () => void): void;
+        export function generateGUID(): string;
     }
 
     namespace BrowserWindow {

--- a/test/rvm_message_bus.test.ts
+++ b/test/rvm_message_bus.test.ts
@@ -1,0 +1,110 @@
+/*
+Copyright 2017 OpenFin Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import * as assert from 'assert';
+import * as mockery from 'mockery';
+import {EventEmitter} from 'events';
+import { app }  from 'electron';
+
+app.generateGUID = () => '' + Math.random;
+
+const mockWMCopyData  = {
+    WMCopyData: function () {
+        return {
+            on: (x: any) => x,
+            publish: (x: any ) => x
+        }
+    }
+}
+
+mockery.registerMock('../transport', mockWMCopyData);
+mockery.enable();
+
+import {rvmMessageBus, RVMMessageBus, LicenseInfo} from '../src/browser/rvm/rvm_message_bus';
+
+describe('rvm message bus', () => {
+
+    describe('registerLiceneInfo', () => {
+
+        it('should send the correct base payload', () => {
+            const payloadShape: any = {
+                processId: 'processId',
+                runtimeVersion: 'runtimeVersion',
+
+                action: 'license-info',
+                sessionId: RVMMessageBus.sessionId,
+                parentApp: {
+                    sourceUrl: null
+                },
+                sourceUrl: null,
+                licenseKey: null,
+                client: {
+                    type: null,
+                    version: null,
+                    pid: null
+                }
+            }
+            const {payload} = <any> rvmMessageBus.registerLicenseInfo(<LicenseInfo> {
+                processId: 'processId',
+                runtimeVersion: 'runtimeVersion'
+            });
+
+            assert.deepEqual(payloadShape, payload, 'shapes should match');
+        });
+
+        it('should send the correct full payload', () => {
+
+            const payloadShape: any = {
+                processId: 'processId',
+                runtimeVersion: 'runtimeVersion',
+
+                action: 'license-info',
+                sessionId: RVMMessageBus.sessionId,
+                parentApp: {
+                    sourceUrl: 'parentApp.sourceUrl'
+                },
+                sourceUrl: 'sourceUrl',
+                licenseKey: 'licenseKey',
+                client: {
+                    type: 'js',
+                    version: 'version',
+                    pid: 999999999
+                }
+            }
+
+            const {payload} = <any> rvmMessageBus.registerLicenseInfo(<LicenseInfo> {
+                processId: 'processId',
+                runtimeVersion: 'runtimeVersion',
+                parentApp: {
+                    sourceUrl: 'parentApp.sourceUrl'
+                },
+                sourceUrl: 'sourceUrl',
+                licenseKey: 'licenseKey',
+                client: {
+                    type: 'js',
+                    version: 'version',
+                    pid: 999999999
+                }
+            });
+
+            assert.deepEqual(payloadShape, payload, 'shapes should match');
+        });
+    });
+});
+
+after(() => {
+    mockery.deregisterAll();
+    mockery.disable();
+});


### PR DESCRIPTION
* RUN-2846 working on testing

* RUN-2846 rebasing to develop

* RUN-2846 send the license info on app run and external adapter connected

* RUN-2846 better name for ExternalLicenseInfo

* RUN-2966 expose webSecurity (#43)

* RUN-2846 stamp the license key on the app meta object, use local license if provided

* RUN-2846 removed redundant setLicenseKey call

* RUN-2846 test file cleanup

* RUN-2846 updated for import statements