### PR TITLE
RUN-3145 Emit diagnostic events from Window

### DIFF
--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -159,7 +159,7 @@ Application.create = function(opts, configUrl = '', parentIdentity = {}) {
     if (parentIdentity && parentIdentity.uuid) {
         // This is a reference to the meta `app` object that is stored in core state,
         // not the actual `application` object created above. Here we are attaching the parent
-        // indentity to it.
+        // identity to it.
         const app = coreState.appByUuid(opts.uuid);
         app.parentUuid = parentUuid;
     }
@@ -638,19 +638,6 @@ Application.run = function(identity, configUrl = '') {
                 electronApp.exit(0);
             }
         }
-    });
-
-    app.mainWindow.webContents.on('crashed', () => {
-        ofEvents.emit(route.application('crashed', uuid), { topic: 'application', type: 'crashed', uuid });
-        ofEvents.emit(route.application('out-of-memory', uuid), { topic: 'application', type: 'out-of-memory', uuid });
-    });
-
-    app.mainWindow.on('responsive', () => {
-        ofEvents.emit(route.application('responding', uuid), { topic: 'application', type: 'responding', uuid });
-    });
-
-    app.mainWindow.on('unresponsive', () => {
-        ofEvents.emit(route.application('not-responding', uuid), { topic: 'application', type: 'not-responding', uuid });
     });
 
     coreState.setAppRunningState(uuid, true);

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -477,7 +477,7 @@ Window.create = function(id, opts) {
             });
 
             // can't unhook when the 'closed' event fires; browserWindow is already destroyed then
-            webContents.removeAllListeners('page-favicon-updated');
+            browserWindow.webContents.removeAllListeners('page-favicon-updated');
 
             // make sure that this uuid/name combo does not have any lingering close-requested subscriptions.
             ofEvents.removeAllListeners(closeEventString);

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -504,10 +504,17 @@ Window.create = function(id, opts) {
 
         const emitToAppAndWin = (...types) => {
             let isMainWindow = (uuid === name);
+
             types.forEach(type => {
+                // Window crashed: inform Window "namespace"
                 ofEvents.emit(route.window(type, uuid, name), { topic: 'window', type, uuid, name });
+
+                // Window crashed: inform Application "namespace" but with "window-" event string prefix
+                ofEvents.emit(route.application(`window-${type}`, uuid), { topic: 'application', type, uuid, name });
+
                 if (isMainWindow) {
-                    ofEvents.emit(route.application(`window-${type}`, uuid), { topic: 'application', type, uuid, name });
+                    // Application crashed: inform Application "namespace"
+                    ofEvents.emit(route.application(type, uuid), { topic: 'application', type, uuid });
                 }
             });
         };

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -502,10 +502,13 @@ Window.create = function(id, opts) {
             }
         });
 
-        var emitToAppAndWin = (...types) => {
+        const emitToAppAndWin = (...types) => {
+            let isMainWindow = (uuid === name);
             types.forEach(type => {
                 ofEvents.emit(route.window(type, uuid, name), { topic: 'window', type, uuid, name });
-                ofEvents.emit(route.application(`window-${type}`, uuid), { topic: 'application', type, uuid, name });
+                if (isMainWindow) {
+                    ofEvents.emit(route.application(`window-${type}`, uuid), { topic: 'application', type, uuid, name });
+                }
             });
         };
 

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -505,7 +505,7 @@ Window.create = function(id, opts) {
         var emitToAppAndWin = (...types) => {
             types.forEach(type => {
                 ofEvents.emit(route.window(type, uuid, name), { topic: 'window', type, uuid, name });
-                ofEvents.emit(route.application(type, uuid), { topic: 'application', type, uuid });
+                ofEvents.emit(route.application(`window-${type}`, uuid), { topic: 'application', type, uuid, name });
             });
         };
 


### PR DESCRIPTION
1. Moved code from `Application.run()` to `new Window()` (constructor) that handles certain Electron "diagnostic" events, re-emiting them to the app (as `'crashed'`, `'responding'`, and `'not-responding'`).
2. Doubled each emit to also emit to window, routed with `-`_name_ and with _name_ added to event object (where _name_ is the window name).

Testing this was a little challenging but I finally came up with a manual test. It is not practical to test this in the test runner because (1) per Roma we do not want to crash the test runner and (2) anyway my test involved manual typing directly into the debugger.

See Jira [RUN-3145](https://appoji.jira.com/browse/RUN-3145) for more details, including my test recipe.