### PR TITLE
RUN-3120 prevent API calls from unauthenticated WS connections

### DIFF
--- a/src/browser/api_protocol/index.ts
+++ b/src/browser/api_protocol/index.ts
@@ -17,7 +17,10 @@ declare var require: any;
 
 const initApplicationApiHandler = require('./api_handlers/application').init;
 import { ExternalApplicationApiHandler } from './api_handlers/external_application';
-const AuthorizationApiHandler = require('./api_handlers/authorization').AuthorizationApiHandler;
+import {
+    init as initAuthorizationApiHandler,
+    registerMiddleware as registerExternalConnAuthMiddleware
+} from './api_handlers/authorization';
 import { init as initClipboardAPIHandler } from './api_handlers/clipboard';
 const EventListenerApiHandler = require('./api_handlers/event_listener').EventListenerApiHandler;
 const InterApplicationBusApiHandler = require('./api_handlers/interappbus').InterApplicationBusApiHandler;
@@ -29,17 +32,18 @@ import { meshEnabled } from '../connection_manager';
 import { registerMiddleware as registerEntityExistenceMiddleware } from './api_handlers/middleware_entity_existence';
 import { registerMiddleware as registerMeshMiddleware } from './api_handlers/mesh_middleware';
 
+// Middleware registration. The order is important.
 registerEntityExistenceMiddleware(getDefaultRequestHandler());
-
 if (meshEnabled) {
     registerMeshMiddleware(getDefaultRequestHandler());
 }
+registerExternalConnAuthMiddleware(getDefaultRequestHandler());
 
 export function initApiHandlers() {
     /* tslint:disable: no-unused-variable */
     initApplicationApiHandler();
     const externalApplicationApiHandler = new ExternalApplicationApiHandler();
-    const authorizationApiHandler = new AuthorizationApiHandler();
+    initAuthorizationApiHandler();
     initClipboardAPIHandler();
     const eventListenerApiHandler = new EventListenerApiHandler();
     const interApplicationBusApiHandler = new InterApplicationBusApiHandler();


### PR DESCRIPTION
ℹ️ Adds auth middleware that prevents unauthenticated WebSocket connections making API calls.

---

➕  **New Test**
• [WS API call w/o authentication](https://testing-dashboard.openfin.co/#/app/tests/597f8383a3c7663182519014/edit)

---

⚠️ **Diff** for `/api_handlers/authorization.js` file looks crazy (because of indentation changes throughout the file), but the only changes to that file are:
1. Made it NOT be a class
2. added `init` function in place of previously having to instantiate class
3. added auth middleware function `isConnectionAuthenticated` and its registration in `registerMiddleware`

---

✅  **Test Results** *(ignore new multi-preload scripts test errors, they are invalid)*
• [Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/597f90748b67d4711b9a9610)
• [Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/597f90dd8b67d4711b9a9612)
• Node-adapter all (84) tests passed
• Java-adapter all tests passed