### PR TITLE
RUN-3125 added ability to query preload state

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -1029,15 +1029,18 @@ Window.getGroup = function(identity) {
 
 
 Window.getWindowInfo = function(identity) {
-    let browserWindow = getElectronBrowserWindow(identity, 'get info for');
-    let webContents = browserWindow.webContents;
-
-    return {
-        url: webContents.getURL(),
-        title: webContents.getTitle(),
+    const browserWindow = getElectronBrowserWindow(identity, 'get info for');
+    const openfinWindow = Window.wrap(identity.uuid, identity.name);
+    const webContents = browserWindow.webContents;
+    const windowInfo = {
+        canNavigateBack: webContents.canGoBack(),
         canNavigateForward: webContents.canGoForward(),
-        canNavigateBack: webContents.canGoBack()
+        preloadState: openfinWindow.preloadState,
+        title: webContents.getTitle(),
+        url: webContents.getURL()
     };
+
+    return windowInfo;
 };
 
 


### PR DESCRIPTION
ℹ️  Adds ability to query for preload state by retrieving window info

🔗 **Paired** with [this PR](https://github.com/openfin/javascript-adapter/pull/318) which documents new window info payload

---

➕ New test:
• [Window.getInfo T2 (preloadState)](https://testing-dashboard.openfin.co/#/app/tests/59774ef9a3c7663182518fca/edit)

---

Local tests pass. **No public test results** because this PR depends on the [previous PR](https://github.com/HadoukenIO/core/pull/128). Will post them after previous PR is consumed.