### PR TITLE
RUN-2905 win.show() restores maximized window

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -1373,6 +1373,12 @@ Window.show = function(identity, force = false) {
         return;
     }
 
+    if (browserWindow.isMaximized() && browserWindow.isVisible()) {
+        // RUN-2905. To match v5 behavior, for maximized window, avoid calling bw.showInactive() because it does an erroneous bw.restore().
+        // Likely an oversight on electron's part considering that an implicit restore _is_ needed for minimized or hidden windows.
+        return;
+    }
+
     let payload = {};
     let defaultAction = () => {
         if (!browserWindow.isMinimized()) {

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -1373,15 +1373,17 @@ Window.show = function(identity, force = false) {
         return;
     }
 
-    if (browserWindow.isMaximized() && browserWindow.isVisible()) {
-        // RUN-2905. To match v5 behavior, for maximized window, avoid calling bw.showInactive() because it does an erroneous bw.restore().
-        // Likely an oversight on electron's part considering that an implicit restore _is_ needed for minimized or hidden windows.
-        return;
-    }
-
     let payload = {};
     let defaultAction = () => {
-        if (!browserWindow.isMinimized()) {
+        const dontShow = (
+            browserWindow.isMinimized() ||
+
+            // RUN-2905: To match v5 behavior, for maximized window, avoid showInactive() because it does an
+            // erroneous restore(), an apparent Electron oversight (a restore _is_ needed in all other cases).
+            browserWindow.isMaximized() && browserWindow.isVisible()
+        );
+
+        if (!dontShow) {
             browserWindow.showInactive();
         }
     };


### PR DESCRIPTION
Regression [test](https://en.wikipedia.org/wiki/File_URI_scheme)ed.