### PR TITLE
RUN-3074 exposes Application and Window API maps

### DIFF
--- a/src/browser/api_protocol/api_handlers/window.js
+++ b/src/browser/api_protocol/api_handlers/window.js
@@ -13,570 +13,568 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+
 const apiProtocolBase = require('./api_protocol_base');
 const Window = require('../../api/window').Window;
 const Application = require('../../api/application').Application;
 const _ = require('underscore');
 const log = require('../../log');
 
-function WindowApiHandler() {
-    let successAck = {
-        success: true
+let successAck = {
+    success: true
+};
+
+module.exports.windowApiMap = {
+    'animate-window': animateWindow,
+    'blur-window': blurWindow,
+    'bring-window-to-front': bringWindowToFront,
+    'close-window': closeWindow,
+    'disable-window-frame': disableWindowFrame,
+    'dock-window': dockWindow,
+    'enable-window-frame': enableWindowFrame,
+    'execute-javascript-in-window': { apiFunc: executeJavascript, apiPath: '.executeJavaScript' },
+    'flash-window': flashWindow,
+    'focus-window': focusWindow,
+    'get-current-window-options': getCurrentWindowOptions,
+    'get-window-bounds': getWindowBounds,
+    'get-window-group': getWindowGroup,
+    'get-window-info': getWindowInfo,
+    'get-window-native-id': { apiFunc: getWindowNativeId, apiPath: '.getNativeId' },
+    'get-window-options': getWindowOptions,
+    'get-window-preload-script': getWindowPreloadScript,
+    'get-window-snapshot': { apiFunc: getWindowSnapshot, apiPath: '.getSnapshot' },
+    'get-window-state': getWindowState,
+    'get-zoom-level': getZoomLevel,
+    'hide-window': hideWindow,
+    'is-window-showing': isWindowShowing,
+    'join-window-group': joinWindowGroup,
+    'leave-window-group': leaveWindowGroup,
+    'maximize-window': maximizeWindow,
+    'merge-window-groups': mergeWindowGroups,
+    'minimize-window': minimizeWindow,
+    'move-window': moveWindow,
+    'move-window-by': moveWindowBy,
+    'navigate-window': navigateWindow,
+    'navigate-window-back': navigateWindowBack,
+    'navigate-window-forward': navigateWindowForward,
+    'stop-window-navigation': stopWindowNavigation,
+    'reload-window': reloadWindow,
+    'on-window-unload': onWindowUnload, // Fires as window unloads its content and resources; reloading a window or navigating away will fire this event
+    'redirect-window-to-url': redirectWindowToUrl, // Deprecated
+    'resize-window': resizeWindow,
+    'resize-window-by': resizeWindowBy,
+    'restore-window': restoreWindow,
+    'show-menu': showMenu,
+    'show-window': showWindow,
+    'set-foreground-window': setForegroundWindow,
+    'set-window-bounds': setWindowBounds,
+    'set-zoom-level': setZoomLevel,
+    'show-at-window': showAtWindow,
+    'stop-flash-window': stopFlashWindow,
+    'undock-window': undockWindow,
+    'update-window-options': updateWindowOptions,
+    'window-embedded': windowEmbedded,
+    'window-exists': windowExists,
+    'window-get-cached-bounds': getCachedBounds,
+    'window-authenticate': windowAuthenticate
+};
+
+module.exports.init = function() {
+    apiProtocolBase.registerActionMap(module.exports.windowApiMap, 'Window');
+};
+
+function getWindowPreloadScript(identity, message, ack, nack) {
+    const payload = message.payload;
+    const windowIdentity = apiProtocolBase.getTargetWindowIdentity(identity);
+
+    Window.getPreloadScript(windowIdentity, payload.preload, (error, preloadScript) => {
+        if (error) {
+            nack(error);
+        } else {
+            const dataAck = _.clone(successAck);
+            dataAck.data = preloadScript;
+            ack(dataAck);
+        }
+    });
+}
+
+function windowAuthenticate(identity, message, ack, nack) {
+    let {
+        userName,
+        password,
+        uuid,
+        name
+    } = message.payload;
+
+    let windowIdentity = {
+        uuid,
+        name
     };
 
-    let windowExternalApiMap = {
-        'animate-window': animateWindow,
-        'blur-window': blurWindow,
-        'bring-window-to-front': bringWindowToFront,
-        'close-window': closeWindow,
-        'disable-window-frame': disableWindowFrame,
-        'dock-window': dockWindow,
-        'enable-window-frame': enableWindowFrame,
-        'execute-javascript-in-window': { apiFunc: executeJavascript, apiPath: '.executeJavaScript' },
-        'flash-window': flashWindow,
-        'focus-window': focusWindow,
-        'get-current-window-options': getCurrentWindowOptions,
-        'get-window-bounds': getWindowBounds,
-        'get-window-group': getWindowGroup,
-        'get-window-info': getWindowInfo,
-        'get-window-native-id': { apiFunc: getWindowNativeId, apiPath: '.getNativeId' },
-        'get-window-options': getWindowOptions,
-        'get-window-preload-script': getWindowPreloadScript,
-        'get-window-snapshot': { apiFunc: getWindowSnapshot, apiPath: '.getSnapshot' },
-        'get-window-state': getWindowState,
-        'get-zoom-level': getZoomLevel,
-        'hide-window': hideWindow,
-        'is-window-showing': isWindowShowing,
-        'join-window-group': joinWindowGroup,
-        'leave-window-group': leaveWindowGroup,
-        'maximize-window': maximizeWindow,
-        'merge-window-groups': mergeWindowGroups,
-        'minimize-window': minimizeWindow,
-        'move-window': moveWindow,
-        'move-window-by': moveWindowBy,
-        'navigate-window': navigateWindow,
-        'navigate-window-back': navigateWindowBack,
-        'navigate-window-forward': navigateWindowForward,
-        'stop-window-navigation': stopWindowNavigation,
-        'reload-window': reloadWindow,
-        'on-window-unload': onWindowUnload, // Fires as window unloads its content and resources; reloading a window or navigating away will fire this event
-        'redirect-window-to-url': redirectWindowToUrl, // Deprecated
-        'resize-window': resizeWindow,
-        'resize-window-by': resizeWindowBy,
-        'restore-window': restoreWindow,
-        'show-menu': showMenu,
-        'show-window': showWindow,
-        'set-foreground-window': setForegroundWindow,
-        'set-window-bounds': setWindowBounds,
-        'set-zoom-level': setZoomLevel,
-        'show-at-window': showAtWindow,
-        'stop-flash-window': stopFlashWindow,
-        'undock-window': undockWindow,
-        'update-window-options': updateWindowOptions,
-        'window-embedded': windowEmbedded,
-        'window-exists': windowExists,
-        'window-get-cached-bounds': getCachedBounds,
-        'window-authenticate': windowAuthenticate
-    };
-    apiProtocolBase.registerActionMap(windowExternalApiMap, 'Window');
+    Window.authenticate(windowIdentity, userName, password, err => {
+        if (!err) {
+            ack(successAck);
+        } else {
+            nack(err);
+        }
+    });
 
-    function getWindowPreloadScript(identity, message, ack, nack) {
-        const payload = message.payload;
-        const windowIdentity = apiProtocolBase.getTargetWindowIdentity(identity);
+}
 
-        Window.getPreloadScript(windowIdentity, payload.preload, (error, preloadScript) => {
-            if (error) {
-                nack(error);
-            } else {
-                const dataAck = _.clone(successAck);
-                dataAck.data = preloadScript;
-                ack(dataAck);
-            }
-        });
-    }
-
-    function windowAuthenticate(identity, message, ack, nack) {
-        let {
-            userName,
-            password,
-            uuid,
-            name
-        } = message.payload;
-
-        let windowIdentity = {
-            uuid,
-            name
+function redirectWindowToUrl(identity, message, ack) {
+    var payload = message.payload,
+        windowIdentity = {
+            uuid: payload.targetUuid,
+            name: payload.targetName
         };
 
-        Window.authenticate(windowIdentity, userName, password, err => {
-            if (!err) {
-                ack(successAck);
-            } else {
-                nack(err);
-            }
-        });
-
-    }
-
-    function redirectWindowToUrl(identity, message, ack) {
-        var payload = message.payload,
-            windowIdentity = {
-                uuid: payload.targetUuid,
-                name: payload.targetName
-            };
-
-        Window.navigate(windowIdentity, payload.url);
-        ack(successAck);
-    }
-
-    function updateWindowOptions(identity, rawMessage, ack) {
-        let message = JSON.parse(JSON.stringify(rawMessage));
-        let payload = message.payload;
-        let windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-
-        Window.updateOptions(windowIdentity, payload.options);
-        ack(successAck);
-    }
-
-    function stopFlashWindow(identity, message, ack) {
-        var payload = message.payload,
-            windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-
-        Window.stopFlashing(windowIdentity);
-        ack(successAck);
-    }
-
-    function setWindowBounds(identity, message, ack) {
-        var payload = message.payload,
-            windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-
-        Window.setBounds(windowIdentity, payload.left, payload.top, payload.width, payload.height);
-        ack(successAck);
-    }
-
-    function setForegroundWindow(identity, message, ack) {
-        var payload = message.payload,
-            windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-
-        Window.setAsForeground(windowIdentity);
-        ack(successAck);
-    }
-
-    function showAtWindow(identity, message, ack) {
-        let payload = message.payload;
-        let windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-        let force = !!payload.force;
-
-        Window.showAt(windowIdentity, payload.left, payload.top, force);
-        ack(successAck);
-    }
-
-    function showMenu(identity, message, ack) {
-        var payload = message.payload;
-        var windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-
-        Window.showMenu(windowIdentity, payload.x, payload.y, payload.editable, payload.hasSelectedText);
-        ack(successAck);
-    }
-
-    function showWindow(identity, message, ack) {
-        let payload = message.payload;
-        let windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-        let force = !!payload.force;
-
-        Window.show(windowIdentity, force);
-        ack(successAck);
-    }
-
-    function restoreWindow(identity, message, ack) {
-        var payload = message.payload,
-            windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-
-        Window.restore(windowIdentity);
-        ack(successAck);
-    }
-
-    function resizeWindow(identity, message, ack) {
-        var payload = message.payload,
-            windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-
-        Window.resizeTo(windowIdentity, payload.width, payload.height, payload.anchor);
-        ack(successAck);
-    }
-
-    function resizeWindowBy(identity, message, ack) {
-        var payload = message.payload,
-            windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-
-        Window.resizeBy(windowIdentity, payload.deltaWidth, payload.deltaHeight, payload.anchor);
-        ack(successAck);
-    }
-
-    function undockWindow(identity, message, ack) {
-        //TODO:Figure out what this is suposed to do.
-        ack(successAck);
-    }
-
-    function moveWindow(identity, message, ack) {
-        var payload = message.payload,
-            windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-
-        Window.moveTo(windowIdentity, payload.left, payload.top);
-        ack(successAck);
-    }
-
-    function moveWindowBy(identity, message, ack) {
-        var payload = message.payload,
-            windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-
-        Window.moveBy(windowIdentity, payload.deltaLeft, payload.deltaTop);
-        ack(successAck);
-    }
-
-    function navigateWindow(identity, message, ack) {
-        let payload = message.payload;
-        let windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-        let url = payload.url;
-
-        Window.navigate(windowIdentity, url);
-        ack(successAck);
-    }
-
-    function navigateWindowBack(identity, message, ack) {
-        let payload = message.payload;
-        let windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-
-        Window.navigateBack(windowIdentity);
-        ack(successAck);
-    }
-
-    function navigateWindowForward(identity, message, ack) {
-        let payload = message.payload;
-        let windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-
-        Window.navigateForward(windowIdentity);
-        ack(successAck);
-    }
-
-    function stopWindowNavigation(identity, message, ack) {
-        let payload = message.payload;
-        let windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-
-        Window.stopNavigation(windowIdentity);
-        ack(successAck);
-    }
-
-    function reloadWindow(identity, message, ack) {
-        let payload = message.payload;
-        let windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-        let ignoreCache = !!payload.ignoreCache;
-
-        Window.reload(windowIdentity, ignoreCache);
-        ack(successAck);
-    }
-
-    function minimizeWindow(identity, message, ack) {
-        var payload = message.payload,
-            windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-
-        Window.minimize(windowIdentity);
-        ack(successAck);
-    }
-
-    function mergeWindowGroups(identity, message, ack) {
-        var payload = message.payload,
-            windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload),
-            groupingIdentity = apiProtocolBase.getGroupingWindowIdentity(payload);
-
-        Window.mergeGroups(windowIdentity, groupingIdentity);
-        ack(successAck);
-    }
-
-    function maximizeWindow(identity, message, ack) {
-        var payload = message.payload,
-            windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-
-        Window.maximize(windowIdentity);
-        ack(successAck);
-    }
-
-    function leaveWindowGroup(identity, message, ack) {
-        var payload = message.payload,
-            windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-
-        Window.leaveGroup(windowIdentity);
-        ack(successAck);
-    }
-
-    function joinWindowGroup(identity, message, ack) {
-        var payload = message.payload,
-            windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload),
-            groupingIdentity = apiProtocolBase.getGroupingWindowIdentity(payload);
-
-        Window.joinGroup(windowIdentity, groupingIdentity);
-        ack(successAck);
-    }
-
-    function isWindowShowing(identity, message, ack) {
-        var payload = message.payload,
-            dataAck = _.clone(successAck),
-            windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-
-        dataAck.data = Window.isShowing(windowIdentity);
-        ack(dataAck);
-    }
-
-    function hideWindow(identity, message, ack) {
-        var payload = message.payload,
-            windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-
-        Window.hide(windowIdentity);
-        ack(successAck);
-    }
-
-    function getWindowSnapshot(identity, message, ack) {
-        var payload = message.payload,
-            windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-
-        Window.getSnapshot(windowIdentity, (err, result) => {
-            if (err) {
-                throw err;
-            } else {
-                let dataAck = _.clone(successAck);
-                dataAck.data = result;
-                ack(dataAck);
-            }
-        });
-    }
-
-    function getWindowState(identity, message, ack) {
-        var payload = message.payload,
-            dataAck = _.clone(successAck),
-            windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-
-        dataAck.data = Window.getState(windowIdentity);
-        ack(dataAck);
-    }
-
-    function getWindowOptions(identity, message, ack) {
-        var payload = message.payload,
-            dataAck = _.clone(successAck),
-            windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-
-        dataAck.data = Window.getOptions(windowIdentity);
-        ack(dataAck);
-    }
-
-    function getCurrentWindowOptions(identity, message, ack) {
-        let dataAck = _.clone(successAck);
-
-        dataAck.data = Window.getOptions(identity);
-        ack(dataAck);
-    }
-
-    function getWindowInfo(identity, message, ack) {
-        var payload = message.payload,
-            dataAck = _.clone(successAck),
-            windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-
-        dataAck.data = Window.getWindowInfo(windowIdentity);
-        ack(dataAck);
-    }
-
-    function getWindowNativeId(identity, message, ack) {
-        var payload = message.payload,
-            dataAck = _.clone(successAck),
-            windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-
-        dataAck.data = Window.getNativeId(windowIdentity);
-        ack(dataAck);
-    }
-
-    function getWindowGroup(identity, message, ack) {
-        var payload = message.payload,
-            dataAck = _.clone(successAck),
-            windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-
-        // NOTE: the Window API returns a wrapped window with 'name' as a member,
-        // while the adaptor expects it to be 'windowName'
-        dataAck.data = _.map(Window.getGroup(windowIdentity), (window) => {
-            if (payload.crossApp === true) {
-                var clone = _.clone(window);
-                clone.windowName = window.name;
-                return clone;
-            } else {
-                return window.name; // backwards compatible
-            }
-        });
-        ack(dataAck);
-    }
-
-    function getWindowBounds(identity, message, ack) {
-        var payload = message.payload,
-            dataAck = _.clone(successAck),
-            windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-
-        dataAck.data = Window.getBounds(windowIdentity);
-        ack(dataAck);
-    }
-
-    function focusWindow(identity, message, ack) {
-        var payload = message.payload,
-            windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-
-        Window.focus(windowIdentity);
-        ack(successAck);
-    }
-
-    function flashWindow(identity, message, ack) {
-        var payload = message.payload,
-            windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-
-        Window.flash(windowIdentity);
-        ack(successAck);
-    }
-
-    function enableWindowFrame(identity, message, ack) {
-        var payload = message.payload,
-            windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-
-        Window.enableFrame(windowIdentity);
-        ack(successAck);
-    }
-
-    function executeJavascript(identity, message, ack, nack) {
-        let payload = message.payload;
-        let windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-        let pUuid = windowIdentity.uuid;
-
-        while (pUuid) {
-            if (pUuid === identity.uuid) {
-                return Window.executeJavascript(windowIdentity, payload.code, (err, result) => {
-                    if (err) {
-                        nack(err);
-                    } else {
-                        let dataAck = _.clone(successAck);
-                        dataAck.data = result;
-                        ack(dataAck);
-                    }
-                });
-            }
-            pUuid = Application.getParentApplication({
-                uuid: pUuid
-            });
-
-        }
-        return nack(new Error('Rejected, target window is not owned by requesting identity'));
-    }
-
-    function disableWindowFrame(identity, message, ack) {
-        var payload = message.payload,
-            windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-
-        Window.disableFrame(windowIdentity);
-        ack(successAck);
-    }
-
-    function windowEmbedded(identity, message, ack) {
-        let payload = message.payload;
-        // Ensure expected shape for identity utility compliance
-        payload.uuid = payload.targetUuid;
-
-        let windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-        Window.embed(windowIdentity, `0x${payload.parentHwnd}`);
-        ack(successAck);
-    }
-
-    function closeWindow(identity, message, ack) {
-        let payload = message.payload;
-        let windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-        let force = !!payload.force;
-
-        Window.close(windowIdentity, force, () => {
-            ack(successAck);
-        });
-    }
-
-    function bringWindowToFront(identity, message, ack) {
-        var payload = message.payload,
-            windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-
-        Window.bringToFront(windowIdentity);
-        ack(successAck);
-    }
-
-    function blurWindow(identity, message, ack) {
-        var payload = message.payload,
-            windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-
-        Window.blur(windowIdentity);
-        ack(successAck);
-    }
-
-    function animateWindow(identity, message, ack) {
-        let windowIdentity = apiProtocolBase.getTargetWindowIdentity(message.payload);
-        let transitions = message.payload.transitions;
-        let options = message.payload.options;
-
-        Window.animate(windowIdentity, transitions, options, () => {
-            ack(successAck);
-        });
-    }
-
-    function dockWindow(identity, message, ack) {
-        //Pending runtime.
-        ack(successAck);
-    }
-
-    function windowExists(identity, message, ack) {
-        let windowIdentity = apiProtocolBase.getTargetWindowIdentity(message.payload);
-        let dataAck = _.clone(successAck);
-
-        dataAck.data = Window.exists(windowIdentity);
-        ack(dataAck);
-    }
-
-    function getCachedBounds(identity, message, ack, nack) {
-        let payload = message.payload;
-        let windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-        let dataAck = _.clone(successAck);
-
-        Window.getBoundsFromDisk(windowIdentity, data => {
-            dataAck.data = data;
-            ack(dataAck);
-        }, nack);
-    }
-
-    function getZoomLevel(identity, message, ack) {
-        let payload = message.payload;
-        let windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-
-        Window.getZoomLevel(windowIdentity, result => {
+    Window.navigate(windowIdentity, payload.url);
+    ack(successAck);
+}
+
+function updateWindowOptions(identity, rawMessage, ack) {
+    let message = JSON.parse(JSON.stringify(rawMessage));
+    let payload = message.payload;
+    let windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+
+    Window.updateOptions(windowIdentity, payload.options);
+    ack(successAck);
+}
+
+function stopFlashWindow(identity, message, ack) {
+    var payload = message.payload,
+        windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+
+    Window.stopFlashing(windowIdentity);
+    ack(successAck);
+}
+
+function setWindowBounds(identity, message, ack) {
+    var payload = message.payload,
+        windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+
+    Window.setBounds(windowIdentity, payload.left, payload.top, payload.width, payload.height);
+    ack(successAck);
+}
+
+function setForegroundWindow(identity, message, ack) {
+    var payload = message.payload,
+        windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+
+    Window.setAsForeground(windowIdentity);
+    ack(successAck);
+}
+
+function showAtWindow(identity, message, ack) {
+    let payload = message.payload;
+    let windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+    let force = !!payload.force;
+
+    Window.showAt(windowIdentity, payload.left, payload.top, force);
+    ack(successAck);
+}
+
+function showMenu(identity, message, ack) {
+    var payload = message.payload;
+    var windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+
+    Window.showMenu(windowIdentity, payload.x, payload.y, payload.editable, payload.hasSelectedText);
+    ack(successAck);
+}
+
+function showWindow(identity, message, ack) {
+    let payload = message.payload;
+    let windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+    let force = !!payload.force;
+
+    Window.show(windowIdentity, force);
+    ack(successAck);
+}
+
+function restoreWindow(identity, message, ack) {
+    var payload = message.payload,
+        windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+
+    Window.restore(windowIdentity);
+    ack(successAck);
+}
+
+function resizeWindow(identity, message, ack) {
+    var payload = message.payload,
+        windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+
+    Window.resizeTo(windowIdentity, payload.width, payload.height, payload.anchor);
+    ack(successAck);
+}
+
+function resizeWindowBy(identity, message, ack) {
+    var payload = message.payload,
+        windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+
+    Window.resizeBy(windowIdentity, payload.deltaWidth, payload.deltaHeight, payload.anchor);
+    ack(successAck);
+}
+
+function undockWindow(identity, message, ack) {
+    //TODO:Figure out what this is suposed to do.
+    ack(successAck);
+}
+
+function moveWindow(identity, message, ack) {
+    var payload = message.payload,
+        windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+
+    Window.moveTo(windowIdentity, payload.left, payload.top);
+    ack(successAck);
+}
+
+function moveWindowBy(identity, message, ack) {
+    var payload = message.payload,
+        windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+
+    Window.moveBy(windowIdentity, payload.deltaLeft, payload.deltaTop);
+    ack(successAck);
+}
+
+function navigateWindow(identity, message, ack) {
+    let payload = message.payload;
+    let windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+    let url = payload.url;
+
+    Window.navigate(windowIdentity, url);
+    ack(successAck);
+}
+
+function navigateWindowBack(identity, message, ack) {
+    let payload = message.payload;
+    let windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+
+    Window.navigateBack(windowIdentity);
+    ack(successAck);
+}
+
+function navigateWindowForward(identity, message, ack) {
+    let payload = message.payload;
+    let windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+
+    Window.navigateForward(windowIdentity);
+    ack(successAck);
+}
+
+function stopWindowNavigation(identity, message, ack) {
+    let payload = message.payload;
+    let windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+
+    Window.stopNavigation(windowIdentity);
+    ack(successAck);
+}
+
+function reloadWindow(identity, message, ack) {
+    let payload = message.payload;
+    let windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+    let ignoreCache = !!payload.ignoreCache;
+
+    Window.reload(windowIdentity, ignoreCache);
+    ack(successAck);
+}
+
+function minimizeWindow(identity, message, ack) {
+    var payload = message.payload,
+        windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+
+    Window.minimize(windowIdentity);
+    ack(successAck);
+}
+
+function mergeWindowGroups(identity, message, ack) {
+    var payload = message.payload,
+        windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload),
+        groupingIdentity = apiProtocolBase.getGroupingWindowIdentity(payload);
+
+    Window.mergeGroups(windowIdentity, groupingIdentity);
+    ack(successAck);
+}
+
+function maximizeWindow(identity, message, ack) {
+    var payload = message.payload,
+        windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+
+    Window.maximize(windowIdentity);
+    ack(successAck);
+}
+
+function leaveWindowGroup(identity, message, ack) {
+    var payload = message.payload,
+        windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+
+    Window.leaveGroup(windowIdentity);
+    ack(successAck);
+}
+
+function joinWindowGroup(identity, message, ack) {
+    var payload = message.payload,
+        windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload),
+        groupingIdentity = apiProtocolBase.getGroupingWindowIdentity(payload);
+
+    Window.joinGroup(windowIdentity, groupingIdentity);
+    ack(successAck);
+}
+
+function isWindowShowing(identity, message, ack) {
+    var payload = message.payload,
+        dataAck = _.clone(successAck),
+        windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+
+    dataAck.data = Window.isShowing(windowIdentity);
+    ack(dataAck);
+}
+
+function hideWindow(identity, message, ack) {
+    var payload = message.payload,
+        windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+
+    Window.hide(windowIdentity);
+    ack(successAck);
+}
+
+function getWindowSnapshot(identity, message, ack) {
+    var payload = message.payload,
+        windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+
+    Window.getSnapshot(windowIdentity, (err, result) => {
+        if (err) {
+            throw err;
+        } else {
             let dataAck = _.clone(successAck);
             dataAck.data = result;
             ack(dataAck);
-        });
-    }
-
-    function setZoomLevel(identity, message, ack) {
-        let payload = message.payload;
-        let windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-        let level = payload.level;
-
-        Window.setZoomLevel(windowIdentity, level);
-        ack(successAck);
-    }
-
-    function onWindowUnload(identity, message, ack) {
-        if (message.isMainRenderFrame === true) {
-            Window.onUnload(identity);
-        } else {
-            log.writeToLog(1, `Ignoring unload for non-main frame ${JSON.stringify(identity)}`, true);
         }
-        ack(successAck);
-    }
-
-    return apiProtocolBase;
+    });
 }
 
