### PR TITLE
RUN-3167 Socket server fix

### DIFF
--- a/src/browser/transports/socket_server.js
+++ b/src/browser/transports/socket_server.js
@@ -69,7 +69,7 @@ let Server = function() {
     };
 
     me.start = function(port) {
-        if (hasStarted) {
+        if (hasStarted && !httpServerError) {
             log.writeToLog(1, 'socket server already running', true);
             return;
         }


### PR DESCRIPTION
Fixed issue where if the port was already in use we would not start the socket server.

@datamadic @StevenEBarbaro @whyn07m3 @HarsimranSingh @joneit 

[Test run](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59769ac5a3c7663182518fc7)

Pending cherry pick on all the branches.
