### PR TITLE
RUN-3136 Limit accelerator registration per options

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -26,7 +26,7 @@
                                 //   "single" : require single quotes
                                 //   "double" : require double quotes
     "undef"         : true,     // true: Require all non-global variables to be declared (prevents global leaks)
-    "unused"        : true,     // Unused variables:
+    "unused"        : "vars",   // Unused variables:
                                 //   true     : all variables, last function parameter
                                 //   "vars"   : all variables only
                                 //   "strict" : all variables, all function parameters

--- a/index.js
+++ b/index.js
@@ -610,15 +610,15 @@ function registerShortcuts() {
         const webContents = browserWindow.webContents;
 
         if (accelerator.zoom) {
-            const zoom = zoomIn => { return () => { webContents.send('zoom', zoomIn, zoomIn === undefined); }; };
+            const zoom = zoomIncrement => { return () => { webContents.send('zoom', zoomIncrement); }; };
 
-            globalShortcut.register('CommandOrControl+0', zoom(undefined));
+            globalShortcut.register('CommandOrControl+0', zoom(0));
 
-            globalShortcut.register('CommandOrControl+=', zoom(true));
-            globalShortcut.register('CommandOrControl+Plus', zoom(true));
+            globalShortcut.register('CommandOrControl+=', zoom(+1));
+            globalShortcut.register('CommandOrControl+Plus', zoom(+1));
 
-            globalShortcut.register('CommandOrControl+-', zoom(false));
-            globalShortcut.register('CommandOrControl+_', zoom(false));
+            globalShortcut.register('CommandOrControl+-', zoom(-1));
+            globalShortcut.register('CommandOrControl+_', zoom(-1));
         }
 
         if (accelerator.devtools) {

--- a/index.js
+++ b/index.js
@@ -604,90 +604,43 @@ function initFirstApp(configObject, configUrl, licenseKey) {
 }
 
 function registerShortcuts() {
-    const resetZoomShortcut = 'CommandOrControl+0';
-    const zoomInShortcut = 'CommandOrControl+=';
-    const zoomInShiftShortcut = 'CommandOrControl+Plus';
-    const zoomOutShortcut = 'CommandOrControl+-';
-    const zoomOutShiftShortcut = 'CommandOrControl+_';
-    const devToolsShortcut = 'CommandOrControl+Shift+I';
-    const reloadF5Shortcut = 'F5';
-    const reloadShiftF5Shortcut = 'Shift+F5';
-    const reloadCtrlRShortcut = 'CommandOrControl+R';
-    const reloadCtrlShiftRShortcut = 'CommandOrControl+Shift+R';
+    app.on('browser-window-focus', (event, browserWindow) => {
+        const windowOptions = coreState.getWindowOptionsById(browserWindow.id);
+        const accelerator = windowOptions && windowOptions.accelerator || {};
+        const webContents = browserWindow.webContents;
 
-    let zoom = (zoomIn, reset = false) => {
-        return () => {
-            let browserWindow = BrowserWindow.getFocusedWindow();
-            let windowOptions = browserWindow && coreState.getWindowOptionsById(browserWindow.id);
+        if (accelerator.zoom) {
+            const zoom = zoomIn => { return () => { webContents.send('zoom', zoomIn, zoomIn === undefined); }; };
 
-            if (windowOptions && windowOptions.accelerator && windowOptions.accelerator.zoom) {
-                browserWindow.webContents.send('zoom', zoomIn, reset);
-            }
-        };
-    };
+            globalShortcut.register('CommandOrControl+0', zoom(undefined));
 
-    let reload = () => {
-        let browserWindow = BrowserWindow.getFocusedWindow();
-        let windowOptions = browserWindow && coreState.getWindowOptionsById(browserWindow.id);
+            globalShortcut.register('CommandOrControl+=', zoom(true));
+            globalShortcut.register('CommandOrControl+Plus', zoom(true));
 
-        if (windowOptions && windowOptions.accelerator && windowOptions.accelerator.reload) {
-            browserWindow.webContents.reload();
+            globalShortcut.register('CommandOrControl+-', zoom(false));
+            globalShortcut.register('CommandOrControl+_', zoom(false));
         }
-    };
 
-    let reloadIgnoringCache = () => {
-        let browserWindow = BrowserWindow.getFocusedWindow();
-        let windowOptions = browserWindow && coreState.getWindowOptionsById(browserWindow.id);
-
-        if (windowOptions && windowOptions.accelerator && windowOptions.accelerator.reloadIgnoringCache) {
-            browserWindow.webContents.reloadIgnoringCache();
+        if (accelerator.devtools) {
+            const devtools = () => { webContents.openDevTools(); };
+            globalShortcut.register('CommandOrControl+Shift+I', devtools);
         }
-    };
 
-    app.on('browser-window-focus', () => {
-        globalShortcut.register(resetZoomShortcut, zoom(undefined, true));
-        globalShortcut.register(zoomInShortcut, zoom(true));
-        globalShortcut.register(zoomInShiftShortcut, zoom(true));
-        globalShortcut.register(zoomOutShortcut, zoom(false));
-        globalShortcut.register(zoomOutShiftShortcut, zoom(false));
+        if (accelerator.reload) {
+            const reload = () => { webContents.reload(); };
+            globalShortcut.register('F5', reload);
+            globalShortcut.register('CommandOrControl+R', reload);
+        }
 
-        globalShortcut.register(devToolsShortcut, () => {
-            let browserWindow = BrowserWindow.getFocusedWindow();
-            let windowOptions = browserWindow && coreState.getWindowOptionsById(browserWindow.id);
-
-            if (windowOptions && windowOptions.accelerator && windowOptions.accelerator.devtools) {
-                browserWindow.webContents.openDevTools();
-            }
-        });
-
-        globalShortcut.register(reloadF5Shortcut, reload);
-        globalShortcut.register(reloadShiftF5Shortcut, reloadIgnoringCache);
-        globalShortcut.register(reloadCtrlRShortcut, reload);
-        globalShortcut.register(reloadCtrlShiftRShortcut, reloadIgnoringCache);
+        if (accelerator.reloadIgnoringCache) {
+            const reloadIgnoringCache = () => { webContents.reloadIgnoringCache(); };
+            globalShortcut.register('Shift+F5', reloadIgnoringCache);
+            globalShortcut.register('CommandOrControl+Shift+R', reloadIgnoringCache);
+        }
     });
 
-    const unhookShortcuts = (event, bw) => {
-        let browserWindow = BrowserWindow.getFocusedWindow();
-        const sourceWindowExists = bw && !bw.isDestroyed();
-        const focusedWindowExists = browserWindow && !browserWindow.isDestroyed();
-        let unhook = !focusedWindowExists;
-
-        if (focusedWindowExists && sourceWindowExists) {
-            unhook = browserWindow.id === bw.id;
-        }
-
-        if (unhook) {
-            globalShortcut.unregister(resetZoomShortcut);
-            globalShortcut.unregister(zoomInShortcut);
-            globalShortcut.unregister(zoomInShiftShortcut);
-            globalShortcut.unregister(zoomOutShortcut);
-            globalShortcut.unregister(zoomOutShiftShortcut);
-            globalShortcut.unregister(devToolsShortcut);
-            globalShortcut.unregister(reloadF5Shortcut);
-            globalShortcut.unregister(reloadShiftF5Shortcut);
-            globalShortcut.unregister(reloadCtrlRShortcut);
-            globalShortcut.unregister(reloadCtrlShiftRShortcut);
-        }
+    const unhookShortcuts = (event, browserWindow) => {
+        globalShortcut.unregisterAll();
     };
 
     app.on('browser-window-closed', unhookShortcuts);

--- a/index.js
+++ b/index.js
@@ -610,7 +610,7 @@ function registerShortcuts() {
         const webContents = browserWindow.webContents;
 
         if (accelerator.zoom) {
-            const zoom = zoomIncrement => { return () => { webContents.send('zoom', zoomIncrement); }; };
+            const zoom = increment => { return () => { webContents.send('zoom', { increment }); }; };
 
             globalShortcut.register('CommandOrControl+0', zoom(0));
 

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -1561,7 +1561,8 @@ Window.getZoomLevel = function(identity, callback) {
 Window.setZoomLevel = function(identity, level) {
     let browserWindow = getElectronBrowserWindow(identity, 'set zoom level for');
 
-    browserWindow.webContents.setZoomLevel(level);
+    // browserWindow.webContents.setZoomLevel(level); // zooms all windows loaded from same domain
+    browserWindow.webContents.send('zoom', { level }); // zoom just this window
 };
 
 Window.onUnload = (identity) => {

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -172,13 +172,8 @@ limitations under the License.
     function wireUpZoomEvents() {
         // listen for zoom-in/out keyboard shortcut
         // messages sent from the browser process
-        ipc.on(`zoom-${renderFrameId}`, (event, zoomIn, reset) => {
-            if (reset) {
-                webFrame.setZoomLevel(0);
-            } else {
-                let level = Math.floor(webFrame.getZoomLevel());
-                webFrame.setZoomLevel(zoomIn ? ++level : --level);
-            }
+        ipc.on(`zoom-${renderFrameId}`, (event, zoomIncrement) => {
+            webFrame.setZoomLevel(zoomIncrement ? webFrame.getZoomLevel() + zoomIncrement : 0);
         });
 
         document.addEventListener('mousewheel', event => {

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -172,8 +172,12 @@ limitations under the License.
     function wireUpZoomEvents() {
         // listen for zoom-in/out keyboard shortcut
         // messages sent from the browser process
-        ipc.on(`zoom-${renderFrameId}`, (event, zoomIncrement) => {
-            webFrame.setZoomLevel(zoomIncrement ? webFrame.getZoomLevel() + zoomIncrement : 0);
+        ipc.on(`zoom-${renderFrameId}`, (event, zoom) => {
+            if ('level' in zoom) {
+                webFrame.setZoomLevel(zoom.level);
+            } else if ('increment' in zoom) {
+                webFrame.setZoomLevel(zoom.increment ? Math.floor(webFrame.getZoomLevel()) + zoom.increment : 0);
+            }
         });
 
         document.addEventListener('mousewheel', event => {


### PR DESCRIPTION
This PR only registers "shortcut" keys that are needed by the page.

Base on current `canary` (`8.56.24.3`).

[Tested](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/599ed18cd2a02971da3a633f) clean.

#### Registering accelerator shortcuts

Previously designated "shortcut" keys were always registered as accelerators, although their handlers only took action as needed. This defect pre-empted the DOM events from firing for those keys so registered.

This improvement allows DOM event handler/listeners to catch these keys in `keydown` handler —
 so long as they are not required per `options.accelerator`. This includes **F5**.

```js
function f5handler(e) {
    if (e.keyCode === 116) console.log('F5 pressed');
}

document.addEventListener('keydown', f5handler); // "listener"
// or:
document.onkeydown = f5handler; // "handler"
```

Documented in a new internal [wiki](https://github.com/openfin/Internal-Wiki/wiki/Trapping-F5-keypress).

#### jshint change

This PR also changes the jshint "no unused vars" rule to ignore unused formal params (in function definitions). I feel it is more helpful to keep unused formal params in place, especially for functions with mandated calling signatures, such as event handler, even when such vars are unused therein. Thoughts?