### PR TITLE
RUN-3158 preload state will be stored in core state

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -763,6 +763,14 @@ Window.create = function(id, opts) {
         _window: browserWindow
     };
 
+    // Set initial preload state if window has preload script
+    if (_options.preload) {
+        winObj.preloadState = {
+            src: _options.preload,
+            state: 'idle'
+        };
+    }
+
     if (!coreState.getWinObjById(id)) {
         coreState.setWindowObj(id, winObj);
 

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -91,6 +91,16 @@ export interface OpenFinWindow {
     id: number;
     name: string;
     uuid: string;
+    preloadState?: { // set if window has a preload script
+        src: String;
+        state:
+            'idle'| // initial state, not emitted, really here for internal use
+            'load-started'| // started loading/downloading the script file
+            'load-failed'| // failed to load/download the script file
+            'load-succeeded'| // preload script's content is loaded and ready to be eval'ed
+            'failed'| // preload script failed to eval
+            'succeeded'; // preload script eval'ed successfully
+    }[];
 }
 
 export interface BrowserWindow {


### PR DESCRIPTION
ℹ️  This PR sets up the stage for subsequent preload script state changes.
State of the preload script will be located in OpenFinWindow object in the core state.
The list of available states shown here will be documented in JavaScript adapter and paired up with another PR.

---

✅  **Test results**
*Note: 2 new fails you see also happen when running against the latest develop. This PR does not introduce new regressions. These errors are likely due to runtime and core versions mismatch.*
• [Windows 7]()
• [Windows 10]()