### PR TITLE
RUN-3165 remove reliance on the renderer for unload events hotfix

### DIFF
--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -499,34 +499,34 @@ Application.run = function(identity, configUrl = '') {
         rvmBus.registerLicenseInfo({ data: genLicensePayload() }, sourceUrl);
     };
     const sendAppsEventsToRVMListener = (appEvent) => {
-        if (!sourceUrl) {
-            return; // Most likely an adapter, RVM can't do anything with what it didn't load(determined by sourceUrl) so ignore
-        }
-        let type = appEvent.type,
-            rvmPayload = {
-                topic: 'application-event',
-                type,
-                sourceUrl
-            };
+            if (!sourceUrl) {
+                return; // Most likely an adapter, RVM can't do anything with what it didn't load(determined by sourceUrl) so ignore
+            }
+            let type = appEvent.type,
+                rvmPayload = {
+                    topic: 'application-event',
+                    type,
+                    sourceUrl
+                };
 
-        if (type === 'ready' || type === 'run-requested') {
-            rvmPayload.hideSplashScreenSupported = true;
-        } else if (type === 'closed') {
+            if (type === 'ready' || type === 'run-requested') {
+                rvmPayload.hideSplashScreenSupported = true;
+            } else if (type === 'closed') {
 
-            // Don't send 'closed' event to RVM when app is restarting.
-            // This solves the problem of apps not being able to make API
-            // calls that rely on RVM and manifest URL
-            if (appState.isRestarting) {
-                return;
+                // Don't send 'closed' event to RVM when app is restarting.
+                // This solves the problem of apps not being able to make API
+                // calls that rely on RVM and manifest URL
+                if (appState.isRestarting) {
+                    return;
+                }
+
+                rvmPayload.isClosing = coreState.shouldCloseRuntime([uuid]);
             }
 
-            rvmPayload.isClosing = coreState.shouldCloseRuntime([uuid]);
-        }
-
-        if (rvmBus) {
-            rvmBus.publish(rvmPayload);
-        }
-    };
+            if (rvmBus) {
+                rvmBus.publish(rvmPayload);
+            }
+};
 
     // if the runtime is in offline mode, the RVM still expects the
     // startup-url/config for communication

--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -499,34 +499,34 @@ Application.run = function(identity, configUrl = '') {
         rvmBus.registerLicenseInfo({ data: genLicensePayload() }, sourceUrl);
     };
     const sendAppsEventsToRVMListener = (appEvent) => {
-            if (!sourceUrl) {
-                return; // Most likely an adapter, RVM can't do anything with what it didn't load(determined by sourceUrl) so ignore
-            }
-            let type = appEvent.type,
-                rvmPayload = {
-                    topic: 'application-event',
-                    type,
-                    sourceUrl
-                };
+        if (!sourceUrl) {
+            return; // Most likely an adapter, RVM can't do anything with what it didn't load(determined by sourceUrl) so ignore
+        }
+        let type = appEvent.type,
+            rvmPayload = {
+                topic: 'application-event',
+                type,
+                sourceUrl
+            };
 
-            if (type === 'ready' || type === 'run-requested') {
-                rvmPayload.hideSplashScreenSupported = true;
-            } else if (type === 'closed') {
+        if (type === 'ready' || type === 'run-requested') {
+            rvmPayload.hideSplashScreenSupported = true;
+        } else if (type === 'closed') {
 
-                // Don't send 'closed' event to RVM when app is restarting.
-                // This solves the problem of apps not being able to make API
-                // calls that rely on RVM and manifest URL
-                if (appState.isRestarting) {
-                    return;
-                }
-
-                rvmPayload.isClosing = coreState.shouldCloseRuntime([uuid]);
+            // Don't send 'closed' event to RVM when app is restarting.
+            // This solves the problem of apps not being able to make API
+            // calls that rely on RVM and manifest URL
+            if (appState.isRestarting) {
+                return;
             }
 
-            if (rvmBus) {
-                rvmBus.publish(rvmPayload);
-            }
-};
+            rvmPayload.isClosing = coreState.shouldCloseRuntime([uuid]);
+        }
+
+        if (rvmBus) {
+            rvmBus.publish(rvmPayload);
+        }
+    };
 
     // if the runtime is in offline mode, the RVM still expects the
     // startup-url/config for communication

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -410,7 +410,7 @@ Window.create = function(id, opts) {
         uuid = _options.uuid;
         name = _options.name;
 
-        const OF_WINDOW_UNLOADED = 'of-window-unloaded';
+        const OF_WINDOW_UNLOADED = 'of-window-navigation';
 
         browserWindow._options = _options;
 

--- a/src/browser/api_protocol/api_handlers/window.js
+++ b/src/browser/api_protocol/api_handlers/window.js
@@ -17,7 +17,6 @@ const apiProtocolBase = require('./api_protocol_base');
 const Window = require('../../api/window').Window;
 const Application = require('../../api/application').Application;
 const _ = require('underscore');
-const log = require('../../log');
 
 function WindowApiHandler() {
     let successAck = {
@@ -59,7 +58,6 @@ function WindowApiHandler() {
         'navigate-window-forward': navigateWindowForward,
         'stop-window-navigation': stopWindowNavigation,
         'reload-window': reloadWindow,
-        'on-window-unload': onWindowUnload, // Fires as window unloads its content and resources; reloading a window or navigating away will fire this event
         'redirect-window-to-url': redirectWindowToUrl, // Deprecated
         'resize-window': resizeWindow,
         'resize-window-by': resizeWindowBy,
@@ -564,15 +562,6 @@ function WindowApiHandler() {
         let level = payload.level;
 
         Window.setZoomLevel(windowIdentity, level);
-        ack(successAck);
-    }
-
-    function onWindowUnload(identity, message, ack) {
-        if (message.isMainRenderFrame === true) {
-            Window.onUnload(identity);
-        } else {
-            log.writeToLog(1, `Ignoring unload for non-main frame ${JSON.stringify(identity)}`, true);
-        }
         ack(successAck);
     }
 

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -25,7 +25,6 @@ limitations under the License.
 
     let renderFrameId = global.routingId;
     let customData = global.getFrameData(renderFrameId);
-    let isMainRenderFrame = global.isMainFrame;
     let glbl = global;
 
     let rqr = require;
@@ -341,16 +340,6 @@ limitations under the License.
             }
         }, 1);
     }
-
-    rqr('electron').remote.getCurrentWebContents(renderFrameId).once('navigation-entry-commited', () => {
-        ipc.send(renderFrameId, 'of-window-message', {
-            action: 'on-window-unload',
-            payload: {},
-            isSync: false,
-            singleFrameOnly: true,
-            isMainRenderFrame
-        });
-    });
 
     var pendingMainCallbacks = [];
     var currPageHasLoaded = false;


### PR DESCRIPTION
Local tests (even against stable) have been less than desirable, but it looks about the same (+/- the additional tests) 

[PRtests](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/597b4d2ea3c7663182519004)
[stable tests](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/597b51fea3c7663182519005)
[additional tests](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/597ba309a3c766318251900b)