### PR TITLE
RUN-3297: Support nonPersistent and nonPersistant

### DIFF
--- a/src/browser/core_state.ts
+++ b/src/browser/core_state.ts
@@ -490,10 +490,12 @@ export function shouldCloseRuntime(ignoreArray: string[]|undefined): boolean {
             conn => conn.nonPersistent === undefined || !conn.nonPersistent
         );
 
-        return !hasPersistentConnections && !getAllAppObjects().find(app =>
-            getAppRunningState(app.uuid) && // app is running
-            ignoredApps.indexOf(app.uuid) < 0 && // app is not being ignored
-            !app._options.nonPersistent // app is persistent
+        return !hasPersistentConnections && !getAllAppObjects().find(app => {
+            const nonPersistent = app._options.nonPersistent !== undefined ? app._options.nonPersistent : app._options.nonPersistant;
+            return getAppRunningState(app.uuid) && // app is running
+                ignoredApps.indexOf(app.uuid) < 0 && // app is not being ignored
+                !nonPersistent; // app is persistent
+            }
         );
     }
 }

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -187,6 +187,7 @@ export interface WindowOptions {
     minWidth?: number;
     name: string;
     nonPersistent?: boolean;
+    nonPersistant?: boolean;  // deprecated, backwards compatible
     opacity?: number;
     plugins?: boolean;
     preload?: string;


### PR DESCRIPTION
Changes for RUN-1939 got lost. 

Test Result 
[W10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59a72c47d2a02971da3a638b)
[W7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59a72b92d2a02971da3a638a)

REDI is waiting for this change.