### PR TITLE
RUN-3275 Always re/fetch local preload script files

### DIFF
--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -74,7 +74,8 @@ const defaultProc = {
     }
 };
 
-const preloadScriptsCache = {};
+let preloadScriptsCache;
+clearPreloadCache();
 
 let MonitorInfo;
 let Session;
@@ -171,16 +172,21 @@ exports.System = {
             cookies: true,
             localStorage: true,
             appcache: true,
-            userData: true // TODO: userData is the window bounds cache
+            userData: true, // TODO: userData is the window bounds cache
+            preload: true
         });
         */
         var settings = options || {};
+
+        if (settings.preload) {
+            clearPreloadCache();
+        }
 
         var availableStorages = ['appcache', 'cookies', 'filesystem', 'indexdb', 'localstorage', 'shadercache', 'websql', 'serviceworkers'];
         var storages = [];
 
         if (typeof settings.localStorage === 'boolean') {
-            settings['localstorage'] = settings.localStorage;
+            settings.localstorage = settings.localStorage;
         }
 
         // 5.0 defaults cache true if not specified
@@ -210,11 +216,12 @@ exports.System = {
         electronApp.vlog(1, `clearCache ${JSON.stringify(storages)}`);
 
         defaultSession.clearCache(() => {
-
             defaultSession.clearStorageData(cacheOptions, () => {
                 resolve();
             });
         });
+
+
     },
     deleteCacheOnExit: function(callback, errorCallback) {
         const folders = [{
@@ -636,6 +643,8 @@ exports.System = {
         }
     },
 
+    clearPreloadCache,
+
     downloadPreloadScripts: function(identity, preloadOption, cb) {
         fetchAndLoadPreloadScripts(identity, preloadOption, cb);
     },
@@ -668,3 +677,7 @@ exports.System = {
         return response;
     }
 };
+
+function clearPreloadCache() {
+    preloadScriptsCache = {};
+}

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -545,14 +545,14 @@ limitations under the License.
                 console.error(response.error);
             } else {
                 response.scripts.forEach((script, index) => {
-                    const {url} = preloadOption[index];
+                    const { url } = preloadOption[index];
 
                     try {
                         window.eval(script); /* jshint ignore:line */
-                        asyncApiCall(action, {url, state: 'succeeded'});
+                        asyncApiCall(action, { url, state: 'succeeded' });
                     } catch (err) {
                         console.error(`Execution failed for preload script "${url}".`, err);
-                        asyncApiCall(action, {url, state: 'failed'});
+                        asyncApiCall(action, { url, state: 'failed' });
                     }
                 });
             }


### PR DESCRIPTION
\[See sister [PR#330](https://github.com/openfin/javascript-adapter/pull/330) in openfin/javascript-adapter.]
 
### This PR:

@omerli points out local files normally bypass Chromium cache anyway and therefore _would always be reloaded on every page;_ and to aid app development, we should do the same. 

1. **Adjust logic to always reload local files** on `new Window({preload:'file://...'})`, even if already loaded by a previously created window.<br>
_Specifically:_ Local files (resources with `file://` scheme) are now _excepted_ from our _temporary_ work-around that generally _avoids_ re-fetching/loading previously loaded preload scripts. (Workaround to be removed by [RUN-3227](https://appoji.jira.com/browse/RUN-3227) once [RUN-3162](https://appoji.jira.com/browse/RUN-3162) is resolved.)<br>
_Caveat:_ Normal page refresh does _not_ reload local files, only on `new Window`.<br><br>
2. **Add a `preload` option** to `fin.desktop.System.clearCache`.<br>
So now app developer can type `fin.desktop.System.clearCache({preload:true})` into console and then reload page to refetch a (presumably modified) preload scripts.

### Tests:
Tested locally. I could add my tests for both items above to test runner's manual test suite though not sure if its worth the effort because:
* test would require a lot of effort (would have to rewrite script files) 
* these were simple changes already tested manually 
* item 1 above is temporary until better resource fetcher comes along