### PR TITLE
RUN-3140 RUN-3141 additional logging calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -388,7 +388,7 @@ function includeFlashPlugin() {
 }
 
 function initializeCrashReporter(argo) {
-    const configUrl = argo['startup-url'];
+    const configUrl = argo['startup-url'] || argo['config'];
     const diagnosticMode = argo['diagnostics'] || false;
     const enableCrashReporting = argo['enable-crash-reporting'];
     const shouldStartCrashReporter = enableCrashReporting || diagnosticMode;

--- a/index.js
+++ b/index.js
@@ -64,7 +64,6 @@ import route from './src/common/route';
 
 // locals
 let firstApp = null;
-let crashReporterEnabled = false;
 let rvmBus;
 let otherInstanceRunning = false;
 let appIsReady = false;
@@ -389,14 +388,13 @@ function includeFlashPlugin() {
 }
 
 function initializeCrashReporter(argo) {
-    if (!crashReporterEnabled && argo['enable-crash-reporting']) {
-        crashReporter.start({
-            productName: 'OpenFin',
-            companyName: 'OpenFin',
-            submitURL: 'https://dl.openfin.co/services/crash-report',
-            autoSubmit: true
-        });
-        crashReporterEnabled = true;
+    const enableCrashReporting = argo['enable-crash-reporting'];
+    const diagnosticMode = argo['diagnostics'] || false;
+    const configUrl = argo['startup-url'];
+    const shouldStartCrashReporter = enableCrashReporting || diagnosticMode;
+
+    if (shouldStartCrashReporter) {
+        crashReporter.startOFCrashReporter({ diagnosticMode, configUrl });
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -388,9 +388,9 @@ function includeFlashPlugin() {
 }
 
 function initializeCrashReporter(argo) {
-    const enableCrashReporting = argo['enable-crash-reporting'];
-    const diagnosticMode = argo['diagnostics'] || false;
     const configUrl = argo['startup-url'];
+    const diagnosticMode = argo['diagnostics'] || false;
+    const enableCrashReporting = argo['enable-crash-reporting'];
     const shouldStartCrashReporter = enableCrashReporting || diagnosticMode;
 
     if (shouldStartCrashReporter) {

--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -22,6 +22,7 @@ const electronApp = electron.app;
 const ResourceFetcher = electron.resourceFetcher;
 const session = electron.session;
 const shell = electron.shell;
+const crashReporter = require('electron').crashReporter;
 
 // npm modules
 const path = require('path');
@@ -248,6 +249,9 @@ exports.System = {
     },
     getConfig: function() {
         return coreState.getStartManifest();
+    },
+    getCrashReporterState: function() {
+        return crashReporter.crashReporterState();
     },
     getDeviceUserId: function() {
         const hash = crypto.createHash('sha256');
@@ -492,6 +496,12 @@ exports.System = {
     },
 
     showChromeNotificationCenter: function() {},
+    startCrashReporter: function(identity, options) {
+        const configUrl = coreState.argo['startup-url'];
+
+        crashReporter.startOFCrashReporter(Object.assign({ configUrl }, options));
+        return crashReporter.crashReporterState();
+    },
     terminateExternalProcess: function(processUuid, timeout = 3000, child = false) {
         let status = ProcessTracker.terminate(processUuid, timeout, child);
 

--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -497,7 +497,7 @@ exports.System = {
 
     showChromeNotificationCenter: function() {},
     startCrashReporter: function(identity, options) {
-        const configUrl = coreState.argo['startup-url'];
+        const configUrl = coreState.argo['startup-url'] || coreState.argo['config'];
         const reporterOptions = Object.assign({ configUrl }, options);
         crashReporter.startOFCrashReporter(reporterOptions);
 

--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -22,7 +22,7 @@ const electronApp = electron.app;
 const ResourceFetcher = electron.resourceFetcher;
 const session = electron.session;
 const shell = electron.shell;
-const crashReporter = require('electron').crashReporter;
+const { crashReporter } = electron;
 
 // npm modules
 const path = require('path');
@@ -498,8 +498,9 @@ exports.System = {
     showChromeNotificationCenter: function() {},
     startCrashReporter: function(identity, options) {
         const configUrl = coreState.argo['startup-url'];
+        const reporterOptions = Object.assign({ configUrl }, options);
+        crashReporter.startOFCrashReporter(reporterOptions);
 
-        crashReporter.startOFCrashReporter(Object.assign({ configUrl }, options));
         return crashReporter.crashReporterState();
     },
     terminateExternalProcess: function(processUuid, timeout = 3000, child = false) {

--- a/src/browser/api_protocol/api_handlers/system.js
+++ b/src/browser/api_protocol/api_handlers/system.js
@@ -35,6 +35,7 @@ function SystemApiHandler() {
         'get-all-windows': getAllWindows,
         'get-command-line-arguments': { apiFunc: getCommandLineArguments, apiPath: '.getCommandLineArguments' },
         'get-config': { apiFunc: getConfig, apiPath: '.getConfig' },
+        'get-crash-reporter-state': getCrashReporterState,
         'get-device-id': { apiFunc: getDeviceId, apiPath: '.getDeviceId' },
         'get-device-user-id': getDeviceUserId,
         'get-el-ipc-config': getElIPCConfig,
@@ -60,6 +61,7 @@ function SystemApiHandler() {
         //'set-clipboard': setClipboard, -> moved to clipboard.ts
         'set-cookie': setCookie,
         'show-developer-tools': showDeveloperTools,
+        'start-crash-reporter': startCrashReporter,
         'terminate-external-process': { apiFunc: terminateExternalProcess, apiPath: '.terminateExternalProcess' },
         'update-proxy': updateProxy,
         'view-log': { apiFunc: viewLog, apiPath: '.getLog' },
@@ -67,9 +69,20 @@ function SystemApiHandler() {
         'download-preload-scripts': downloadPreloadScripts //internal function
     };
 
-
-
     apiProtocolBase.registerActionMap(SystemApiHandlerMap, 'System');
+
+    function startCrashReporter(identity, message, ack) {
+        let dataAck = _.clone(successAck);
+        const { payload } = message;
+        dataAck.data = System.startCrashReporter(identity, payload, false);
+        ack(dataAck);
+    }
+
+    function getCrashReporterState(identity, message, ack) {
+        let dataAck = _.clone(successAck);
+        dataAck.data = System.getCrashReporterState();
+        ack(dataAck);
+    }
 
     function downloadPreloadScripts(identity, message, ack, nack) {
         const { payload } = message;

--- a/src/browser/api_protocol/api_handlers/system.js
+++ b/src/browser/api_protocol/api_handlers/system.js
@@ -72,14 +72,14 @@ function SystemApiHandler() {
     apiProtocolBase.registerActionMap(SystemApiHandlerMap, 'System');
 
     function startCrashReporter(identity, message, ack) {
-        let dataAck = _.clone(successAck);
+        const dataAck = _.clone(successAck);
         const { payload } = message;
         dataAck.data = System.startCrashReporter(identity, payload, false);
         ack(dataAck);
     }
 
     function getCrashReporterState(identity, message, ack) {
-        let dataAck = _.clone(successAck);
+        const dataAck = _.clone(successAck);
         dataAck.data = System.getCrashReporterState();
         ack(dataAck);
     }


### PR DESCRIPTION
@StevenEBarbaro @rdepena @joneit 

[needs adapter](https://github.com/openfin/javascript-adapter/pull/322)

tests well (parody with vanilla for me):
[general](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/598c6d8fd2a02971da3a6299)
[initially failed...](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/598c7b68d2a02971da3a62a9)
[additional](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/598c7c5ed2a02971da3a62aa)