### PR TITLE
RUN-3067 When using the downloadRuntime API from an API created appli…

### DIFF
--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -581,11 +581,8 @@ module.exports.System = {
     },
 
     downloadRuntime: function(identity, options, cb) {
-        const appObject = coreState.getAppObjByUuid(identity.uuid);
-
-        options.sourceUrl = (appObject || {})._configUrl;
+        options.sourceUrl = coreState.getConfigUrlByUuid(identity.uuid);
         rvmBus.downloadRuntime(options, cb);
-
     },
     getAllExternalApplications: function() {
         return ExternalApplication.getAllExternalConnctions().map(eApp => {

--- a/src/browser/core_state.js
+++ b/src/browser/core_state.js
@@ -188,8 +188,8 @@ function getUuidBySourceUrl(sourceUrl) {
 
 function getConfigUrlByUuid(uuid) {
     let app = appByUuid(uuid);
-    while (app && app.appObj && app.appObj.parentUuid) {
-        app = appByUuid(app.appObj.parentUuid);
+    while (app && app.appObj && app.parentUuid) {
+        app = appByUuid(app.parentUuid);
     }
     return app && app._configUrl;
 }


### PR DESCRIPTION
…cation you would get an RVM Error.

* Had to fix coreState.getConfigUrlByUuid as it was failing to find the parent's config url.
* Changed the downloadRuntime API to use the getConfigUrlByUuid function for sourceUrl
* Pending test run

@StevenEBarbaro @HarsimranSingh @wenjunche @datamadic @whyn07m3 @joneit please check it out.