### PR TITLE
RUN-3286 App assets API does not work if not launched by manifest

### DIFF
--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -448,13 +448,12 @@ exports.System = {
         RvmInfoFetcher.fetch(sourceUrl, callback, errorCallback);
     },
     launchExternalProcess: function(identity, options, errDataCallback) { // Node-style callback used here
-        var appObject = coreState.getAppObjByUuid(identity.uuid);
-        options.srcUrl = (appObject || {})._configUrl;
+        options.srcUrl = coreState.getConfigUrlByUuid(identity.uuid);
 
         ProcessTracker.launch(identity, options, errDataCallback);
     },
     monitorExternalProcess: function(identity, options, callback, errorCallback) {
-        var payload = ProcessTracker.monitor(identity, Object.assign({
+        const payload = ProcessTracker.monitor(identity, Object.assign({
             monitor: true
         }, options));
 
@@ -569,8 +568,7 @@ exports.System = {
         return ofEvents.emit(eventName, eventArgs);
     },
     downloadAsset: function(identity, asset, cb) {
-        const appObject = coreState.getAppObjByUuid(identity.uuid);
-        const srcUrl = (appObject || {})._configUrl;
+        const srcUrl = coreState.getConfigUrlByUuid(identity.uuid);
         const downloadId = asset.downloadId;
 
         //setup defaults.

--- a/src/browser/api_protocol/api_handlers/authorization.js
+++ b/src/browser/api_protocol/api_handlers/authorization.js
@@ -99,9 +99,11 @@ function onRequestAuthorization(id, data) {
     const uuid = data.payload.uuid;
     const authObj = pendingAuthentications.get(uuid);
     const externalConnObj = Object.assign({}, data.payload, {
-        id,
-        configUrl: authObj.authReqPayload && authObj.authReqPayload.configUrl
+        id
     });
+    if (authObj && authObj.authReqPayload) {
+        externalConnObj.configUrl = authObj.authReqPayload.configUrl;
+    }
 
     //Check if the file and token were written.
 
@@ -124,14 +126,14 @@ function onRequestAuthorization(id, data) {
 
         rvmMessageBus.registerLicenseInfo({
             data: {
-                licenseKey: authObj.authReqPayload && authObj.authReqPayload.licenseKey,
-                client: authObj.authReqPayload && authObj.authReqPayload.client,
+                licenseKey: authObj && authObj.authReqPayload && authObj.authReqPayload.licenseKey,
+                client: authObj && authObj.authReqPayload && authObj.authReqPayload.client,
                 uuid,
                 parentApp: {
                     uuid: null
                 }
             }
-        }, authObj.authReqPayload && authObj.authReqPayload.configUrl);
+        }, authObj && authObj.authReqPayload && authObj.authReqPayload.configUrl);
 
         if (!success) {
             socketServer.closeConnection(id);
@@ -178,7 +180,7 @@ function authenticateUuid(authObj, authRequest, cb) {
 }
 
 function cleanPendingRequest(authObj) {
-    if (authObj.type === AUTH_TYPE.file) {
+    if (authObj && authObj.type === AUTH_TYPE.file) {
         fs.unlink(authObj.file, err => {
             //really don't care about this error but log it either way.
             log.writeToLog('info', err);

--- a/src/browser/core_state.ts
+++ b/src/browser/core_state.ts
@@ -211,7 +211,12 @@ export function getUuidBySourceUrl(sourceUrl: string): string|boolean {
 
 export function getConfigUrlByUuid(uuid: string): string|boolean {
     const app = getAppAncestor(uuid);
-    return app && app._configUrl;
+    if  (app && app._configUrl) {
+        return app._configUrl;
+    } else {
+        const externalApp = getExternalAncestor(uuid);
+        return externalApp && externalApp.configUrl;
+    }
 }
 
 export function setAppObj(id: number, appObj: Shapes.AppObj): Shapes.App|void {
@@ -513,6 +518,15 @@ export function getAppAncestor(descendantAppUuid: string): Shapes.App {
         return getAppAncestor(app.parentUuid);
     } else {
         return app;
+    }
+}
+
+function getExternalAncestor(descendantAppUuid: string): any {
+    const app = appByUuid(descendantAppUuid);
+    if (app && app.parentUuid) {
+        return getExternalAncestor(app.parentUuid);
+    } else {
+        return ExternalApplication.getExternalConnectionByUuid(descendantAppUuid);
     }
 }
 


### PR DESCRIPTION
Test results:
[Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/599f65a4d2a02971da3a6347
)
[Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/599f6542d2a02971da3a6346)

Also, fixed code in authorization.js according to [https://github.com/openfin/openfin/wiki/RVM-Protocol]().  created RUN-3290 to track the issue.

New versions of .net and Java adapters are required to test app asset APIs from external adapters.
