### PR TITLE
RUN-3265 fixed falsy preload

### DIFF
--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -263,10 +263,15 @@ module.exports = {
             newOptions.permissions = options.permissions;
         }
 
-        if (typeof options.preload === 'string') {
-            newOptions.preload = [{ url: options.preload }];
+        const preload = options.preload;
+        if (!preload) {
+            newOptions.preload = []; // for all falsy values
         } else {
-            newOptions.preload = options.preload || [];
+            if (typeof preload === 'string') {
+                newOptions.preload = [{ url: preload }]; // backward compatibility
+            } else {
+                newOptions.preload = preload;
+            }
         }
 
         if (returnAsString) {

--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -265,13 +265,13 @@ module.exports = {
 
         const preload = options.preload;
         if (!preload) {
-            newOptions.preload = []; // for all falsy values
+            // for all falsy values
+            newOptions.preload = [];
+        } else if (typeof preload === 'string') {
+            // backward compatibility
+            newOptions.preload = [{ url: preload }];
         } else {
-            if (typeof preload === 'string') {
-                newOptions.preload = [{ url: preload }]; // backward compatibility
-            } else {
-                newOptions.preload = preload;
-            }
+            newOptions.preload = preload;
         }
 
         if (returnAsString) {

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -427,7 +427,7 @@ limitations under the License.
         let webContentsId = getWebContentsId();
         // Reset state machine values that are set through synchronous handshake between native WebContent lifecycle observers and JS
         options.openfin = true;
-        options.preload = options.preload || winOpts.preload;
+        options.preload = 'preload' in options ? options.preload : winOpts.preload;
         options.uuid = winOpts.uuid;
         let responseChannel = `${frameName}-created`;
         ipc.once(responseChannel, () => {


### PR DESCRIPTION
ℹ️   **Description**
Fixes support for falsy preload scripts

➕  **New test**
• [new Window (preload) (falsy value / reset)](https://testing-dashboard.openfin.co/#/app/tests/59944c83d2a02971da3a62d6/edit)

✅  **Test results**
• [Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/599492fed2a02971da3a62da)
• [Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5994935bd2a02971da3a62db)