-module.exports.WindowApiHandler = WindowApiHandler;
+function getWindowState(identity, message, ack) {
+    var payload = message.payload,
+        dataAck = _.clone(successAck),
+        windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+
+    dataAck.data = Window.getState(windowIdentity);
+    ack(dataAck);
+}
+
+function getWindowOptions(identity, message, ack) {
+    var payload = message.payload,
+        dataAck = _.clone(successAck),
+        windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+
+    dataAck.data = Window.getOptions(windowIdentity);
+    ack(dataAck);
+}
+
+function getCurrentWindowOptions(identity, message, ack) {
+    let dataAck = _.clone(successAck);
+
+    dataAck.data = Window.getOptions(identity);
+    ack(dataAck);
+}
+
+function getWindowInfo(identity, message, ack) {
+    var payload = message.payload,
+        dataAck = _.clone(successAck),
+        windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+
+    dataAck.data = Window.getWindowInfo(windowIdentity);
+    ack(dataAck);
+}
+
+function getWindowNativeId(identity, message, ack) {
+    var payload = message.payload,
+        dataAck = _.clone(successAck),
+        windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+
+    dataAck.data = Window.getNativeId(windowIdentity);
+    ack(dataAck);
+}
+
+function getWindowGroup(identity, message, ack) {
+    var payload = message.payload,
+        dataAck = _.clone(successAck),
+        windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+
+    // NOTE: the Window API returns a wrapped window with 'name' as a member,
+    // while the adaptor expects it to be 'windowName'
+    dataAck.data = _.map(Window.getGroup(windowIdentity), (window) => {
+        if (payload.crossApp === true) {
+            var clone = _.clone(window);
+            clone.windowName = window.name;
+            return clone;
+        } else {
+            return window.name; // backwards compatible
+        }
+    });
+    ack(dataAck);
+}
+
+function getWindowBounds(identity, message, ack) {
+    var payload = message.payload,
+        dataAck = _.clone(successAck),
+        windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+
+    dataAck.data = Window.getBounds(windowIdentity);
+    ack(dataAck);
+}
+
+function focusWindow(identity, message, ack) {
+    var payload = message.payload,
+        windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+
+    Window.focus(windowIdentity);
+    ack(successAck);
+}
+
+function flashWindow(identity, message, ack) {
+    var payload = message.payload,
+        windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+
+    Window.flash(windowIdentity);
+    ack(successAck);
+}
+
+function enableWindowFrame(identity, message, ack) {
+    var payload = message.payload,
+        windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+
+    Window.enableFrame(windowIdentity);
+    ack(successAck);
+}
+
+function executeJavascript(identity, message, ack, nack) {
+    let payload = message.payload;
+    let windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+    let pUuid = windowIdentity.uuid;
+
+    while (pUuid) {
+        if (pUuid === identity.uuid) {
+            return Window.executeJavascript(windowIdentity, payload.code, (err, result) => {
+                if (err) {
+                    nack(err);
+                } else {
+                    let dataAck = _.clone(successAck);
+                    dataAck.data = result;
+                    ack(dataAck);
+                }
+            });
+        }
+        pUuid = Application.getParentApplication({
+            uuid: pUuid
+        });
+
+    }
+    return nack(new Error('Rejected, target window is not owned by requesting identity'));
+}
+
+function disableWindowFrame(identity, message, ack) {
+    var payload = message.payload,
+        windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+
+    Window.disableFrame(windowIdentity);
+    ack(successAck);
+}
+
+function windowEmbedded(identity, message, ack) {
+    let payload = message.payload;
+    // Ensure expected shape for identity utility compliance
+    payload.uuid = payload.targetUuid;
+
+    let windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+    Window.embed(windowIdentity, `0x${payload.parentHwnd}`);
+    ack(successAck);
+}
+
+function closeWindow(identity, message, ack) {
+    let payload = message.payload;
+    let windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+    let force = !!payload.force;
+
+    Window.close(windowIdentity, force, () => {
+        ack(successAck);
+    });
+}
+
+function bringWindowToFront(identity, message, ack) {
+    var payload = message.payload,
+        windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+
+    Window.bringToFront(windowIdentity);
+    ack(successAck);
+}
+
+function blurWindow(identity, message, ack) {
+    var payload = message.payload,
+        windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+
+    Window.blur(windowIdentity);
+    ack(successAck);
+}
+
+function animateWindow(identity, message, ack) {
+    let windowIdentity = apiProtocolBase.getTargetWindowIdentity(message.payload);
+    let transitions = message.payload.transitions;
+    let options = message.payload.options;
+
+    Window.animate(windowIdentity, transitions, options, () => {
+        ack(successAck);
+    });
+}
+
+function dockWindow(identity, message, ack) {
+    //Pending runtime.
+    ack(successAck);
+}
+
+function windowExists(identity, message, ack) {
+    let windowIdentity = apiProtocolBase.getTargetWindowIdentity(message.payload);
+    let dataAck = _.clone(successAck);
+
+    dataAck.data = Window.exists(windowIdentity);
+    ack(dataAck);
+}
+
+function getCachedBounds(identity, message, ack, nack) {
+    let payload = message.payload;
+    let windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+    let dataAck = _.clone(successAck);
+
+    Window.getBoundsFromDisk(windowIdentity, data => {
+        dataAck.data = data;
+        ack(dataAck);
+    }, nack);
+}
+
+function getZoomLevel(identity, message, ack) {
+    let payload = message.payload;
+    let windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+
+    Window.getZoomLevel(windowIdentity, result => {
+        let dataAck = _.clone(successAck);
+        dataAck.data = result;
+        ack(dataAck);
+    });
+}
+
+function setZoomLevel(identity, message, ack) {
+    let payload = message.payload;
+    let windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+    let level = payload.level;
+
+    Window.setZoomLevel(windowIdentity, level);
+    ack(successAck);
+}
+
+function onWindowUnload(identity, message, ack) {
+    if (message.isMainRenderFrame === true) {
+        Window.onUnload(identity);
+    } else {
+        log.writeToLog(1, `Ignoring unload for non-main frame ${JSON.stringify(identity)}`, true);
+    }
+    ack(successAck);
+}

