### PR TITLE
RUN-3165 remove reliance on the renderer for unload events 7.53.22/staging

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -347,7 +347,6 @@ Window.create = function(id, opts) {
     let _options;
     let _boundsChangedHandler;
     let groupUuid = null; // windows by default don't belong to any groups
-    let urlBeforeunload;
 
     let hideReason = 'hide';
     let hideOnCloseListener = () => {
@@ -356,20 +355,19 @@ Window.create = function(id, opts) {
         browserWindow.hide();
     };
 
-    function onDidUnload() {
-        urlBeforeunload = webContents ? webContents.getURL() : null;
-    }
+    const ofUnloadedHandler = (eventObj, url, isReload) => {
 
-    function onDocumentLoaded() {
-        const url = webContents.getURL();
-        if (url === urlBeforeunload) {
+        if (isReload) {
             emitReloadedEvent({
                 uuid,
                 name
             }, url);
         }
-        urlBeforeunload = '';
-    }
+
+        ofEvents.emit(route.window('unload', uuid, name, false), identity);
+        ofEvents.emit(route.window('init-subscription-listeners'), identity);
+        ofEvents.emit(route.window('openfin-diagnostic/unload', uuid, name, true), url);
+    };
 
     let _externalWindowEventAdapter;
 
@@ -415,7 +413,7 @@ Window.create = function(id, opts) {
         uuid = _options.uuid;
         name = _options.name;
 
-        const WINDOW_DOCUMENT_LOADED = 'document-loaded';
+        const OF_WINDOW_UNLOADED = 'of-window-navigation';
 
         browserWindow._options = _options;
 
@@ -443,15 +441,10 @@ Window.create = function(id, opts) {
             });
 
             //tear down any listeners on external event emitters.
-            ofEvents.removeListener(route.window('unload', uuid, name, false), onDidUnload);
-            webContents.removeListener(WINDOW_DOCUMENT_LOADED, onDocumentLoaded);
+            webContents.removeListener(OF_WINDOW_UNLOADED, ofUnloadedHandler);
         };
 
         let windowTeardown = createWindowTearDown(identity, id);
-
-        //wire up unload/navigate events for reload.
-        ofEvents.on(route.window('unload', uuid, name, false), onDidUnload);
-        webContents.on(WINDOW_DOCUMENT_LOADED, onDocumentLoaded);
 
         // once the window is closed, be sure to close all the children
         // it may have and remove it from the
@@ -710,6 +703,7 @@ Window.create = function(id, opts) {
 
         if (opts.url === 'about:blank') {
             webContents.once('did-finish-load', () => {
+                webContents.on(OF_WINDOW_UNLOADED, ofUnloadedHandler);
                 constructorCallbackMessage.data = {
                     httpResponseCode
                 };
@@ -720,6 +714,7 @@ Window.create = function(id, opts) {
             ofEvents.once(resourceResponseReceivedEventString, resourceResponseReceivedHandler);
             ofEvents.once(resourceLoadFailedEventString, resourceLoadFailedHandler);
             ofEvents.once(route.window('connected', uuid, name), () => {
+                webContents.on(OF_WINDOW_UNLOADED, ofUnloadedHandler);
                 constructorCallbackMessage.data = {
                     httpResponseCode,
                     apiInjected: true
@@ -1560,35 +1555,41 @@ Window.onUnload = (identity) => {
 };
 
 function emitCloseEvents(identity) {
+    const { uuid, name } = identity;
+
     electronApp.emit('browser-window-closed', null, getElectronBrowserWindow(identity));
 
     ofEvents.emit(route.window('closed'), {
-        name: identity.name,
-        uuid: identity.uuid
+        name,
+        uuid
     });
 
-    ofEvents.emit(route.window('closed', identity.uuid, identity.name, true), {
+    ofEvents.emit(route.window('closed', uuid, name, true), {
         topic: 'window',
         type: 'closed',
-        uuid: identity.uuid,
-        name: identity.name
+        uuid,
+        name
     });
 
     // Need to emit this event because notifications use dashes (-)
     // in their window names
-    ofEvents.emit(route.window('closed', identity.uuid, identity.name, false), {
+    ofEvents.emit(route.window('closed', uuid, name, false), {
         topic: 'window',
         type: 'closed',
-        uuid: identity.uuid,
-        name: identity.name
+        uuid,
+        name
     });
 
-    ofEvents.emit(route.application('window-closed', identity.uuid), {
+    ofEvents.emit(route.application('window-closed', uuid), {
         topic: 'application',
         type: 'window-closed',
-        uuid: identity.uuid,
-        name: identity.name
+        uuid,
+        name
     });
+
+    ofEvents.emit(route.window('unload', uuid, name, false), identity);
+    ofEvents.emit(route.window('openfin-diagnostic/unload', uuid, name, true), identity);
+    ofEvents.emit(route.window('init-subscription-listeners'), identity);
 }
 
 function emitReloadedEvent(identity, url) {

--- a/src/browser/api_protocol/api_handlers/window.js
+++ b/src/browser/api_protocol/api_handlers/window.js
@@ -18,7 +18,6 @@ const apiProtocolBase = require('./api_protocol_base');
 const Window = require('../../api/window').Window;
 const Application = require('../../api/application').Application;
 const _ = require('underscore');
-const log = require('../../log');
 
 let successAck = {
     success: true
@@ -59,7 +58,6 @@ module.exports.windowApiMap = {
     'navigate-window-forward': navigateWindowForward,
     'stop-window-navigation': stopWindowNavigation,
     'reload-window': reloadWindow,
-    'on-window-unload': onWindowUnload, // Fires as window unloads its content and resources; reloading a window or navigating away will fire this event
     'redirect-window-to-url': redirectWindowToUrl, // Deprecated
     'resize-window': resizeWindow,
     'resize-window-by': resizeWindowBy,
@@ -567,14 +565,5 @@ function setZoomLevel(identity, message, ack) {
     let level = payload.level;
 
     Window.setZoomLevel(windowIdentity, level);
-    ack(successAck);
-}
-
-function onWindowUnload(identity, message, ack) {
-    if (message.isMainRenderFrame === true) {
-        Window.onUnload(identity);
-    } else {
-        log.writeToLog(1, `Ignoring unload for non-main frame ${JSON.stringify(identity)}`, true);
-    }
     ack(successAck);
 }

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -25,7 +25,6 @@ limitations under the License.
 
     let renderFrameId = global.routingId;
     let customData = global.getFrameData(renderFrameId);
-    let isMainRenderFrame = global.isMainFrame;
     let glbl = global;
 
     const electron = require('electron');
@@ -341,16 +340,6 @@ limitations under the License.
             }
         }, 1);
     }
-
-    electron.remote.getCurrentWebContents(renderFrameId).once('navigation-entry-commited', () => {
-        ipc.send(renderFrameId, 'of-window-message', {
-            action: 'on-window-unload',
-            payload: {},
-            isSync: false,
-            singleFrameOnly: true,
-            isMainRenderFrame
-        });
-    });
 
     var pendingMainCallbacks = [];
     var currPageHasLoaded = false;


### PR DESCRIPTION
https://github.com/HadoukenIO/core/pull/119/files for develop.

[tests well*](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/597f86e4a3c7663182519015)

*I am getting local fails with the same build w/o my runtime + core changes as well 