### PR TITLE
RUN-3271 Ignore run-application for entity existence checks for now as it breaks behaviour contracts with Adapters.

### DIFF
--- a/src/browser/api_protocol/api_handlers/middleware_entity_existence.ts
+++ b/src/browser/api_protocol/api_handlers/middleware_entity_existence.ts
@@ -24,6 +24,8 @@ const apisToIgnore = new Set([
     // Application
     'create-application',
     'create-child-window',
+    //TODO: we do not check run for .NET, the adapter will create an application then run it without waiting for the ack.
+    'run-application',
     // Window
     'window-exists'
 ]);


### PR DESCRIPTION
Tests are currently running...