--- a/src/browser/api_protocol/index.ts
+++ b/src/browser/api_protocol/index.ts
@@ -15,7 +15,7 @@ limitations under the License.
 */
 declare var require: any;
 
-const ApplicationApiHandler = require('./api_handlers/application').ApplicationApiHandler;
+const initApplicationApiHandler = require('./api_handlers/application').init;
 import { ExternalApplicationApiHandler } from './api_handlers/external_application';
 const AuthorizationApiHandler = require('./api_handlers/authorization').AuthorizationApiHandler;
 import { init as initClipboardAPIHandler } from './api_handlers/clipboard';
@@ -23,13 +23,13 @@ const EventListenerApiHandler = require('./api_handlers/event_listener').EventLi
 const InterApplicationBusApiHandler = require('./api_handlers/interappbus').InterApplicationBusApiHandler;
 const NotificationApiHandler = require('./api_handlers/notifications').NotificationApiHandler;
 const SystemApiHandler = require('./api_handlers/system').SystemApiHandler;
-const WindowApiHandler = require('./api_handlers/window').WindowApiHandler;
+const initWindowApiHandler = require('./api_handlers/window').init;
 
 const apiProtocolBase = require('./api_handlers/api_protocol_base.js');
 
 export function initApiHandlers() {
     /* tslint:disable: no-unused-variable */
-    const applicationApiHandler = new ApplicationApiHandler();
+    initApplicationApiHandler();
     const externalApplicationApiHandler = new ExternalApplicationApiHandler();
     const authorizationApiHandler = new AuthorizationApiHandler();
     initClipboardAPIHandler();
@@ -37,7 +37,7 @@ export function initApiHandlers() {
     const interApplicationBusApiHandler = new InterApplicationBusApiHandler();
     const notificationApiHandler = new NotificationApiHandler();
     const systemApiHandler = new SystemApiHandler();
-    const windowApiHandler = new WindowApiHandler();
+    initWindowApiHandler();
 
     apiProtocolBase.init();
 


### PR DESCRIPTION
Currently, API handler maps are located inside classes. I need the maps (App and Window) out exported without the need to instantiate anything (for my next PR).

This PR shows big changes because of indentation: everything indented and inside the class is now moved out of it, hence, no indentation.

### Do not fear linting diffs!

Tests results (typical errors for vanilla):
• [Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5954002f0c1017021736590b)
• [Windows 8](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5954002a0c1017021736590a)
• [Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5954012c0c1017021736590c)