### PR TITLE
RUN-3161 Wait for ready-to-show

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -379,6 +379,11 @@ Window.create = function(id, opts) {
 
         browserWindow = BrowserWindow.fromId(id);
 
+        // set this listener up as soon as possible
+        browserWindow._whenReadyToShow = new Promise(ready => {
+            browserWindow.once('ready-to-show', ready);
+        });
+
         // this is a first pass at teardown. for now, push the unsubscribe
         // function for each subscription you make, on closed, remove them all
         // if you listen on 'closed' it will crash as your resources are
@@ -1724,10 +1729,7 @@ function applyAdditionalOptionsToWindowOnVisible(browserWindow, callback) {
                     callback();
                 } else {
                     // Version 8: Will be visible on the next tick
-                    browserWindow.once('ready-to-show', () => {
-                        browserWindow._readyToShowFiredAlready = true;
-                        callback();
-                    });
+                    browserWindow._whenReadyToShow.then(callback);
                 }
             }
         });

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -1720,14 +1720,14 @@ function applyAdditionalOptionsToWindowOnVisible(browserWindow, callback) {
     } else {
         browserWindow.once('visibility-changed', (event, isVisible) => {
             if (isVisible) {
-                if (browserWindow.isVisible()) {
+                if (browserWindow._readyToShowFiredAlready) {
                     callback();
-                    // Version 8: Will be visible on the next tick
-                    // TODO: Refactor to also use 'ready-to-show'
                 } else {
-                    setTimeout(() => {
+                    // Version 8: Will be visible on the next tick
+                    browserWindow.once('ready-to-show', () => {
+                        browserWindow._readyToShowFiredAlready = true;
                         callback();
-                    }, 1);
+                    });
                 }
             }
         });


### PR DESCRIPTION
I saved the state of `ready-to-show` event-fired directly on the `browserWindow` object (much as we save `_options` there). Seems like a good place for it inasmuch as it reflects `browserWindow` state. Nonetheless I throw it out there: Is there a better place for (what can also be thought of as) a window instance var?

@HarsimranSingh @StevenEBarbaro How do we test this? Is there already a v8 test for this (that tests the existing `setTimeout` solution)?

Based on current `canary` (`runtime-v8.56.24.10`).
Regression [tested](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59a30434d2a02971da3a6365) clean.