### PR TITLE
Read javascript-adapter from dir and then asar; for ease of development

### DIFF
--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -19,7 +19,19 @@ let fs = require('fs');
 let path = require('path');
 let me = fs.readFileSync(path.join(__dirname, 'api-decorator.js'), 'utf8');
 
-let jsAdapter = fs.readFileSync(path.join(process.resourcesPath, 'adapter.asar', 'openfin-desktop.js'), 'utf8');
+// check resources/adapter/openfin-desktop.js then
+// resources/adapter.asar/openfin-desktop.js
+// for ease of developement
+let jsAdapter = '';
+const searchPaths = ['adapter', 'adapter.asar'];
+for (let adapterPath of searchPaths) {
+    try {
+        jsAdapter = fs.readFileSync(path.join(process.resourcesPath, adapterPath, 'openfin-desktop.js'), 'utf8');
+        break;
+    } catch (error) {
+        continue;
+    }
+}
 
 // Remove strict (Prevents, as of now, poorly understood memory lifetime scoping issues with remote module)
 me = me.slice(13);


### PR DESCRIPTION
Tests came back clean:
[Win 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59a876f8d2a02971da3a639d)
[Win 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59a87c0bd2a02971da3a639f)