### PR TITLE
RUN-3160 8.56.*.* - Opacity not applied on window construction

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -1665,7 +1665,15 @@ function applyAdditionalOptionsToWindowOnVisible(browserWindow, callback) {
     } else {
         browserWindow.once('visibility-changed', (event, isVisible) => {
             if (isVisible) {
-                callback();
+                if (browserWindow.isVisible()) {
+                    callback();
+                    // Version 8: Will be visible on the next tick
+                    // TODO: Refactor to also use 'ready-to-show'
+                } else {
+                    setTimeout(() => {
+                        callback();
+                    }, 1);
+                }
             }
         });
     }


### PR DESCRIPTION

[before change](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/596e722aa3c7663182518f99)

[including change](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/596e731fa3c7663182518f9c)

TODO as  RUN-3161 - Refactor applyAdditionalOptionsToWindowOnVisible to also use `ready-to-show` 