### PR TITLE
 RUN-2989 bad port discovery message / no error dialogs 

### DIFF
--- a/index.js
+++ b/index.js
@@ -313,6 +313,7 @@ app.on('ready', function() {
             });
         }
     });
+
     rvmBus.on(route.rvmMessageBus('broadcast', 'download-asset', 'complete'), payload => {
         if (payload) {
             ofEvents.emit(route.system(`asset-download-complete-${payload.downloadId}`), {
@@ -490,7 +491,7 @@ function launchApp(argo, startExternalAdapterServer) {
         if (openfinWinOpts && !isRunning) {
             //making sure that if a window is pressent we set the window name === to the uuid as per 5.0
             openfinWinOpts.name = uuid;
-            initFirstApp(openfinWinOpts, configUrl, licenseKey);
+            initFirstApp(configObject, configUrl, licenseKey);
         } else if (uuid) {
             Application.run({
                 uuid,
@@ -519,8 +520,12 @@ function launchApp(argo, startExternalAdapterServer) {
 }
 
 
-function initFirstApp(options, configUrl, licenseKey) {
+function initFirstApp(configObject, configUrl, licenseKey) {
+    let options;
+
     try {
+        options = convertOptions.getWindowOptions(configObject);
+
         // Needs proper configs
         firstApp = Application.create(options, configUrl);
 
@@ -530,10 +535,12 @@ function initFirstApp(options, configUrl, licenseKey) {
             uuid: firstApp.uuid
         });
 
-        // Emitted when the window is closed.
         firstApp.mainWindow.on('closed', function() {
             firstApp = null;
         });
+
+        socketServer.start(configObject['websocket_port'] || 9696);
+
     } catch (error) {
         log.writeToLog(1, error, true);
 

--- a/index.js
+++ b/index.js
@@ -505,15 +505,14 @@ function launchApp(argo, startExternalAdapterServer) {
             configObject: { licenseKey }
         } = configuration;
 
-        const openfinWinOpts = convertOptions.getWindowOptions(configObject);
-        const startUpApp = configObject.startup_app; /* jshint ignore:line */
-        const uuid = startUpApp && startUpApp.uuid;
+        const startupAppOptions = convertOptions.getStartupAppOptions(configObject);
+        const uuid = startupAppOptions && startupAppOptions.uuid;
         const ofApp = Application.wrap(uuid);
         const isRunning = Application.isRunning(ofApp);
 
-        if (openfinWinOpts && !isRunning) {
-            //making sure that if a window is pressent we set the window name === to the uuid as per 5.0
-            openfinWinOpts.name = uuid;
+        if (startupAppOptions && !isRunning) {
+            //making sure that if a window is present we set the window name === to the uuid as per 5.0
+            startupAppOptions.name = uuid;
             initFirstApp(configObject, configUrl, licenseKey);
         } else if (uuid) {
             Application.run({
@@ -544,15 +543,15 @@ function launchApp(argo, startExternalAdapterServer) {
 
 
 function initFirstApp(configObject, configUrl, licenseKey) {
-    let options;
+    let startupAppOptions;
 
     try {
-        options = convertOptions.getWindowOptions(configObject);
+        startupAppOptions = convertOptions.getStartupAppOptions(configObject);
 
         // Needs proper configs
-        firstApp = Application.create(options, configUrl);
+        firstApp = Application.create(startupAppOptions, configUrl);
 
-        coreState.setLicenseKey({ uuid: options.uuid }, licenseKey);
+        coreState.setLicenseKey({ uuid: startupAppOptions.uuid }, licenseKey);
 
         Application.run({
             uuid: firstApp.uuid
@@ -577,7 +576,7 @@ function initFirstApp(configObject, configUrl, licenseKey) {
 
         if (!coreState.argo['noerrdialogs']) {
             const srcMsg = error ? error.message : '';
-            const errorMessage = options.loadErrorMessage || `There was an error loading the application: ${ srcMsg }`;
+            const errorMessage = startupAppOptions.loadErrorMessage || `There was an error loading the application: ${ srcMsg }`;
 
             dialog.showErrorBox('Fatal Error', errorMessage);
         }

--- a/index.js
+++ b/index.js
@@ -511,7 +511,7 @@ function launchApp(argo, startExternalAdapterServer) {
     }, error => {
         log.writeToLog(1, error, true);
 
-        if (!coreState.argo['noerrdialog']) {
+        if (!coreState.argo['noerrdialogs']) {
             dialog.showErrorBox('Fatal Error', `${error}`);
         }
 
@@ -552,7 +552,7 @@ function initFirstApp(configObject, configUrl, licenseKey) {
             });
         }
 
-        if (!coreState.argo['noerrdialog']) {
+        if (!coreState.argo['noerrdialogs']) {
             const srcMsg = error ? error.message : '';
             const errorMessage = options.loadErrorMessage || `There was an error loading the application: ${ srcMsg }`;
 

--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -1009,7 +1009,7 @@ function createAppObj(uuid, opts, configUrl = '') {
                     log.writeToLog(1, `receiving net error ${errorCode} for ${opts.uuid}`, true);
                     if (!coreState.argo['noerrdialog'] && configUrl) {
                         // NOTE: don't show this dialog if the app is created via the api
-                        const errorMessage = opts.loadErrorMessage || 'There was an error loading the application: ${ errorDescription }';
+                        const errorMessage = opts.loadErrorMessage || `There was an error loading the application: ${ errorDescription }`;
                         dialog.showErrorBox('Fatal Error', errorMessage);
                     }
                     _.defer(() => {

--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -1007,7 +1007,7 @@ function createAppObj(uuid, opts, configUrl = '') {
                     log.writeToLog(1, `ignoring net error ${errorCode} for ${opts.uuid}`, true);
                 } else {
                     log.writeToLog(1, `receiving net error ${errorCode} for ${opts.uuid}`, true);
-                    if (!coreState.argo['noerrdialog'] && configUrl) {
+                    if (!coreState.argo['noerrdialogs'] && configUrl) {
                         // NOTE: don't show this dialog if the app is created via the api
                         const errorMessage = opts.loadErrorMessage || `There was an error loading the application: ${ errorDescription }`;
                         dialog.showErrorBox('Fatal Error', errorMessage);

--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -194,7 +194,7 @@ function fetchLocalConfig(configUrl, successCallback, errorCallback) {
 
 module.exports = {
 
-    getWindowOptions: function(appJson) {
+    getStartupAppOptions: function(appJson) {
         return appJson['startup_app'];
     },
 


### PR DESCRIPTION
The port discovery message will now only be sent out if the initial app load is successful. A typo in the `noerrdialogs` guard was fixed as well. 

@wenjunche I tested with .NET and Node adapters and it seems to behave, can you check against Java? 
@rdepena You had expressed some concern with moving the message here, can you remind me what it was 😄? 

[tests well](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/594d3a830c10170217365886) all fails pass in isolation