### PR TITLE
RUN-3165 remove reliance on the renderer for unload events 

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -356,9 +356,17 @@ Window.create = function(id, opts) {
         browserWindow.hide();
     };
 
-    function onDidUnload() {
+    const ofUnloadedHandler = (url, isMainFrame) => {
+
+        if (isMainFrame) {
+            ofEvents.emit(route.window('unload', uuid, name, false), identity);
+            ofEvents.emit(route.window('init-subscription-listeners'), identity);
+        } else {
+            log.writeToLog(1, `Ignoring unload for non-main frame ${JSON.stringify(identity)}`, true);
+        }
+
         urlBeforeunload = webContents ? webContents.getURL() : null;
-    }
+    };
 
     function onDocumentLoaded() {
         const url = webContents.getURL();
@@ -416,6 +424,7 @@ Window.create = function(id, opts) {
         name = _options.name;
 
         const WINDOW_DOCUMENT_LOADED = 'document-loaded';
+        const OF_WINDOW_UNLOADED = 'of-window-unloaded';
 
         browserWindow._options = _options;
 
@@ -443,15 +452,15 @@ Window.create = function(id, opts) {
             });
 
             //tear down any listeners on external event emitters.
-            ofEvents.removeListener(route.window('unload', uuid, name, false), onDidUnload);
             webContents.removeListener(WINDOW_DOCUMENT_LOADED, onDocumentLoaded);
+            webContents.removeListener(OF_WINDOW_UNLOADED, ofUnloadedHandler);
         };
 
         let windowTeardown = createWindowTearDown(identity, id);
 
         //wire up unload/navigate events for reload.
-        ofEvents.on(route.window('unload', uuid, name, false), onDidUnload);
         webContents.on(WINDOW_DOCUMENT_LOADED, onDocumentLoaded);
+        webContents.on(OF_WINDOW_UNLOADED, ofUnloadedHandler);
 
         // once the window is closed, be sure to close all the children
         // it may have and remove it from the

--- a/src/browser/api_protocol/api_handlers/window.js
+++ b/src/browser/api_protocol/api_handlers/window.js
@@ -18,7 +18,6 @@ const apiProtocolBase = require('./api_protocol_base');
 const Window = require('../../api/window').Window;
 const Application = require('../../api/application').Application;
 const _ = require('underscore');
-const log = require('../../log');
 
 let successAck = {
     success: true
@@ -59,7 +58,6 @@ module.exports.windowApiMap = {
     'navigate-window-forward': navigateWindowForward,
     'stop-window-navigation': stopWindowNavigation,
     'reload-window': reloadWindow,
-    'on-window-unload': onWindowUnload, // Fires as window unloads its content and resources; reloading a window or navigating away will fire this event
     'redirect-window-to-url': redirectWindowToUrl, // Deprecated
     'resize-window': resizeWindow,
     'resize-window-by': resizeWindowBy,
@@ -567,14 +565,5 @@ function setZoomLevel(identity, message, ack) {
     let level = payload.level;
 
     Window.setZoomLevel(windowIdentity, level);
-    ack(successAck);
-}
-
-function onWindowUnload(identity, message, ack) {
-    if (message.isMainRenderFrame === true) {
-        Window.onUnload(identity);
-    } else {
-        log.writeToLog(1, `Ignoring unload for non-main frame ${JSON.stringify(identity)}`, true);
-    }
     ack(successAck);
 }

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -25,7 +25,6 @@ limitations under the License.
 
     let renderFrameId = global.routingId;
     let customData = global.getFrameData(renderFrameId);
-    let isMainRenderFrame = global.isMainFrame;
     let glbl = global;
 
     const electron = require('electron');
@@ -341,16 +340,6 @@ limitations under the License.
             }
         }, 1);
     }
-
-    electron.remote.getCurrentWebContents(renderFrameId).once('navigation-entry-commited', () => {
-        ipc.send(renderFrameId, 'of-window-message', {
-            action: 'on-window-unload',
-            payload: {},
-            isSync: false,
-            singleFrameOnly: true,
-            isMainRenderFrame
-        });
-    });
 
     var pendingMainCallbacks = [];
     var currPageHasLoaded = false;


### PR DESCRIPTION
This removes the need to listen for unload events on the renderer side. This is paired with [this runtime PR](https://github.com/openfin/runtime/pull/532). Listening via remote for the unload event was causing a browser side error when the child was cross origin. 

Tests will be posed after getting an upstream runtime to target. Local tests were at least as good as current stable / 22 though I get black screen crashes on almost every run for both stable and my locally built changes. 