### PR TITLE
RUN-3030: Abstract out some repetitive route and emit call patterns

### DIFF
--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -458,6 +458,7 @@ Application.run = function(identity, configUrl = '') {
     const mainWindowOpts = _.clone(app._options);
     const hideSplashTopic = route.application('hide-splashscreen', uuid);
     const eventListenerStrings = [];
+    const emitToApp = type => ofEvents.emit(route.application(type, uuid), { topic: 'application', type, uuid });
     const hideSplashListener = () => {
         let rvmPayload = {
             topic: 'application',
@@ -568,7 +569,7 @@ Application.run = function(identity, configUrl = '') {
             app._processInfo.getCpuUsage();
         }
 
-        ofEvents.emit(route.application('connected', uuid), { topic: 'application', type: 'connected', uuid });
+        emitToApp('connected');
     });
 
     // turn on plugins for the main window
@@ -591,7 +592,7 @@ Application.run = function(identity, configUrl = '') {
         delete fetchingIcon[uuid];
         removeTrayIcon(app);
 
-        ofEvents.emit(route.application('closed', uuid), { topic: 'application', type: 'closed', uuid });
+        emitToApp('closed');
 
         eventListenerStrings.forEach(eventString => {
             app.mainWindow.removeAllListeners(eventString);
@@ -641,21 +642,21 @@ Application.run = function(identity, configUrl = '') {
     });
 
     app.mainWindow.webContents.on('crashed', () => {
-        ofEvents.emit(route.application('crashed', uuid), { topic: 'application', type: 'crashed', uuid });
-        ofEvents.emit(route.application('out-of-memory', uuid), { topic: 'application', type: 'out-of-memory', uuid });
+        emitToApp('crashed');
+        emitToApp('out-of-memory');
     });
 
     app.mainWindow.on('responsive', () => {
-        ofEvents.emit(route.application('responding', uuid), { topic: 'application', type: 'responding', uuid });
+        emitToApp('responding');
     });
 
     app.mainWindow.on('unresponsive', () => {
-        ofEvents.emit(route.application('not-responding', uuid), { topic: 'application', type: 'not-responding', uuid });
+        emitToApp('not-responding');
     });
 
     coreState.setAppRunningState(uuid, true);
 
-    ofEvents.emit(route.application('started', uuid), { topic: 'application', type: 'started', uuid });
+    emitToApp('started');
 };
 
 /**

--- a/src/browser/api_protocol/api_handlers/application.js
+++ b/src/browser/api_protocol/api_handlers/application.js
@@ -349,7 +349,7 @@ function ApplicationApiHandler() {
     function externalWindowAction(identity, message, ack) {
         /* jshint bitwise: false */
         let payload = message.payload;
-        const { uuid, name } = payload;
+        const emitToExtWin = (type, data) => ofEvents.emit(route.externalWindow(type, payload.uuid, payload.name), data);
 
         const SWP_HIDEWINDOW = 128;
         const SWP_SHOWWINDOW = 64;
@@ -360,27 +360,27 @@ function ApplicationApiHandler() {
         switch (payload.type) {
             case 2:
                 // WM_DESTROY
-                ofEvents.emit(route.externalWindow('close', uuid, name));
+                emitToExtWin('close');
                 break;
             case 7:
                 // WM_SETFOCUS
-                ofEvents.emit(route.externalWindow('focus', uuid, name));
+                emitToExtWin('focus');
                 break;
             case 8:
                 // WM__KILLFOCUS
-                ofEvents.emit(route.externalWindow('blur', uuid, name));
+                emitToExtWin('blur');
                 break;
             case 71:
                 // WM_WINDOWPOSCHANGED
                 let flags = payload.flags;
 
-                ofEvents.emit(route.externalWindow('bounds-changed', uuid, name));
+                emitToExtWin('bounds-changed');
 
                 // dispatch show and hide events
                 if (flags & SWP_SHOWWINDOW) {
-                    ofEvents.emit(route.externalWindow('visibility-changed', uuid, name), true);
+                    emitToExtWin('visibility-changed', true);
                 } else if (flags & SWP_HIDEWINDOW) {
-                    ofEvents.emit(route.externalWindow('visibility-changed', uuid, name), false);
+                    emitToExtWin('visibility-changed', false);
                 }
                 break;
             case 274:
@@ -394,26 +394,26 @@ function ApplicationApiHandler() {
                 /* falls through */
             case 163:
                 // WM_NCLBUTTONDBLCLK
-                ofEvents.emit(route.externalWindow('state-change', uuid, name));
+                emitToExtWin('state-change');
                 break;
             case 532:
                 // WM_SIZING
-                ofEvents.emit(route.externalWindow('sizing', uuid, name));
+                emitToExtWin('sizing');
                 break;
             case 534:
                 // WM_MOVING
-                ofEvents.emit(route.externalWindow('moving', uuid, name));
+                emitToExtWin('moving');
                 break;
             case 561:
                 // WM_ENTERSIZEMOVE
-                ofEvents.emit(route.externalWindow('end-user-bounds-change', {
+                emitToExtWin('begin-user-bounds-change', {
                     x: payload.mouseX,
                     y: payload.mouseY
-                }));
+                });
                 break;
             case 562:
                 // WM_EXITSIZEMOVE
-                ofEvents.emit(route.externalWindow('end-user-bounds-change', uuid, name));
+                emitToExtWin('end-user-bounds-change');
                 break;
             default:
                 // Do nothing

--- a/src/browser/external_window_event_adapter.js
+++ b/src/browser/external_window_event_adapter.js
@@ -28,15 +28,17 @@ class ExternalWindowEventAdapter {
 
         let cachedState = null;
 
-        ofEvents.on(route.externalWindow('focus', uuid, name), () => {
+        const routeExtWin = type => route.externalWindow(type, uuid, name);
+
+        ofEvents.on(routeExtWin('focus'), () => {
             browserWindow.emit('focus');
         });
 
-        ofEvents.on(route.externalWindow('blur', uuid, name), () => {
+        ofEvents.on(routeExtWin('blur'), () => {
             browserWindow.emit('blur');
         });
 
-        ofEvents.on(route.externalWindow('state-change', uuid, name), () => {
+        ofEvents.on(routeExtWin('state-change'), () => {
             let prevState = cachedState || 'normal';
 
             let currState = 'normal';
@@ -59,15 +61,15 @@ class ExternalWindowEventAdapter {
             }
         });
 
-        ofEvents.on(route.externalWindow('bounds-changed', uuid, name), () => {
+        ofEvents.on(routeExtWin('bounds-changed'), () => {
             browserWindow.emit('bounds-changed');
         });
 
-        ofEvents.on(route.externalWindow('visibility-changed', uuid, name), (visibility) => {
+        ofEvents.on(routeExtWin('visibility-changed'), (visibility) => {
             browserWindow.emit('visibility-changed', {}, visibility);
         });
 
-        ofEvents.on(route.externalWindow('begin-user-bounds-change', uuid, name), (coordinates) => {
+        ofEvents.on(routeExtWin('begin-user-bounds-change'), (coordinates) => {
             if (!disabledFrameState.leftButtonDown && !browserWindow.isUserMovementEnabled()) {
                 // left mouse button is now in the down position
                 disabledFrameState.leftButtonDown = true;
@@ -84,7 +86,7 @@ class ExternalWindowEventAdapter {
             browserWindow.emit('begin-user-bounds-change');
         });
 
-        ofEvents.on(route.externalWindow('end-user-bounds-change', uuid, name), () => {
+        ofEvents.on(routeExtWin('end-user-bounds-change'), () => {
             if (disabledFrameState.leftButtonDown) {
                 if (disabledFrameState.changeType !== -1) {
                     browserWindow.emit('disabled-frame-bounds-changed', {}, browserWindow.getBounds(), disabledFrameState.changeType);
@@ -97,7 +99,7 @@ class ExternalWindowEventAdapter {
             browserWindow.emit('end-user-bounds-change');
         });
 
-        ofEvents.on(route.externalWindow('sizing', uuid, name), (bounds) => {
+        ofEvents.on(routeExtWin('sizing'), (bounds) => {
             if (disabledFrameState.leftButtonDown) {
                 // check if the position has also changed by checking whether the origins match up
                 if (disabledFrameState.changeType !== 2) {
@@ -110,7 +112,7 @@ class ExternalWindowEventAdapter {
             }
         });
 
-        ofEvents.on(route.externalWindow('moving', uuid, name), () => {
+        ofEvents.on(routeExtWin('moving'), () => {
             if (disabledFrameState.leftButtonDown) {
                 let bounds = browserWindow.getBounds();
                 let mousePosition = MonitorInfo.getMousePosition();
@@ -138,7 +140,7 @@ class ExternalWindowEventAdapter {
             }
         });
 
-        ofEvents.on(route.externalWindow('close', uuid, name), () => {
+        ofEvents.on(routeExtWin('close'), () => {
             browserWindow.emit('close');
             browserWindow.close();
             browserWindow.emit('closed');


### PR DESCRIPTION
Added some local abstractions:
* `routeWin`
* `routeExtWin`
* `emitToApp`
* `emitToExtWin`

**Feedback please your comfort level with merging these now _vs._ living with new `route` functions a bit longer before we add these additional layers of abstraction.** We could easily postpone merge to a future sprint.

When inventing these, please keep to the above naming conventions, _i.e.,_ begin with either `route` or `emitTo`. This will make routes easier to search for globally using the regex I recommended in #37.