### PR TITLE
RUN-3165 remove reliance on the renderer for unload events

### DIFF
--- a/src/browser/api_protocol/api_handlers/window.js
+++ b/src/browser/api_protocol/api_handlers/window.js
@@ -17,7 +17,6 @@ const apiProtocolBase = require('./api_protocol_base');
 const Window = require('../../api/window').Window;
 const Application = require('../../api/application').Application;
 const _ = require('underscore');
-const log = require('../../log');
 
 function WindowApiHandler() {
     let successAck = {
@@ -59,7 +58,6 @@ function WindowApiHandler() {
         'navigate-window-forward': navigateWindowForward,
         'stop-window-navigation': stopWindowNavigation,
         'reload-window': reloadWindow,
-        'on-window-unload': onWindowUnload, // Fires as window unloads its content and resources; reloading a window or navigating away will fire this event
         'redirect-window-to-url': redirectWindowToUrl, // Deprecated
         'resize-window': resizeWindow,
         'resize-window-by': resizeWindowBy,
@@ -564,15 +562,6 @@ function WindowApiHandler() {
         let level = payload.level;
 
         Window.setZoomLevel(windowIdentity, level);
-        ack(successAck);
-    }
-
-    function onWindowUnload(identity, message, ack) {
-        if (message.isMainRenderFrame === true) {
-            Window.onUnload(identity);
-        } else {
-            log.writeToLog(1, `Ignoring unload for non-main frame ${JSON.stringify(identity)}`, true);
-        }
         ack(successAck);
     }
 

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -25,7 +25,6 @@ limitations under the License.
 
     let renderFrameId = global.routingId;
     let customData = global.getFrameData(renderFrameId);
-    let isMainRenderFrame = global.isMainFrame;
     let glbl = global;
 
     let rqr = require;
@@ -341,16 +340,6 @@ limitations under the License.
             }
         }, 1);
     }
-
-    rqr('electron').remote.getCurrentWebContents(renderFrameId).once('navigation-entry-commited', () => {
-        ipc.send(renderFrameId, 'of-window-message', {
-            action: 'on-window-unload',
-            payload: {},
-            isSync: false,
-            singleFrameOnly: true,
-            isMainRenderFrame
-        });
-    });
 
     var pendingMainCallbacks = [];
     var currPageHasLoaded = false;


### PR DESCRIPTION
This represents the hotfix changes bound for the 7.53.21.6 patch.


Requires runtime update ([this change set](https://github.com/openfin/runtime/pull/533) to hotfix)
@HarsimranSingh where should I make that to? 