### PR TITLE
RUN-3081 middleware refactor to control handler queue

### DIFF
--- a/src/browser/api_protocol/api_handlers/api_protocol_base.ts
+++ b/src/browser/api_protocol/api_handlers/api_protocol_base.ts
@@ -20,17 +20,11 @@ const ElipcStrategy = require('../transport_strategy/elipc_strategy').ElipcStrat
 
 import { default as RequestHandler } from '../transport_strategy/base_handler';
 import { MessagePackage } from '../transport_strategy/api_transport_base';
-import { registerMiddleware as registerMeshMiddleware } from './mesh_middleware';
-import { meshEnabled } from '../../connection_manager';
 import { ApiPath, ApiFunc, EndpointSpec, ActionSpecMap, Endpoint, ActionMap } from '../shapes';
 
 export const actionMap: ActionMap = Object.create(null); // no prototype to avoid having to call hasOwnProperty()
 
 const requestHandler = new RequestHandler<MessagePackage>();
-
-if (meshEnabled) {
-    registerMeshMiddleware(requestHandler);
-}
 
 // add the handler + create with action map
 const webSocketStrategy = new WebSocketStrategy(actionMap, requestHandler);

--- a/src/browser/api_protocol/index.ts
+++ b/src/browser/api_protocol/index.ts
@@ -24,8 +24,13 @@ const InterApplicationBusApiHandler = require('./api_handlers/interappbus').Inte
 const NotificationApiHandler = require('./api_handlers/notifications').NotificationApiHandler;
 const SystemApiHandler = require('./api_handlers/system').SystemApiHandler;
 const initWindowApiHandler = require('./api_handlers/window').init;
+import { init as initApiProtocol, getDefaultRequestHandler } from './api_handlers/api_protocol_base';
+import { meshEnabled } from '../connection_manager';
+import { registerMiddleware as registerMeshMiddleware } from './api_handlers/mesh_middleware';
 
-const apiProtocolBase = require('./api_handlers/api_protocol_base.js');
+if (meshEnabled) {
+    registerMeshMiddleware(getDefaultRequestHandler());
+}
 
 export function initApiHandlers() {
     /* tslint:disable: no-unused-variable */
@@ -39,7 +44,7 @@ export function initApiHandlers() {
     const systemApiHandler = new SystemApiHandler();
     initWindowApiHandler();
 
-    apiProtocolBase.init();
+    initApiProtocol();
 
     const apiPolicyProcessor = require('./api_handlers/api_policy_processor');
 }


### PR DESCRIPTION
Refactored mesh middlewear initiation so that we can control the middlewear handler queue.

This is needed for my future PR.

Test results are good (typical vanilla build errors)
[Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/595530e10c10170217365912)
[Windows 8](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/595530ec0c10170217365913)
[Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/595532710c10170217365914)