### PR TITLE
RUN-3299 Handle undefined preload option more gracefully

### DIFF
--- a/src/browser/preload_scripts.ts
+++ b/src/browser/preload_scripts.ts
@@ -75,8 +75,10 @@ export function fetchAndLoadPreloadScripts(
 ): Promise<undefined> {
     let allLoaded: Promise<undefined>;
 
-    // convert legacy `preloadOption` option into modern `preloadOption` option
-    if (typeof preloadOption === 'string') {
+    if (!preloadOption) {
+        preloadOption = [];
+    } else if (typeof preloadOption === 'string') {
+        // convert legacy `preloadOption` option into modern `preloadOption` option
         preloadOption = [<PreloadInstance>{ url: preloadOption }];
     }
 


### PR DESCRIPTION
This just avoids logging an error for what it is being validated as a malformed preload option.
Regression [tests](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59a8814fd2a02971da3a63a1) clean.