### PR TITLE
RUN-3251 feature/toggle log levels

### DIFF
--- a/index.js
+++ b/index.js
@@ -398,17 +398,6 @@ function initializeCrashReporter(argo) {
     }
 }
 
-let nums = 0;
-setInterval(() => {
-    log.writeToLog(1, nums++, true);
-}, 4000);
-
-// setTimeout(() => {
-//     log.writeToLog(1, 'NOW', true);
-//     app.SetMinLogLevel(0);
-//     log.writeToLog(1, 'THEN', true);
-// }, 10000);
-
 function rotateLogs(argo) {
     // only keep the 7 most recent logfiles
     System.getLogList((err, files) => {

--- a/index.js
+++ b/index.js
@@ -398,6 +398,17 @@ function initializeCrashReporter(argo) {
     }
 }
 
+let nums = 0;
+setInterval(() => {
+    log.writeToLog(1, nums++, true);
+}, 4000);
+
+// setTimeout(() => {
+//     log.writeToLog(1, 'NOW', true);
+//     app.SetMinLogLevel(0);
+//     log.writeToLog(1, 'THEN', true);
+// }, 10000);
+
 function rotateLogs(argo) {
     // only keep the 7 most recent logfiles
     System.getLogList((err, files) => {

--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -39,18 +39,22 @@ import ofEvents from '../of_events';
 const ProcessTracker = require('../process_tracker.js');
 import route from '../../common/route';
 import { fetchAndLoadPreloadScripts } from '../preload_scripts';
-
+const verbose = 'verbose';
+const info = 'info';
+const warning = 'warning';
+const error = 'error';
+const fatal = 'fatal';
 const logLevelMappings = new Map([
-    ['verbose', -1],
-    ['info', 0],
-    ['warning', 1],
-    ['error', 2],
-    ['fatal', 3],
-    [-1, 'verbose'],
-    [0, 'info'],
-    [1, 'warning'],
-    [2, 'error'],
-    [3, 'fatal']
+    [verbose, -1],
+    [info, 0],
+    [warning, 1],
+    [error, 2],
+    [fatal, 3],
+    [-1, verbose],
+    [0, info],
+    [1, warning],
+    [2, error],
+    [3, fatal]
 ]);
 
 const defaultProc = {

--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -40,6 +40,18 @@ const ProcessTracker = require('../process_tracker.js');
 import route from '../../common/route';
 import { fetchAndLoadPreloadScripts } from '../preload_scripts';
 
+const logLevelMappings = new Map([
+    ['verbose', -1],
+    ['info', 0],
+    ['warning', 1],
+    ['error', 2],
+    ['fatal', 3],
+    [-1, 'verbose'],
+    [0, 'info'],
+    [1, 'warning'],
+    [2, 'error'],
+    [3, 'fatal']
+]);
 
 const defaultProc = {
     getCpuUsage: function() {
@@ -373,6 +385,15 @@ exports.System = {
             }
         });
     },
+    getMinLogLevel: function() {
+        try {
+            const logLevel = electronApp.getMinLogLevel();
+
+            return logLevelMappings.get(logLevel);
+        } catch (e) {
+            return e;
+        }
+    },
     getMonitorInfo: function() {
         return MonitorInfo.getInfo('api-query');
     },
@@ -466,6 +487,18 @@ exports.System = {
     },
     log: function(level, message) {
         return log.writeToLog(level, message, false);
+    },
+    setMinLogLevel: function(level) {
+        try {
+            const mappedLevel = logLevelMappings.get(level + '');
+
+            if (mappedLevel === undefined) {
+                throw new Error(`Invalid logging level: ${level}`);
+            }
+            electronApp.setMinLogLevel(mappedLevel);
+        } catch (e) {
+            return e;
+        }
     },
     debugLog: function(level, message) {
         return log.writeToLog(level, message, true);

--- a/src/browser/api_protocol/api_handlers/system.js
+++ b/src/browser/api_protocol/api_handlers/system.js
@@ -41,6 +41,7 @@ function SystemApiHandler() {
         'get-el-ipc-config': getElIPCConfig,
         'get-environment-variable': { apiFunc: getEnvironmentVariable, apiPath: '.getEnvironmentVariable' },
         'get-host-specs': { apiFunc: getHostSpecs, apiPath: '.getHostSpecs' },
+        'get-min-log-level': getMinLogLevel,
         'get-monitor-info': getMonitorInfo, // apiPath: '.getMonitorInfo' -> called by js adapter during init so can't be disabled
         'get-mouse-position': { apiFunc: getMousePosition, apiPath: '.getMousePosition' },
         'get-nearest-display-root': getNearestDisplayRoot,
@@ -60,6 +61,7 @@ function SystemApiHandler() {
         'resolve-uuid': resolveUuid,
         //'set-clipboard': setClipboard, -> moved to clipboard.ts
         'set-cookie': setCookie,
+        'set-min-log-level': setMinLogLevel,
         'show-developer-tools': showDeveloperTools,
         'start-crash-reporter': startCrashReporter,
         'terminate-external-process': { apiFunc: terminateExternalProcess, apiPath: '.terminateExternalProcess' },
@@ -70,6 +72,35 @@ function SystemApiHandler() {
     };
 
     apiProtocolBase.registerActionMap(SystemApiHandlerMap, 'System');
+
+    function didFail(e) {
+        return e !== undefined && e.constructor === Error;
+    }
+
+    function setMinLogLevel(identity, message, ack, nack) {
+        const { payload: { level } } = message;
+        const response = System.setMinLogLevel(level);
+
+        if (didFail(response)) {
+            nack(response);
+
+        } else {
+            ack(_.clone(successAck));
+        }
+    }
+
+    function getMinLogLevel(identity, message, ack, nack) {
+        const response = System.getMinLogLevel();
+
+        if (didFail(response)) {
+            nack(response);
+
+        } else {
+            const dataAck = _.clone(successAck);
+            dataAck.data = response;
+            ack(dataAck);
+        }
+    }
 
     function startCrashReporter(identity, message, ack) {
         const dataAck = _.clone(successAck);


### PR DESCRIPTION
Adds the ability to toggle the verbosity levels programmaticly.

Needs [adapter PR](https://github.com/openfin/javascript-adapter/pull/328)
Needs [runtime PR](https://github.com/openfin/runtime/pull/582)

[tests](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/599668e5d2a02971da3a62e7) (fails passed in isolation / parody with vanilla build) 
[added tests](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59966fd0d2a02971da3a62ed)