### PR TITLE
RUN-2452 Fire error callbacks for nonexistent apps and windows (where appropriate)

### DIFF
--- a/src/browser/api_protocol/api_handlers/api_middleware.ts
+++ b/src/browser/api_protocol/api_handlers/api_middleware.ts
@@ -1,0 +1,78 @@
+/*
+Copyright 2017 OpenFin Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import RequestHandler from '../transport_strategy/base_handler';
+import { appByUuid, windowExists } from '../../core_state';
+import { applicationApiMap } from './application.js';
+import { MessagePackage } from '../transport_strategy/api_transport_base';
+import { windowApiMap } from './window.js';
+
+const apisToIgnore = new Set([
+    // Application
+    'create-application',
+    'create-child-window',
+    // Window
+    'window-exists'
+]);
+
+/**
+ * Verifies that API is called on applications and windows that exist,
+ * otherwise a proper error callback is executed.
+ */
+function verifyEntityExistence(msg: MessagePackage, next: () => void): void {
+    const { data, nack } = msg;
+    const payload = data && data.payload;
+    const uuid = payload && payload.uuid;
+    const name = payload && payload.name;
+    const action = data && data.action;
+
+    if (!uuid || apisToIgnore.has(action)) {
+        return next();
+    }
+
+    if (applicationApiMap.hasOwnProperty(action)) {
+        // Application API
+
+        const appExists = !!appByUuid(uuid);
+
+        if (!appExists) {
+
+            // Ignore cases where an app was created from a manifest and RVM is being asked to run it.
+            // In those cases the app doesn't exist yet at the time 'run' is called on it, hence, no
+            // need to error out this call in those cases.
+            if (action === 'run-application' && payload.manifestUrl) {
+                return next();
+            }
+
+            return nack('Could not locate the requested application');
+        }
+
+    } else if (windowApiMap.hasOwnProperty(action)) {
+        // Window API
+
+        const wndExists = windowExists(uuid, name);
+
+        if (!wndExists) {
+            return nack('Could not locate the requested window');
+        }
+    }
+
+    next();
+}
+
+export function registerMiddleware(requestHandler: RequestHandler<MessagePackage>): void {
+    requestHandler.addPreProcessor(verifyEntityExistence);
+}

--- a/src/browser/api_protocol/api_handlers/middleware_entity_existence.ts
+++ b/src/browser/api_protocol/api_handlers/middleware_entity_existence.ts
@@ -39,7 +39,10 @@ function verifyEntityExistence(msg: MessagePackage, next: () => void): void {
     const name = payload && payload.name;
     const action = data && data.action;
 
-    if (apisToIgnore.has(action)) {
+    // When the user wraps non-existing application or window and tries to make an API
+    // call on it, uuid in those cases is provided in the payload. So if no UUID found
+    // just ignore checking further and continue
+    if (!uuid || apisToIgnore.has(action)) {
         return next();
     }
 

--- a/src/browser/api_protocol/api_handlers/middleware_entity_existence.ts
+++ b/src/browser/api_protocol/api_handlers/middleware_entity_existence.ts
@@ -39,7 +39,7 @@ function verifyEntityExistence(msg: MessagePackage, next: () => void): void {
     const name = payload && payload.name;
     const action = data && data.action;
 
-    if (!uuid || apisToIgnore.has(action)) {
+    if (apisToIgnore.has(action)) {
         return next();
     }
 

--- a/src/browser/api_protocol/index.ts
+++ b/src/browser/api_protocol/index.ts
@@ -26,7 +26,10 @@ const SystemApiHandler = require('./api_handlers/system').SystemApiHandler;
 const initWindowApiHandler = require('./api_handlers/window').init;
 import { init as initApiProtocol, getDefaultRequestHandler } from './api_handlers/api_protocol_base';
 import { meshEnabled } from '../connection_manager';
+import { registerMiddleware as registerApiMiddleware } from './api_handlers/api_middleware';
 import { registerMiddleware as registerMeshMiddleware } from './api_handlers/mesh_middleware';
+
+registerApiMiddleware(getDefaultRequestHandler());
 
 if (meshEnabled) {
     registerMeshMiddleware(getDefaultRequestHandler());

--- a/src/browser/api_protocol/index.ts
+++ b/src/browser/api_protocol/index.ts
@@ -26,10 +26,10 @@ const SystemApiHandler = require('./api_handlers/system').SystemApiHandler;
 const initWindowApiHandler = require('./api_handlers/window').init;
 import { init as initApiProtocol, getDefaultRequestHandler } from './api_handlers/api_protocol_base';
 import { meshEnabled } from '../connection_manager';
-import { registerMiddleware as registerApiMiddleware } from './api_handlers/api_middleware';
+import { registerMiddleware as registerEntityExistenceMiddleware } from './api_handlers/middleware_entity_existence';
 import { registerMiddleware as registerMeshMiddleware } from './api_handlers/mesh_middleware';
 
-registerApiMiddleware(getDefaultRequestHandler());
+registerEntityExistenceMiddleware(getDefaultRequestHandler());
 
 if (meshEnabled) {
     registerMeshMiddleware(getDefaultRequestHandler());


### PR DESCRIPTION
Added a new middleware that will check for existence of applications and windows before proceeding with an API call execution. Will fire an error callback if an app or a window doesn't exist. This will match v5 behavior.

Middleware handler queue becomes:
API policy => Mesh / multi-runtime => Entity check (this PR) => API Execution

Added 2 new tests: 1 test for one of the application APIs and 1 test for one of the window APIs. Will publish them once the PR is merged and a build is produced.
• [Application.isRunning (called on non-existent app)](https://testing-dashboard.openfin.co/#/app/tests/5952a4b20c101702173658c4/edit)
• [Window.focus (called on non-existent window)](https://testing-dashboard.openfin.co/#/app/tests/5952a5090c101702173658c5/edit)

Test results (typical for vanilla):
[Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5956a5c60c10170217365936)
[Windows 8](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5956a69e0c10170217365938)
[Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5956a60c0c10170217365937)