### PR TITLE
VS 2013 is MIA, point to VS 2015 build tools for building on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 #### Requirements
 _The following setup is known to be working well. You can try other versions at your 
 own risk of losing a lot of time._
-* [Visual Studio 2013](https://www.microsoft.com/en-us/download/details.aspx?id=44914) *
+* [Visual Studio 2015 Build Tools](http://landinghub.visualstudio.com/visual-cpp-build-tools) *
 * [Node](https://nodejs.org/download/release/v6.9.0/) 6.9.0
 * Grunt (`grunt-cli` 1.2.0)
 * [Python 2.7.12](https://www.python.org/downloads/release/python-2712/)
@@ -23,7 +23,7 @@ npm install
 #### Windows
 You need to ensure that Visual Studio 2013 is used to build the project.
 ```bash
-npm update -msvs_version=2013
+npm update -msvs_version=2015
 npm install
 ```
 


### PR DESCRIPTION
Microsoft has turned links for VS 2013 into a black hole. The VS 2015 build tools will let you build the project. Contains updated link & instruction.