### PR TITLE
RUN-3228 Remove unneeded `mustSucceed` preload script option

### DIFF
--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -541,16 +541,15 @@ limitations under the License.
         if (response.error) {
             console.error(response.error);
         } else {
-            response.scripts.find((script, index) => {
-                const { url, mustSucceed } = preloadOption[index];
+            response.scripts.forEach((script, index) => {
+                const { url } = preloadOption[index];
 
                 try {
                     window.eval(script); /* jshint ignore:line */
                     asyncApiCall(action, { url, state: 'succeeded' });
                 } catch (err) {
-                    console.error(`Execution failed for preload script "${url}"; remaining scripts canceled.`, err);
+                    console.error(`Execution failed for preload script "${url}".`, err);
                     asyncApiCall(action, { url, state: 'failed' });
-                    return mustSucceed; // aborts .find() when a must-succeed script fails
                 }
             });
         }


### PR DESCRIPTION
Regression [**tests**](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/598de08ad2a02971da3a62bf) passed (no relevant fails).