### PR TITLE
RUN-3154 do not launch the socket server twice

### DIFF
--- a/index.js
+++ b/index.js
@@ -509,11 +509,12 @@ function launchApp(argo, startExternalAdapterServer) {
         const uuid = startupAppOptions && startupAppOptions.uuid;
         const ofApp = Application.wrap(uuid);
         const isRunning = Application.isRunning(ofApp);
+        let successfulInitialLaunch = false;
 
         if (startupAppOptions && !isRunning) {
             //making sure that if a window is present we set the window name === to the uuid as per 5.0
             startupAppOptions.name = uuid;
-            initFirstApp(configObject, configUrl, licenseKey);
+            successfulInitialLaunch = initFirstApp(configObject, configUrl, licenseKey);
         } else if (uuid) {
             Application.run({
                 uuid,
@@ -521,7 +522,7 @@ function launchApp(argo, startExternalAdapterServer) {
             });
         }
 
-        if (startExternalAdapterServer) {
+        if (startExternalAdapterServer && successfulInitialLaunch) {
             coreState.setStartManifest(configUrl, configObject);
             socketServer.start(configObject['websocket_port'] || 9696);
         }
@@ -544,6 +545,7 @@ function launchApp(argo, startExternalAdapterServer) {
 
 function initFirstApp(configObject, configUrl, licenseKey) {
     let startupAppOptions;
+    let successfulLaunch = false;
 
     try {
         startupAppOptions = convertOptions.getStartupAppOptions(configObject);
@@ -561,7 +563,7 @@ function initFirstApp(configObject, configUrl, licenseKey) {
             firstApp = null;
         });
 
-        socketServer.start(configObject['websocket_port'] || 9696);
+        successfulLaunch = true;
 
     } catch (error) {
         log.writeToLog(1, error, true);
@@ -587,6 +589,8 @@ function initFirstApp(configObject, configUrl, licenseKey) {
             });
         }
     }
+
+    return successfulLaunch;
 }
 
 function registerShortcuts() {

--- a/index.js
+++ b/index.js
@@ -509,7 +509,9 @@ function launchApp(argo, startExternalAdapterServer) {
         const uuid = startupAppOptions && startupAppOptions.uuid;
         const ofApp = Application.wrap(uuid);
         const isRunning = Application.isRunning(ofApp);
-        let successfulInitialLaunch = false;
+
+        // this ensures that external connections that start the runtime can do so without a main window
+        let successfulInitialLaunch = true;
 
         if (startupAppOptions && !isRunning) {
             //making sure that if a window is present we set the window name === to the uuid as per 5.0

--- a/src/browser/transports/socket_server.js
+++ b/src/browser/transports/socket_server.js
@@ -4,9 +4,10 @@ Copyright 2017 OpenFin Inc.
 Licensed under OpenFin Commercial License you may not use this file except in compliance with your Commercial License.
 Please contact OpenFin Inc. at sales@openfin.co to obtain a Commercial License.
 */
-let http = require('http');
-let EventEmitter = require('events').EventEmitter;
-let util = require('util');
+const http = require('http');
+const EventEmitter = require('events').EventEmitter;
+const util = require('util');
+const log = require('../log');
 import route from '../../common/route';
 
 
@@ -14,6 +15,7 @@ let Server = function() {
     let me = this;
     EventEmitter.call(this);
 
+    let hasStarted = false;
     let activeConnections = {};
     let idPool = require('../int_pool').default;
     let httpServer = http.createServer(function(req, res) {
@@ -67,6 +69,11 @@ let Server = function() {
     };
 
     me.start = function(port) {
+        if (hasStarted) {
+            log.writeToLog(1, 'socket server already running');
+            return;
+        }
+
         httpServer.listen(port, '127.0.0.1', function() {
             if (httpServerError) {
                 httpServerError = false;
@@ -118,6 +125,7 @@ let Server = function() {
             me.emit(route.server('open'), me.getPort());
         });
 
+        hasStarted = true;
     };
 
     me.connectionAuthenticated = function(id, uuid) {


### PR DESCRIPTION
@rdepena  @wenjunche 

This fixes a bug I created fixing a bug where we were sending out a bad port discovery message on failed launch. The socket server would in some cases be launched twice, this is the fix. 

[tests well](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59692cf3a3c7663182518f87). Testing with the node and java adapters was positive as well.