### PR TITLE
RUN-3284 Add smallWindow flag and update move/resize functions

### DIFF
--- a/src/browser/animations.js
+++ b/src/browser/animations.js
@@ -246,10 +246,16 @@ function AnimationHandler(desiredInterval) {
                                 });
                             }
                             hwndToId[hwnd] = bw.id;
+                            if (bw.isMaximized()) {
+                                bw.unmaximize();
+                            }
 
                             const { x, y, width: w, height: h } = newBounds;
                             wt.setWindowPos(hwnd, { x, y, w, h, flags });
                         } else {
+                            if (bw.isMaximized()) {
+                                bw.unmaximize();
+                            }
                             bw.setBounds(newBounds);
                         }
                     }

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -1223,6 +1223,10 @@ Window.moveBy = function(identity, deltaLeft, deltaTop) {
     let left = toSafeInt(deltaLeft, 0);
     let top = toSafeInt(deltaTop, 0);
 
+    if (browserWindow.isMaximized()) {
+        browserWindow.unmaximize();
+    }
+
     // no need to call clipBounds here because width and height are not changing
     browserWindow.setBounds({
         x: currentBounds.x + left,
@@ -1243,6 +1247,10 @@ Window.moveTo = function(identity, x, y) {
     const currentBounds = browserWindow.getBounds();
     const safeX = toSafeInt(x);
     const safeY = toSafeInt(y);
+
+    if (browserWindow.isMaximized()) {
+        browserWindow.unmaximize();
+    }
 
     // no need to call clipBounds here because width and height are not changing
     browserWindow.setBounds({
@@ -1296,6 +1304,10 @@ Window.resizeBy = function(identity, deltaWidth, deltaHeight, anchor) {
         return;
     }
 
+    if (browserWindow.isMaximized()) {
+        browserWindow.unmaximize();
+    }
+
     let currentBounds = browserWindow.getBounds();
     let newWidth = toSafeInt(currentBounds.width + deltaWidth, currentBounds.width);
     let newHeight = toSafeInt(currentBounds.height + deltaHeight, currentBounds.height);
@@ -1314,6 +1326,10 @@ Window.resizeTo = function(identity, newWidth, newHeight, anchor) {
 
     if (!browserWindow) {
         return;
+    }
+
+    if (browserWindow.isMaximized()) {
+        browserWindow.unmaximize();
     }
 
     const currentBounds = browserWindow.getBounds();
@@ -1357,6 +1373,11 @@ Window.setAsForeground = function(identity) {
 Window.setBounds = function(identity, left, top, width, height) {
     let browserWindow = getElectronBrowserWindow(identity, 'set window bounds for');
     let bounds = browserWindow.getBounds();
+
+    if (browserWindow.isMaximized()) {
+        browserWindow.unmaximize();
+    }
+
     browserWindow.setBounds(clipBounds({
         x: toSafeInt(left, bounds.x),
         y: toSafeInt(top, bounds.y),
@@ -1399,6 +1420,10 @@ Window.showAt = function(identity, left, top, force = false) {
     };
     let defaultAction = () => {
         let currentBounds = browserWindow.getBounds();
+
+        if (browserWindow.isMaximized()) {
+            browserWindow.unmaximize();
+        }
 
         // no need to call clipBounds here because width and height are not changing
         browserWindow.setBounds({

--- a/src/browser/bounds_changed_state_tracker.js
+++ b/src/browser/bounds_changed_state_tracker.js
@@ -130,7 +130,7 @@ function BoundsChangedStateTracker(uuid, name, browserWindow) {
         var currentBounds = getCurrentBounds();
         var cachedBounds = getCachedBounds();
         var boundsCompare = compareBoundsResult(currentBounds, cachedBounds);
-        var stateMinMax = boundsCompare.state && currentBounds.state !== 'normal'; // maximized or minimized
+        var stateMin = boundsCompare.state && currentBounds.state === 'minimized';
 
         var eventType = isAdditionalChangeExpected ? 'bounds-changing' :
             'bounds-changed';
@@ -154,7 +154,7 @@ function BoundsChangedStateTracker(uuid, name, browserWindow) {
             positionChangedCriteria.push(positionChanged);
         }
 
-        if (boundsCompare.changed && !stateMinMax || force) {
+        if (boundsCompare.changed && !stateMin || force) {
 
             // returns true if any of the criteria are true
             var sizeChange = _.some(sizeChangedCriteria, (criteria) => {
@@ -230,8 +230,14 @@ function BoundsChangedStateTracker(uuid, name, browserWindow) {
                                 });
                             }
                             hwndToId[hwnd] = win.browserWindow.id;
+                            if (win.browserWindow.isMaximized()) {
+                                win.browserWindow.unmaximize();
+                            }
                             wt.setWindowPos(hwnd, { x, y, flags });
                         } else {
+                            if (win.browserWindow.isMaximized()) {
+                                win.browserWindow.unmaximize();
+                            }
                             // no need to call clipBounds here because width and height are not changing
                             win.browserWindow.setBounds({ x, y, width, height });
                         }

--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -90,6 +90,7 @@ function five0BaseOptions() {
         'saveWindowState': true,
         'shadow': false,
         'showTaskbarIcon': true,
+        'smallWindow': false,
         'state': 'normal',
         'taskbarIcon': '',
         'taskbarIconGroup': '',

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -211,6 +211,7 @@ export interface WindowOptions {
     show?: boolean;
     showTaskbarIcon?: boolean;
     skipTaskbar?: boolean;
+    smallWindow?: boolean;
     state?: 'maximized'|'minimized'|'normal';
     taskbarIcon?: string;
     taskbarIconGroup?: string;


### PR DESCRIPTION
By adding a `smallWindow` flag to allow for very small frameless windows, the move and resize code needs to be updated to preserve bounds-changed and window groups functionality.

runtime: https://github.com/openfin/runtime/pull/608
javascript-adapter: https://github.com/openfin/javascript-adapter/pull/337
