### PR TITLE
RUN-3044 merge into 7.53.21/staging

### DIFF
--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -161,7 +161,6 @@ Application.create = function(opts, configUrl = '', parentIdentity = {}) {
         // not the actual `application` object created above. Here we are attaching the parent
         // indentity to it.
         const app = coreState.appByUuid(opts.uuid);
-
         app.parentUuid = parentUuid;
     }
 
@@ -452,26 +451,54 @@ Application.run = function(identity, configUrl = '') {
 
     createAppObj(identity.uuid, null, configUrl);
 
-    let uuid = identity.uuid,
-        app = Application.wrap(uuid),
-        appState = coreState.appByUuid(uuid),
-        mainWindowOpts = _.clone(app._options),
-        hideSplashTopic = route.application('hide-splashscreen', uuid),
-        eventListenerStrings = [],
-        sourceUrl = appState.appObj._configUrl,
-        hideSplashListener = () => {
-            let rvmPayload = {
-                topic: 'application',
-                action: 'hide-splashscreen',
-                sourceUrl
-            };
+    const uuid = identity.uuid;
+    const app = Application.wrap(uuid);
+    const appState = coreState.appByUuid(uuid);
+    let sourceUrl = appState.appObj._configUrl;
+    const mainWindowOpts = _.clone(app._options);
+    const hideSplashTopic = route.application('hide-splashscreen', uuid);
+    const eventListenerStrings = [];
+    const hideSplashListener = () => {
+        let rvmPayload = {
+            topic: 'application',
+            action: 'hide-splashscreen',
+            sourceUrl
+        };
 
-            if (rvmBus) {
-                rvmBus.publish(rvmPayload);
+        if (rvmBus) {
+            rvmBus.publish(rvmPayload);
+        }
+    };
+
+    // First check the local option set for any license info, then check
+    // if any license info was stamped on the meta app obj (this is the case
+    // when the app was manifest launched), finally check the parent's meta
+    // obj. If any is found assign this to the current app's meta object. This
+    // will ensure it is carried forward to and descendant app launches.
+    const genLicensePayload = () => {
+        let licenseKey = mainWindowOpts.licenseKey;
+
+        licenseKey = licenseKey || coreState.getLicenseKey({ uuid });
+        licenseKey = licenseKey || coreState.getLicenseKey({ uuid: appState.parentUuid });
+
+        coreState.setLicenseKey({ uuid }, licenseKey);
+
+        return {
+            licenseKey,
+            uuid,
+            client: {
+                type: 'js'
+            },
+            parentApp: {
+                uuid: appState.parentUuid || null
             }
-        },
-        appEventsForRVM = ['started', 'closed', 'ready', 'run-requested', 'crashed', 'error', 'not-responding', 'out-of-memory'],
-        sendAppsEventsToRVMListener = (appEvent) => {
+        };
+    };
+    const appEventsForRVM = ['closed', 'ready', 'run-requested', 'crashed', 'error', 'not-responding', 'out-of-memory'];
+    const appStartedHandler = () => {
+        rvmBus.registerLicenseInfo({ data: genLicensePayload() }, sourceUrl);
+    };
+    const sendAppsEventsToRVMListener = (appEvent) => {
             if (!sourceUrl) {
                 return; // Most likely an adapter, RVM can't do anything with what it didn't load(determined by sourceUrl) so ignore
             }
@@ -499,7 +526,7 @@ Application.run = function(identity, configUrl = '') {
             if (rvmBus) {
                 rvmBus.publish(rvmPayload);
             }
-        };
+};
 
     // if the runtime is in offline mode, the RVM still expects the
     // startup-url/config for communication
@@ -519,6 +546,7 @@ Application.run = function(identity, configUrl = '') {
 
     // Set up RVM related listeners for events the RVM cares about
     ofEvents.on(hideSplashTopic, hideSplashListener);
+    ofEvents.on(route.application('started', uuid), appStartedHandler);
     appEventsForRVM.forEach(appEvent => {
         ofEvents.on(route.application(appEvent, uuid), sendAppsEventsToRVMListener);
     });
@@ -541,33 +569,6 @@ Application.run = function(identity, configUrl = '') {
         }
 
         ofEvents.emit(route.application('connected', uuid), { topic: 'application', type: 'connected', uuid });
-
-        const parentConfigUrl = coreState.getConfigUrlByUuid(uuid);
-
-        // First check the local option set for any license info, then check
-        // if any license info was stamped on the meta app obj (this is the case
-        // when the app was manifest launched), finally check the parent's meta
-        // obj. If any is found assign this to the current app's meta object. This
-        // will ensure it is carried forward to and descendant app launches.
-
-        let licenseKey = mainWindowOpts.licenseKey;
-
-        licenseKey = licenseKey || coreState.getLicenseKey({ uuid });
-        licenseKey = licenseKey || coreState.getLicenseKey({ uuid: appState.parentUuid });
-
-        coreState.setLicenseKey({ uuid }, licenseKey);
-
-        rvmBus.registerLicenseInfo({
-            licenseKey,
-            client: {
-                type: 'js',
-                pid
-            },
-            parentApp: {
-                sourceUrl: parentConfigUrl
-            },
-            sourceUrl
-        });
     });
 
     // turn on plugins for the main window
@@ -604,6 +605,7 @@ Application.run = function(identity, configUrl = '') {
         appEventsForRVM.forEach(appEvent => {
             ofEvents.removeListener(route.application(appEvent, uuid), sendAppsEventsToRVMListener);
         });
+        ofEvents.removeListener(route.application('started', uuid), appStartedHandler);
 
         coreState.removeApp(app.id);
 

--- a/src/browser/api_protocol/api_handlers/authorization.js
+++ b/src/browser/api_protocol/api_handlers/authorization.js
@@ -123,8 +123,14 @@ function AuthorizationApiHandler() {
             socketServer.connectionAuthenticated(id, uuid);
 
             rvmMessageBus.registerLicenseInfo({
-                licenseKey: externalConnObj.licenseKey,
-                client: externalConnObj.client
+                data: {
+                    licenseKey: externalConnObj.licenseKey,
+                    client: externalConnObj.client,
+                    uuid,
+                    parentApp: {
+                        uuid: null
+                    }
+                }
             });
 
             if (!success) {

--- a/src/browser/core_state.js
+++ b/src/browser/core_state.js
@@ -517,9 +517,14 @@ function getAppAncestor(descendantAppUuid) {
 function setLicenseKey(identity, licenseKey) {
     const { uuid } = identity;
     const app = getAppByUuid(uuid);
+    const externalConnection = ExternalApplication.getExternalConnectionByUuid(uuid);
 
     if (app) {
         app.licenseKey = licenseKey;
+
+        return licenseKey;
+    } else if (externalConnection) {
+        externalConnection.licenseKey = licenseKey;
 
         return licenseKey;
     } else {
@@ -530,9 +535,12 @@ function setLicenseKey(identity, licenseKey) {
 function getLicenseKey(identity) {
     const { uuid } = identity;
     const app = getAppByUuid(uuid);
+    const externalConnection = ExternalApplication.getExternalConnectionByUuid(uuid);
 
     if (app) {
         return app.licenseKey;
+    } else if (externalConnection) {
+        return externalConnection.licenseKey;
     } else {
         return null;
     }

--- a/test/electron.ts
+++ b/test/electron.ts
@@ -1,0 +1,29 @@
+/*
+Copyright 2017 OpenFin Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+export let lastVlogValue = '';
+export let lastLogValue = '';
+
+export const mockElectron = {
+    app: {
+        generateGUID: () => 'some unique value',
+        vlog: (level: number, val: string) => {
+            lastVlogValue = val;
+        },
+        log: (level: string, val: string) => {
+            lastLogValue = val;
+        }
+    }
+};

--- a/test/log.test.ts
+++ b/test/log.test.ts
@@ -16,18 +16,7 @@ limitations under the License.
 import * as assert from 'assert';
 import * as mockery from 'mockery';
 
-let lastVlogValue = '';
-let lastLogValue = '';
-const mockElectron = {
-    app: {
-        vlog: (level: number, val: string) => {
-            lastVlogValue = val;
-        },
-        log: (level: string, val: string) => {
-            lastLogValue = val;
-        }
-    }
-};
+import {mockElectron, lastLogValue, lastVlogValue} from './electron';
 
 mockery.registerMock('electron', mockElectron);
 mockery.enable();


### PR DESCRIPTION
@StevenEBarbaro @HarsimranSingh @rdepena @whyn07m3 

So why the funny `{data: {...}}` shape on the register license call? Testing. It makes it easier to override the dynamic values in a mock situation. 

[tests well](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59442a020f8f4a3476957134)