### PR TITLE
RUN-3296 Add navigation validation to Window.navigate API

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -47,6 +47,7 @@ let regex = require('../../common/regex');
 import SubscriptionManager from '../subscription_manager';
 let WindowGroups = require('../window_groups.js');
 import {
+    isValidNavigation,
     validateNavigation,
     navigationValidator
 } from '../navigation_validation';
@@ -1254,8 +1255,14 @@ Window.moveTo = function(identity, x, y) {
 };
 
 Window.navigate = function(identity, url) {
-    let browserWindow = getElectronBrowserWindow(identity, 'navigate');
-    browserWindow.webContents.loadURL(url);
+    const browserWindow = getElectronBrowserWindow(identity, 'navigate');
+    const valid = isValidNavigation(url, identity.uuid);
+
+    if (valid) {
+        browserWindow.webContents.loadURL(url);
+    }
+
+    return valid;
 };
 
 Window.navigateBack = function(identity) {

--- a/src/browser/api_protocol/api_handlers/window.js
+++ b/src/browser/api_protocol/api_handlers/window.js
@@ -219,13 +219,16 @@ function moveWindowBy(identity, message, ack) {
     ack(successAck);
 }
 
-function navigateWindow(identity, message, ack) {
+function navigateWindow(identity, message, ack, nack) {
     let payload = message.payload;
     let windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
     let url = payload.url;
 
-    Window.navigate(windowIdentity, url);
-    ack(successAck);
+    if (Window.navigate(windowIdentity, url)) {
+        ack(successAck);
+    } else {
+        nack(new Error('Navigation rejected.'));
+    }
 }
 
 function navigateWindowBack(identity, message, ack) {


### PR DESCRIPTION
`Window.navigate` now validates specified url against navigation rules. `nack` is now called if url not allowed (does not trigger `navigation-rejected` event).

Adding test [`Window.navigate (blacklisted url)`](https://testing-dashboard.openfin.co/#/app/tests/59a73763d2a02971da3a638c/edit) (currently set to private).

Ran regression [test](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59a843ecd2a02971da3a6399) (including private test + regression suite + integration suite).