### PR TITLE
RUN-3269 fixed the isConnectionAuthenticated check to include multi runtime

### DIFF
--- a/src/browser/api_protocol/api_handlers/authorization.js
+++ b/src/browser/api_protocol/api_handlers/authorization.js
@@ -215,15 +215,16 @@ module.exports.init = function() {
 
 const isConnectionAuthenticated = (msg, next) => {
     const { data, nack, identity, strategyName } = msg;
-    const { uuid } = identity;
+    const { runtimeUuid, uuid } = identity;
     const action = data && data.action;
+    const uuidToCheck = runtimeUuid || uuid; //determine if the msg came as a forwarded action from a peer runtime.
 
     // Prevent all API calls from unauthenticated external connections,
     // except for authentication APIs
     if (
         strategyName === 'WebSocketStrategy' && // external connection
         !authenticationApiMap.hasOwnProperty(action) && // not an authentication action
-        !ExternalApplication.getExternalConnectionByUuid(uuid) // connection not authenticated
+        !ExternalApplication.getExternalConnectionByUuid(uuidToCheck) // connection not authenticated
     ) {
         return nack(new Error('This connection must be authenticated first'));
     }


### PR DESCRIPTION
Forwarded requests were being incorrectly flaged as not being authenticated.