### PR TITLE
RUN-3300 Cool down code cleanup

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -38,23 +38,17 @@ let clipBounds = require('../clip_bounds.js').default;
 let convertOptions = require('../convert_options.js');
 let coreState = require('../core_state.js');
 let ExternalWindowEventAdapter = require('../external_window_event_adapter.js');
-import {
-    cachedFetch
-} from '../cached_resource_fetcher';
+import { cachedFetch } from '../cached_resource_fetcher';
 let log = require('../log');
 import ofEvents from '../of_events';
 let regex = require('../../common/regex');
 import SubscriptionManager from '../subscription_manager';
 let WindowGroups = require('../window_groups.js');
-import {
-    validateNavigation,
-    navigationValidator
-} from '../navigation_validation';
-import {
-    toSafeInt
-} from '../../common/safe_int';
+import { validateNavigation, navigationValidator } from '../navigation_validation';
+import { toSafeInt } from '../../common/safe_int';
 import route from '../../common/route';
 import { getPreloadScriptState } from '../preload_scripts';
+import WindowsMessages from '../../microsoft';
 
 const subscriptionManager = new SubscriptionManager();
 const isWin32 = process.platform === 'win32';
@@ -934,10 +928,10 @@ Window.embed = function(identity, parentHwnd) {
     }
 
     if (isWin32) {
-        browserWindow.setMessageObserver(0x0100, parentHwnd); // WM_KEYDOWN
-        browserWindow.setMessageObserver(0x0101, parentHwnd); // WM_KEYUP
-        browserWindow.setMessageObserver(0x0104, parentHwnd); // WM_SYSKEYDOWN
-        browserWindow.setMessageObserver(0x0105, parentHwnd); // WM_SYSKEYUP
+        browserWindow.setMessageObserver(WindowsMessages.WM_KEYDOWN, parentHwnd);
+        browserWindow.setMessageObserver(WindowsMessages.WM_KEYUP, parentHwnd);
+        browserWindow.setMessageObserver(WindowsMessages.WM_SYSKEYDOWN, parentHwnd);
+        browserWindow.setMessageObserver(WindowsMessages.WM_SYSKEYUP, parentHwnd);
     }
 
     ofEvents.emit(route.window('embedded', identity.uuid, identity.name), {

--- a/src/browser/api_protocol/api_handlers/application.js
+++ b/src/browser/api_protocol/api_handlers/application.js
@@ -31,7 +31,7 @@ import route from '../../../common/route';
 import { WindowsMessages, SetWindowPosition, SysCommands } from '../../../microsoft';
 
 // some local sugar
-const getAppId = message => apiProtocolBase.getTargetApplicationIdentity(message.payload);
+const getTargetAppId = message => apiProtocolBase.getTargetApplicationIdentity(message.payload);
 
 module.exports.applicationApiMap = {
     'close-application': closeApplication,
@@ -69,32 +69,32 @@ module.exports.init = function() {
 function setTrayIcon(identity, rawMessage) {
     return new Promise((resolve, reject) => {
         const message = JSON.parse(JSON.stringify(rawMessage));
-        Application.setTrayIcon(getAppId(message), message.payload.enabledIcon, resolve, reject);
+        Application.setTrayIcon(getTargetAppId(message), message.payload.enabledIcon, resolve, reject);
     });
 }
 
 function getTrayIconInfo(identity, message) {
     return new Promise((resolve, reject) => {
-        Application.getTrayIconInfo(getAppId(message), resolve, reject);
+        Application.getTrayIconInfo(getTargetAppId(message), resolve, reject);
     });
 }
 
 function removeTrayIcon(identity, message) {
-    Application.removeTrayIcon(getAppId(message));
+    Application.removeTrayIcon(getTargetAppId(message));
 }
 
 function waitForHungApplication(identity, message) {
-    Application.wait(getAppId(message));
+    Application.wait(getTargetAppId(message));
 }
 
 function terminateApplication(identity, message) {
     return new Promise(resolve => {
-        Application.terminate(getAppId(message), resolve);
+        Application.terminate(getTargetAppId(message), resolve);
     });
 }
 
 function restartApplication(identity, message) {
-    Application.restart(getAppId(message));
+    Application.restart(getTargetAppId(message));
 }
 
 function createChildWindow(identity, message) {
@@ -110,7 +110,7 @@ function pingChildWindow(identity, message) {
 }
 
 function isApplicationRunning(identity, message) {
-    return Application.isRunning(getAppId(message));
+    return Application.isRunning(getTargetAppId(message));
 }
 
 function getApplicationManifest(identity, message) {
@@ -119,7 +119,7 @@ function getApplicationManifest(identity, message) {
 
         // When manifest URL is provided, will be retrieving a remote manifest
         if (!message.payload.hasOwnProperty('manifestUrl')) {
-            appIdentity = getAppId(message);
+            appIdentity = getTargetAppId(message);
         }
 
         Application.getManifest(appIdentity, message.payload.manifestUrl, resolve, reject);
@@ -127,7 +127,7 @@ function getApplicationManifest(identity, message) {
 }
 
 function getApplicationGroups(identity, message) {
-    const { uuid } = getAppId(message);
+    const { uuid } = getTargetAppId(message);
 
     // NOTE: the Window API returns a wrapped window with 'name' as a member,
     // while the adaptor expects it to be 'windowName'
@@ -150,7 +150,7 @@ function getApplicationGroups(identity, message) {
 }
 
 function getChildWindows(identity, message) {
-    return _.chain(Application.getChildWindows(getAppId(message)))
+    return _.chain(Application.getChildWindows(getTargetAppId(message)))
         .filter(function(c) {
             return c.name !== c.uuid;
         })
@@ -161,37 +161,35 @@ function getChildWindows(identity, message) {
 
 function getInfo(identity, message) {
     return new Promise((resolve, reject) => {
-        Application.getInfo(getAppId(message), resolve, reject);
+        Application.getInfo(getTargetAppId(message), resolve, reject);
     });
 }
 
 function getParentApplication(identity, message) {
-    return new Promise((resolve, reject) => {
-        const parentUuid = Application.getParentApplication(getAppId(message));
+    const parentUuid = Application.getParentApplication(getTargetAppId(message));
 
-        if (parentUuid) {
-            resolve(parentUuid);
-        } else {
-            reject(new Error('No parent application found'));
-        }
-    });
+    if (!parentUuid) {
+        throw new Error('No parent application found');
+    }
+
+    return parentUuid;
 }
 
 function getShortcuts(identity, message) {
     return new Promise((resolve, reject) => {
-        Application.getShortcuts(getAppId(message), resolve, reject);
+        Application.getShortcuts(getTargetAppId(message), resolve, reject);
     });
 }
 
 function setShortcuts(identity, message) {
     return new Promise((resolve, reject) => {
-        Application.setShortcuts(getAppId(message), message.payload.data, resolve, reject);
+        Application.setShortcuts(getTargetAppId(message), message.payload.data, resolve, reject);
     });
 }
 
 function closeApplication(identity, message) {
     return new Promise(resolve => {
-        Application.close(getAppId(message), !!message.payload.force, resolve);
+        Application.close(getTargetAppId(message), !!message.payload.force, resolve);
     });
 }
 
@@ -214,7 +212,7 @@ function notifyOnContentLoaded(identity, message) {
 function runApplication(identity, message) {
     return new Promise((resolve, reject) => {
         const { manifestUrl } = message.payload;
-        const appIdentity = getAppId(message);
+        const appIdentity = getTargetAppId(message);
         const { uuid } = appIdentity;
         let remoteSubscriptionUnSubscribe;
         const remoteSubscription = {
@@ -331,12 +329,12 @@ function externalWindowAction(identity, message) {
 
 function registerCustomData(identity, message) {
     return new Promise((resolve, reject) => {
-        Application.registerCustomData(getAppId(message), message.payload.data, resolve, reject);
+        Application.registerCustomData(getTargetAppId(message), message.payload.data, resolve, reject);
     });
 }
 
 function relaunchOnClose(identity, message) {
     return new Promise((resolve, reject) => {
-        Application.scheduleRestart(getAppId(message), resolve, reject);
+        Application.scheduleRestart(getTargetAppId(message), resolve, reject);
     });
 }

--- a/src/browser/api_protocol/api_handlers/authorization.js
+++ b/src/browser/api_protocol/api_handlers/authorization.js
@@ -11,15 +11,11 @@ import {
 } from '../../api/external_application';
 let coreState = require('../../core_state.js');
 import ofEvents from '../../of_events';
-let _ = require('underscore');
 let log = require('../../log');
 let socketServer = require('../../transports/socket_server').server;
 let ProcessTracker = require('../../process_tracker.js');
 const rvmMessageBus = require('../../rvm/rvm_message_bus').rvmMessageBus;
 import route from '../../../common/route';
-const successAck = {
-    success: true
-};
 
 const AUTH_TYPE = {
     file: 0,
@@ -37,26 +33,19 @@ var pendingAuthentications = new Map(),
         }
     };
 
-function registerExternalConnection(identity, message, ack) {
-    let uuidToRegister = message.payload.uuid;
+function registerExternalConnection(identity, message) {
+    const { uuid } = message.payload;
     let token = electronApp.generateGUID();
-    let dataAck = _.clone(successAck);
-    dataAck.data = {
-        uuid: uuidToRegister,
-        token
-    };
 
-    addPendingAuthentication(uuidToRegister, token, null, identity, null);
-    ack(dataAck);
+    addPendingAuthentication(uuid, token, null, identity, null);
+
+    return { uuid, token };
 }
 
 function onRequestExternalAuth(id, message) {
     console.log('processing request-external-authorization', message);
 
-    let {
-        uuid: uuidRequested,
-        pid
-    } = message.payload;
+    const { uuid: uuidRequested, pid } = message.payload;
 
     let extProcess, file, token;
 

--- a/src/browser/api_protocol/api_handlers/clipboard.ts
+++ b/src/browser/api_protocol/api_handlers/clipboard.ts
@@ -58,90 +58,47 @@ interface APIMessageClipboardExpanded extends APIMessage {
     };
 }
 
-function clipboardWrite(identity: Identity,
-                        message: APIMessageClipboardExpanded,
-                        ack: (payload: APIPayloadAck) => void) {
-    const {data, type} = message.payload;
-    ack({
-        success: true,
-        data: clipboard.write(data, type)
-    });
+function clipboardWrite(identity: Identity, message: APIMessageClipboardExpanded) {
+    const { data, type } = message.payload;
+    return clipboard.write(data, type);
 }
 
-function clipboardWriteRtf(identity: Identity,
-                           message: APIMessageClipboard,
-                           ack: (payload: APIPayloadAck) => void) {
-    const {data, type} = message.payload;
-    ack({
-        success: true,
-        data: clipboard.writeRtf(data, type)
-    });
+function clipboardWriteRtf(identity: Identity, message: APIMessageClipboard) {
+    const { data, type } = message.payload;
+    return clipboard.writeRtf(data, type);
 }
 
-function clipboardWriteHtml(identity: Identity,
-                            message: APIMessageClipboard,
-                            ack: (payload: APIPayloadAck) => void) {
-    const {data, type} = message.payload;
-    ack({
-        success: true,
-        data: clipboard.writeHtml(data, type)
-    });
+function clipboardWriteHtml(identity: Identity, message: APIMessageClipboard) {
+    const { data, type } = message.payload;
+    return clipboard.writeHtml(data, type);
 }
 
-function clipboardWriteText(identity: Identity,
-                            message: APIMessageClipboard,
-                            ack: (payload: APIPayloadAck) => void) {
-    const {data, type} = message.payload;
-    ack({
-        success: true,
-        data: clipboard.writeText(data, type)
-    });
+function clipboardWriteText(identity: Identity, message: APIMessageClipboard) {
+    const { data, type } = message.payload;
+    return clipboard.writeText(data, type);
 }
 
-function clipboardAvailableFormats(identity: Identity,
-                                   message: APIMessageClipboard,
-                                   ack: (payload: APIPayloadAck) => void) {
-    const {type} = message.payload;
-    ack({
-        success: true,
-        data: clipboard.availableFormats(type)
-    });
+function clipboardAvailableFormats(identity: Identity, message: APIMessageClipboard) {
+    const { type } = message.payload;
+    return clipboard.availableFormats(type);
 }
 
-function clipboardClear(identity: Identity,
-                        message: APIMessageClipboard,
-                        ack: (payload: APIPayloadAck) => void) {
-    const {type} = message.payload;
+function clipboardClear(identity: Identity, message: APIMessageClipboard) {
+    const { type } = message.payload;
     clipboard.clear(type);
-    ack({success: true});
 }
 
-function clipboardReadRtf(identity: Identity,
-                          message: APIMessageClipboard,
-                          ack: (payload: APIPayloadAck) => void) {
-    const {type} = message.payload;
-    ack({
-        success: true,
-        data: clipboard.readRtf(type)
-    });
+function clipboardReadRtf(identity: Identity, message: APIMessageClipboard) {
+    const { type } = message.payload;
+    return clipboard.readRtf(type);
 }
 
-function clipboardReadHtml(identity: Identity,
-                           message: APIMessageClipboard,
-                           ack: (payload: APIPayloadAck) => void) {
-    const {type} = message.payload;
-    ack({
-        success: true,
-        data: clipboard.readHtml(type)
-    });
+function clipboardReadHtml(identity: Identity, message: APIMessageClipboard) {
+    const { type } = message.payload;
+    return clipboard.readHtml(type);
 }
 
-function clipboardReadText(identity: Identity,
-                           message: APIMessageClipboard,
-                           ack: (payload: APIPayloadAck) => void) {
-    const {type} = message.payload;
-    ack({
-        success: true,
-        data: clipboard.readText(type)
-    });
+function clipboardReadText(identity: Identity, message: APIMessageClipboard) {
+    const { type } = message.payload;
+    return clipboard.readText(type);
 }

--- a/src/browser/api_protocol/api_handlers/event_listener.js
+++ b/src/browser/api_protocol/api_handlers/event_listener.js
@@ -38,11 +38,6 @@ import {
     addRemoteSubscription
 } from '../../remote_subscriptions';
 
-// locals
-const successAck = {
-    success: true
-};
-
 function isBrowserClient(uuid) {
     return connectionManager.connections.map((conn) => {
         return conn.portInfo.version + ':' + conn.portInfo.port;
@@ -151,7 +146,7 @@ function EventListenerApiHandler() {
         }
     };
 
-    function subToDesktopEvent(identity, message, ack) {
+    function subToDesktopEvent(identity, message) {
         let topic = message.payload.topic;
         let uuid = message.payload.uuid;
         let type = message.payload.type;
@@ -188,17 +183,15 @@ function EventListenerApiHandler() {
 
             apiProtocolBase.registerSubscription(unsubscribe, identity, topic, uuid, type, name);
         }
-        ack(successAck);
     }
 
-    function unSubToDesktopEvent(identity, message, ack) {
+    function unSubToDesktopEvent(identity, message) {
         let topic = message.payload.topic;
         let uuid = message.payload.uuid;
         let type = message.payload.type;
         let name = message.payload.name;
 
         apiProtocolBase.removeSubscription(identity, topic, uuid, type, name);
-        ack(successAck);
     }
 }
 

--- a/src/browser/api_protocol/api_handlers/notifications.ts
+++ b/src/browser/api_protocol/api_handlers/notifications.ts
@@ -26,9 +26,7 @@ const { writeToLog } = require('../../log');
 /* tslint:disable: function-name */
 function NotificationApiHandler() {
     const noteApiMap: ActionSpecMap = {
-        'notifications': (id: any, request: any, ack: any) => {
-            routeRequest(id, unpackGeneralMsg(request), ack);
-        },
+        'notifications': notifications,
         'send-action-to-notifications-center': normalizeAndDispatch
     };
 
@@ -37,28 +35,28 @@ function NotificationApiHandler() {
     return apiProtocolBase;
 }
 
-function normalizeAndDispatch(id: any, msg: any, ack: () => void): void {
-    const { action } = msg;
+function notifications(id: any, request: any) {
+    return new Promise((resolve, reject) => {
+        routeRequest(id, unpackGeneralMsg(request), resolve);
+    });
+}
 
-    switch (action) {
-        case 'send-action-to-notifications-center':
-            routeNoteCenterMessages(id, msg, ack);
-        break;
+function normalizeAndDispatch(id: any, msg: any) {
+    return new Promise((resolve, reject) => {
+        const {action} = msg;
 
-        default:
-        break;
-
-    }
+        switch (action) {
+            case 'send-action-to-notifications-center':
+                routeNoteCenterMessages(id, msg, resolve);
+                break;
+        }
+    });
 }
 
 // Route the messages that have the shape of the <= 5.0
 // 'send-action-to-notifications-center' messages
 function routeNoteCenterMessages(id: any, msg: any, ack: () => void) {
-    const {
-        payload: {
-            action,
-            payload: data
-        }} = msg;
+    const { payload: { action, payload: data } } = msg;
 
     switch (action) {
         case 'create-notification':

--- a/src/browser/api_protocol/api_handlers/system.js
+++ b/src/browser/api_protocol/api_handlers/system.js
@@ -69,30 +69,24 @@ function SystemApiHandler() {
 
     apiProtocolBase.registerActionMap(SystemApiHandlerMap, 'System');
 
-    function didFail(e) {
-        return e !== undefined && e.constructor === Error;
-    }
-
     function setMinLogLevel(identity, message) {
-        return new Promise((resolve, reject) => {
-            const response = System.setMinLogLevel(message.payload.level);
-            if (didFail(response)) {
-                reject(response);
-            } else {
-                resolve();
-            }
-        });
+        const response = System.setMinLogLevel(message.payload.level);
+
+        if (response instanceof Error) {
+            throw response;
+        }
+
+        return response;
     }
 
     function getMinLogLevel(identity, message) {
-        return new Promise((resolve, reject) => {
-            const response = System.getMinLogLevel();
-            if (didFail(response)) {
-                reject(response);
-            } else {
-                resolve(response);
-            }
-        });
+        const response = System.getMinLogLevel();
+
+        if (response instanceof Error) {
+            throw response;
+        }
+
+        return response;
     }
 
     function startCrashReporter(identity, message) {

--- a/src/browser/api_protocol/api_handlers/system.js
+++ b/src/browser/api_protocol/api_handlers/system.js
@@ -15,13 +15,8 @@ limitations under the License.
 */
 let apiProtocolBase = require('./api_protocol_base.js');
 let System = require('../../api/system.js').System;
-let _ = require('underscore');
 
 function SystemApiHandler() {
-    let successAck = {
-        success: true
-    };
-
     let SystemApiHandlerMap = {
         'clear-cache': { apiFunc: clearCache, apiPath: '.clearCache' },
         'convert-options': convertOptions,
@@ -78,386 +73,303 @@ function SystemApiHandler() {
         return e !== undefined && e.constructor === Error;
     }
 
-    function setMinLogLevel(identity, message, ack, nack) {
-        const { payload: { level } } = message;
-        const response = System.setMinLogLevel(level);
-
-        if (didFail(response)) {
-            nack(response);
-
-        } else {
-            ack(_.clone(successAck));
-        }
-    }
-
-    function getMinLogLevel(identity, message, ack, nack) {
-        const response = System.getMinLogLevel();
-
-        if (didFail(response)) {
-            nack(response);
-
-        } else {
-            const dataAck = _.clone(successAck);
-            dataAck.data = response;
-            ack(dataAck);
-        }
-    }
-
-    function startCrashReporter(identity, message, ack) {
-        const dataAck = _.clone(successAck);
-        const { payload } = message;
-        dataAck.data = System.startCrashReporter(identity, payload, false);
-        ack(dataAck);
-    }
-
-    function getCrashReporterState(identity, message, ack) {
-        const dataAck = _.clone(successAck);
-        dataAck.data = System.getCrashReporterState();
-        ack(dataAck);
-    }
-
-    function downloadPreloadScripts(identity, message, ack, nack) {
-        const { payload } = message;
-        const { uuid, name, scripts } = payload;
-        const windowIdentity = { uuid, name };
-
-        System.downloadPreloadScripts(windowIdentity, scripts, err => {
-            if (!err) {
-                const dataAck = _.clone(successAck);
-                ack(dataAck);
+    function setMinLogLevel(identity, message) {
+        return new Promise((resolve, reject) => {
+            const response = System.setMinLogLevel(message.payload.level);
+            if (didFail(response)) {
+                reject(response);
             } else {
-                nack(err);
+                resolve();
             }
         });
     }
 
-    function getAppAssetInfo(identity, message, ack, nack) {
-        let options = message.payload;
-
-        System.getAppAssetInfo(identity, options, function(data) {
-            let dataAck = _.clone(successAck);
-            //remove path due to security concern
-            delete data.path;
-            dataAck.data = data;
-            ack(dataAck);
-        }, nack);
+    function getMinLogLevel(identity, message) {
+        return new Promise((resolve, reject) => {
+            const response = System.getMinLogLevel();
+            if (didFail(response)) {
+                reject(response);
+            } else {
+                resolve(response);
+            }
+        });
     }
 
-    function getDeviceUserId(identity, message, ack) {
-        let dataAck = _.clone(successAck);
-
-        dataAck.data = System.getDeviceUserId();
-        ack(dataAck);
+    function startCrashReporter(identity, message) {
+        const { payload } = message;
+        return System.startCrashReporter(identity, payload, false);
     }
 
-    function getAllExternalApplications(identity, message, ack) {
-        let dataAck = _.clone(successAck);
-
-        dataAck.data = System.getAllExternalApplications();
-        ack(dataAck);
+    function getCrashReporterState(identity, message) {
+        return System.getCrashReporterState();
     }
 
-    function raiseEvent(identity, message, ack) {
-        let evt = message.payload.eventName;
-        let eventArgs = message.payload.eventArgs;
+    function downloadPreloadScripts(identity, message) {
+        return new Promise((resolve, reject) => {
+            const { payload: { uuid, name, scripts } } = message;
+            const windowIdentity = { uuid, name };
 
-        System.raiseEvent(evt, eventArgs);
-        ack(successAck);
+            System.downloadPreloadScripts(windowIdentity, scripts, err => {
+                if (!err) {
+                    resolve();
+                } else {
+                    reject(err);
+                }
+            });
+        });
     }
 
-    function getElIPCConfig(identity, message, ack) {
-        let dataAck = _.clone(successAck);
-
-        dataAck.data = System.getElIPCConfiguration();
-        ack(dataAck);
+    function getAppAssetInfo(identity, message) {
+        return new Promise((resolve, reject) => {
+            const options = message.payload;
+            System.getAppAssetInfo(identity, options, data => {
+                //remove `path` due to security concern
+                delete data.path;
+                resolve(data);
+            }, reject);
+        });
     }
 
-    function convertOptions(identity, message, ack) {
-        let dataAck = _.clone(successAck);
-
-        dataAck.data = System.convertOptions(message.payload);
-        ack(dataAck);
-
+    function getDeviceUserId(identity, message) {
+        return System.getDeviceUserId();
     }
 
-    function getWebSocketState(identity, message, ack) {
-        let dataAck = _.clone(successAck);
-
-        dataAck.data = System.getWebSocketServerState();
-        ack(dataAck);
+    function getAllExternalApplications(identity, message) {
+        return System.getAllExternalApplications();
     }
 
-    function generateGuid(identity, message, ack) {
-        let dataAck = _.clone(successAck);
-        dataAck.data = System.generateGUID();
-        ack(dataAck);
+    function raiseEvent(identity, message) {
+        const { payload: { eventName, eventArgs } } = message;
+        System.raiseEvent(eventName, eventArgs);
     }
 
-    function showDeveloperTools(identity, message, ack) {
+    function getElIPCConfig(identity, message) {
+        return System.getElIPCConfiguration();
+    }
+
+    function convertOptions(identity, message) {
+        return System.convertOptions(message.payload);
+    }
+
+    function getWebSocketState(identity, message) {
+        return System.getWebSocketServerState();
+    }
+
+    function generateGuid(identity, message) {
+        return System.generateGUID();
+    }
+
+    function showDeveloperTools(identity, message) {
         System.showDeveloperTools(message.payload.uuid, message.payload.name);
-        ack(successAck);
     }
 
-    function clearCache(identity, message, ack, nack) {
-        System.clearCache(message.payload, (err) => {
-            if (!err) {
-                ack(successAck);
-            } else {
-                nack(err);
-            }
+    function clearCache(identity, message) {
+        return new Promise((resolve, reject) => {
+            System.clearCache(message.payload, err => {
+                if (!err) {
+                    resolve();
+                } else {
+                    reject(err);
+                }
+            });
         });
     }
 
-    function deleteCacheRequest(identity, message, ack, nack) {
+    function deleteCacheRequest(identity, message) {
         // deleteCacheOnRestart has been deprecated; redirects
         // to deleteCacheOnExit
-        System.deleteCacheOnExit(() => {
-            ack(successAck);
-        }, nack);
+
+        return new Promise((resolve, reject) => {
+            System.deleteCacheOnExit(resolve, reject);
+        });
     }
 
-    function exitDesktop(identity, message, ack) {
-        ack(successAck);
-        System.exit();
+    function exitDesktop(identity, message) {
+        setTimeout(() => System.exit());
     }
 
-    function getAllApplications(identity, message, ack) {
-        var dataAck = _.clone(successAck);
-        dataAck.data = System.getAllApplications();
-        ack(dataAck);
+    function getAllApplications(identity, message) {
+        return System.getAllApplications();
     }
 
-    function getAllWindows(identity, message, ack) {
-        var dataAck = _.clone(successAck);
-        dataAck.data = System.getAllWindows(identity);
-        ack(dataAck);
+    function getAllWindows(identity, message) {
+        return System.getAllWindows(identity);
     }
 
-    function getCommandLineArguments(identity, message, ack) {
-        var dataAck = _.clone(successAck);
-        dataAck.data = System.getCommandLineArguments();
-        ack(dataAck);
+    function getCommandLineArguments(identity, message) {
+        return System.getCommandLineArguments();
     }
 
-    function getConfig(identity, message, ack) {
-        var dataAck = _.clone(successAck);
-        dataAck.data = System.getConfig().data;
-        ack(dataAck);
+    function getConfig(identity, message) {
+        return System.getConfig().data;
     }
 
-    function getDeviceId(identity, message, ack) {
-        var dataAck = _.clone(successAck);
-        dataAck.data = System.getDeviceId();
-        ack(dataAck);
+    function getDeviceId(identity, message) {
+        return System.getDeviceId();
     }
 
-    function getRemoteConfig(identity, message, ack, nack) {
-        System.getRemoteConfig(message.payload.url,
-            function(data) {
-                var dataAck = _.clone(successAck);
-                dataAck.data = data;
-                ack(dataAck);
-            },
-            function(reason) {
-                nack(reason);
+    function getRemoteConfig(identity, message) {
+        return new Promise((resolve, reject) => {
+            System.getRemoteConfig(message.payload.url, resolve, reject);
+        });
+    }
+
+    function getEnvironmentVariable(identity, message) {
+        return System.getEnvironmentVariable(message.payload.environmentVariables);
+    }
+
+    function viewLog(identity, message) {
+        return new Promise((resolve, reject) => {
+            System.getLog((message.payload || {}).name || '', (err, contents) => {
+                if (!err) {
+                    resolve(contents);
+                } else {
+                    reject(err);
+                }
             });
-    }
-
-    function getEnvironmentVariable(identity, message, ack) {
-        var dataAck = _.clone(successAck);
-        dataAck.data = System.getEnvironmentVariable(message.payload.environmentVariables);
-        ack(dataAck);
-    }
-
-    function viewLog(identity, message, ack, nack) {
-        System.getLog((message.payload || {}).name || '', (err, contents) => {
-            if (!err) {
-                var dataAck = _.clone(successAck);
-                dataAck.data = contents;
-                ack(dataAck);
-            } else {
-                nack(err);
-            }
         });
     }
 
-    function listLogs(identity, message, ack, nack) {
-        System.getLogList((err, logList) => {
-            if (!err) {
-                var dataAck = _.clone(successAck);
-                dataAck.data = logList;
-                ack(dataAck);
-            } else {
-                nack(err);
-            }
+    function listLogs(identity, message) {
+        return new Promise((resolve, reject) => {
+            System.getLogList((err, logList) => {
+                if (!err) {
+                    resolve(logList);
+                } else {
+                    reject(err);
+                }
+            });
         });
     }
 
-    function getMonitorInfo(identity, message, ack) {
-        let dataAck = _.clone(successAck);
-        dataAck.data = System.getMonitorInfo();
-        ack(dataAck);
+    function getMonitorInfo(identity, message) {
+        return System.getMonitorInfo();
     }
 
-    function getMousePosition(identity, message, ack) {
-        var dataAck = _.clone(successAck);
-        dataAck.data = System.getMousePosition();
-        ack(dataAck);
+    function getMousePosition(identity, message) {
+        return System.getMousePosition();
     }
 
-    function processSnapshot(identity, message, ack) {
-        var dataAck = _.clone(successAck);
-        dataAck.data = System.getProcessList();
-        ack(dataAck);
+    function processSnapshot(identity, message) {
+        return System.getProcessList();
     }
 
-    function getProxySettings(identity, message, ack) {
-        let dataAck = _.clone(successAck);
-        dataAck.data = System.getProxySettings();
-        ack(dataAck);
+    function getProxySettings(identity, message) {
+        return System.getProxySettings();
     }
 
-    function getVersion(identity, message, ack) {
-        var dataAck = _.clone(successAck);
-        dataAck.data = System.getVersion();
-        ack(dataAck);
+    function getVersion(identity, message) {
+        return System.getVersion();
     }
 
-    function getRvmInfo(identity, message, ack, nack) {
-        System.getRvmInfo(identity, function(data) {
-            let dataAck = _.clone(successAck);
-            dataAck.data = data;
-            ack(dataAck);
-        }, function(err) {
-            nack(err);
+    function getRvmInfo(identity, message) {
+        return new Promise((resolve, reject) => {
+            System.getRvmInfo(identity, resolve, reject);
         });
     }
 
-    function launchExternalProcess(identity, message, ack, nack) {
-        let dataAck = _.clone(successAck);
-        System.launchExternalProcess(identity, message.payload, (err, res) => {
-            if (!err) {
-                dataAck.data = res;
-                ack(dataAck);
-            } else {
-                nack(err);
-            }
+    function launchExternalProcess(identity, message) {
+        return new Promise((resolve, reject) => {
+            System.launchExternalProcess(identity, message.payload, (err, res) => {
+                if (!err) {
+                    resolve(res);
+                } else {
+                    reject(err);
+                }
+            });
         });
     }
 
-    function writeToLog(identity, message, ack, nack) {
-        var logData = message.payload || {};
-        var err = System.log(logData.level || '', logData.message || '');
+    function writeToLog(identity, message) {
+        const logData = message.payload || {};
+        const err = System.log(logData.level || '', logData.message || '');
         if (err) {
-            nack(err);
-        } else {
-            ack(successAck);
+            throw err;
         }
     }
 
-    function openUrlWithBrowser(identity, message, ack) {
+    function openUrlWithBrowser(identity, message) {
         System.openUrlWithBrowser(message.payload.url);
-        ack(successAck);
     }
 
 
-    function releaseExternalProcess(identity, message, ack) {
+    function releaseExternalProcess(identity, message) {
         System.releaseExternalProcess(message.payload.uuid);
-        ack(successAck);
     }
 
-    function monitorExternalProcess(identity, message, ack, nack) {
-        System.monitorExternalProcess(identity, message.payload, function(data) {
-            let dataAck = _.clone(successAck);
-            dataAck.data = data;
-            ack(dataAck);
-        }, function(err) {
-            nack(err);
+    function monitorExternalProcess(identity, message) {
+        return new Promise((resolve, reject) => {
+            System.monitorExternalProcess(identity, message.payload, resolve, reject);
         });
     }
 
-    function setCookie(identity, message, ack, nack) {
-        System.setCookie(message.payload, function() {
-            ack(successAck);
-        }, function(err) {
-            nack(err);
+    function setCookie(identity, message) {
+        return new Promise((resolve, reject) => {
+            System.setCookie(message.payload, resolve, reject);
         });
-
     }
 
-    function terminateExternalProcess(identity, message, ack) {
-        let payload = message.payload || {};
-        let dataAck = _.clone(successAck);
-        dataAck.data = System.terminateExternalProcess(payload.uuid, payload.timeout, payload.child);
-        ack(dataAck);
+    function terminateExternalProcess(identity, message) {
+        const payload = message.payload || {};
+        return System.terminateExternalProcess(payload.uuid, payload.timeout, payload.child);
     }
 
-    function updateProxy(identity, message, ack, nack) {
-        var err = System.updateProxySettings(message.payload.type,
-            message.payload.proxyAddress,
-            message.payload.proxyPort);
-
-        if (!err) {
-            ack(successAck);
-        } else {
-            nack(err);
+    function updateProxy(identity, message) {
+        const { payload: { type, proxyAddress, proxyPort } } = message;
+        const err = System.updateProxySettings(type, proxyAddress, proxyPort);
+        if (err) {
+            throw err;
         }
     }
 
-    function getNearestDisplayRoot(identity, message, ack) {
-        let dataAck = _.clone(successAck);
-        dataAck.data = System.getNearestDisplayRoot(message.payload);
-        ack(dataAck);
+    function getNearestDisplayRoot(identity, message) {
+        return System.getNearestDisplayRoot(message.payload);
     }
 
-    function downloadAsset(identity, message, ack, errorAck) {
-        let dataAck = _.clone(successAck);
-        System.downloadAsset(identity, message.payload, (err) => {
-            if (!err) {
-                ack(dataAck);
-            } else {
-                errorAck(err);
-            }
+    function downloadAsset(identity, message) {
+        return new Promise((resolve, reject) => {
+            System.downloadAsset(identity, message.payload, err => {
+                if (!err) {
+                    resolve();
+                } else {
+                    reject(err);
+                }
+            });
         });
     }
 
-    function downloadRuntime(identity, message, ack, nack) {
-        const { payload } = message;
-        const dataAck = _.clone(successAck);
+    function downloadRuntime(identity, message) {
+        return new Promise((resolve, reject) => {
+            const { payload } = message;
 
-        System.downloadRuntime(identity, payload, (err) => {
-            if (err) {
-                nack(err);
-            } else {
-                ack(dataAck);
-            }
+            System.downloadRuntime(identity, payload, err => {
+                if (!err) {
+                    resolve();
+                } else {
+                    reject(err);
+                }
+            });
         });
     }
 
-    function getHostSpecs(identity, message, ack) {
-        let dataAck = _.clone(successAck);
-        dataAck.data = System.getHostSpecs();
-        ack(dataAck);
+    function getHostSpecs(identity, message) {
+        return System.getHostSpecs();
     }
 
-    function resolveUuid(identity, message, ack, nack) {
-        let dataAck = _.clone(successAck);
-
-        System.resolveUuid(identity, message.payload.entityKey, (err, entity) => {
-            if (err) {
-                nack(err);
-            } else {
-                dataAck.data = entity;
-                ack(dataAck);
-            }
+    function resolveUuid(identity, message) {
+        return new Promise((resolve, reject) => {
+            System.resolveUuid(identity, message.payload.entityKey, (err, entity) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve(entity);
+                }
+            });
         });
     }
 
-    function getSelectedPreloadScripts(identity, message, ack, nack) {
-        const { payload } = message;
-        const dataAck = _.clone(successAck);
-        dataAck.data = System.getSelectedPreloadScripts(payload, ack, nack);
-        ack(dataAck);
+    function getSelectedPreloadScripts(identity, message) {
+        return System.getSelectedPreloadScripts(message.payload);
     }
 }
 

--- a/src/browser/api_protocol/api_handlers/window.js
+++ b/src/browser/api_protocol/api_handlers/window.js
@@ -19,8 +19,6 @@ const Window = require('../../api/window').Window;
 const Application = require('../../api/application').Application;
 
 // some local sugar
-const successAck = { success: true };
-const dataAck = data => Object.assign({ data }, successAck);
 const getWinId = message => apiProtocolBase.getTargetWindowIdentity(message.payload);
 const getGroupingWinId = message => apiProtocolBase.getGroupingWindowIdentity(message.payload);
 
@@ -82,222 +80,193 @@ module.exports.init = function() {
     apiProtocolBase.registerActionMap(module.exports.windowApiMap, 'Window');
 };
 
-function windowAuthenticate(identity, message, ack, nack) {
+function windowAuthenticate(identity, message) {
     const { userName, password } = message.payload;
     Window.authenticate(getWinId(message), userName, password, err => {
         if (err) {
-            nack(err);
-        } else {
-            ack(successAck);
+            throw err;
         }
     });
 }
 
-function redirectWindowToUrl(identity, message, ack) {
+function redirectWindowToUrl(identity, message) {
     const { targetUuid: uuid, targetName: name, url } = message.payload;
     const windowIdentity = { uuid, name };
     Window.navigate(windowIdentity, url);
-    ack(successAck);
 }
 
-function updateWindowOptions(identity, rawMessage, ack) {
+function updateWindowOptions(identity, rawMessage) {
     const message = JSON.parse(JSON.stringify(rawMessage));
     Window.updateOptions(getWinId(message), message.payload.options);
-    ack(successAck);
 }
 
-function stopFlashWindow(identity, message, ack) {
+function stopFlashWindow(identity, message) {
     Window.stopFlashing(getWinId(message));
-    ack(successAck);
 }
 
-function setWindowBounds(identity, message, ack) {
+function setWindowBounds(identity, message) {
     const { left, top, width, height } = message.payload;
     Window.setBounds(getWinId(message), left, top, width, height);
-    ack(successAck);
 }
 
-function setWindowPreloadState(identity, message, ack) {
+function setWindowPreloadState(identity, message) {
     const windowIdentity = apiProtocolBase.getTargetWindowIdentity(identity);
     Window.setWindowPreloadState(windowIdentity, message.payload);
-    ack(successAck);
 }
 
-function setForegroundWindow(identity, message, ack) {
+function setForegroundWindow(identity, message) {
     Window.setAsForeground(getWinId(message));
-    ack(successAck);
 }
 
-function showAtWindow(identity, message, ack) {
+function showAtWindow(identity, message) {
     const { left, top, force } = message.payload;
     Window.showAt(getWinId(message), left, top, !!force);
-    ack(successAck);
 }
 
-function showMenu(identity, message, ack) {
+function showMenu(identity, message) {
     const { x, y, editable, hasSelectedText } = message.payload;
     Window.showMenu(getWinId(message), x, y, editable, hasSelectedText);
-    ack(successAck);
 }
 
-function showWindow(identity, message, ack) {
+function showWindow(identity, message) {
     Window.show(getWinId(message), !!message.payload.force);
-    ack(successAck);
 }
 
-function restoreWindow(identity, message, ack) {
+function restoreWindow(identity, message) {
     Window.restore(getWinId(message));
-    ack(successAck);
 }
 
-function resizeWindow(identity, message, ack) {
+function resizeWindow(identity, message) {
     const { width, height, anchor } = message.payload;
     Window.resizeTo(getWinId(message), width, height, anchor);
-    ack(successAck);
 }
 
-function resizeWindowBy(identity, message, ack) {
+function resizeWindowBy(identity, message) {
     const { deltaWidth, deltaHeight, anchor } = message.payload;
     Window.resizeBy(getWinId(message), deltaWidth, deltaHeight, anchor);
-    ack(successAck);
 }
 
-function undockWindow(identity, message, ack) {
+function undockWindow(identity, message) {
     //TODO:Figure out what this is supposed to do.
-    ack(successAck);
 }
 
-function moveWindow(identity, message, ack) {
+function moveWindow(identity, message) {
     const { left, top } = message.payload;
     Window.moveTo(getWinId(message), left, top);
-    ack(successAck);
 }
 
-function moveWindowBy(identity, message, ack) {
+function moveWindowBy(identity, message) {
     const { deltaLeft, deltaTop } = message.payload;
     Window.moveBy(getWinId(message), deltaLeft, deltaTop);
-    ack(successAck);
 }
 
-function navigateWindow(identity, message, ack) {
+function navigateWindow(identity, message) {
     Window.navigate(getWinId(message), message.payload.url);
-    ack(successAck);
 }
 
-function navigateWindowBack(identity, message, ack) {
+function navigateWindowBack(identity, message) {
     Window.navigateBack(getWinId(message));
-    ack(successAck);
 }
 
-function navigateWindowForward(identity, message, ack) {
+function navigateWindowForward(identity, message) {
     Window.navigateForward(getWinId(message));
-    ack(successAck);
 }
 
-function stopWindowNavigation(identity, message, ack) {
+function stopWindowNavigation(identity, message) {
     Window.stopNavigation(getWinId(message));
-    ack(successAck);
 }
 
-function reloadWindow(identity, message, ack) {
+function reloadWindow(identity, message) {
     Window.reload(getWinId(message), !!message.payload.ignoreCache);
-    ack(successAck);
 }
 
-function minimizeWindow(identity, message, ack) {
+function minimizeWindow(identity, message) {
     Window.minimize(getWinId(message));
-    ack(successAck);
 }
 
-function mergeWindowGroups(identity, message, ack) {
+function mergeWindowGroups(identity, message) {
     Window.mergeGroups(getWinId(message), getGroupingWinId(message));
-    ack(successAck);
 }
 
-function maximizeWindow(identity, message, ack) {
+function maximizeWindow(identity, message) {
     Window.maximize(getWinId(message));
-    ack(successAck);
 }
 
-function leaveWindowGroup(identity, message, ack) {
+function leaveWindowGroup(identity, message) {
     Window.leaveGroup(getWinId(message));
-    ack(successAck);
 }
 
-function joinWindowGroup(identity, message, ack) {
+function joinWindowGroup(identity, message) {
     Window.joinGroup(getWinId(message), getGroupingWinId(message));
-    ack(successAck);
 }
 
-function isWindowShowing(identity, message, ack) {
-    ack(dataAck(Window.isShowing(getWinId(message))));
+function isWindowShowing(identity, message) {
+    return Window.isShowing(getWinId(message));
 }
 
-function hideWindow(identity, message, ack) {
+function hideWindow(identity, message) {
     Window.hide(getWinId(message));
-    ack(successAck);
 }
 
-function getWindowSnapshot(identity, message, ack) {
-    Window.getSnapshot(getWinId(message), (err, result) => {
-        if (err) {
-            throw err; //todo: why not using nack?
-        } else {
-            ack(dataAck(result));
-        }
+function getWindowSnapshot(identity, message) {
+    return new Promise((resolve, reject) => {
+        Window.getSnapshot(getWinId(message), (err, result) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(result);
+            }
+        });
     });
 }
 
-function getWindowState(identity, message, ack) {
-    ack(dataAck(Window.getState(getWinId(message))));
+function getWindowState(identity, message) {
+    return Window.getState(getWinId(message));
 }
 
-function getWindowOptions(identity, message, ack) {
-    ack(dataAck(Window.getOptions(getWinId(message))));
+function getWindowOptions(identity, message) {
+    return Window.getOptions(getWinId(message));
 }
 
-function getCurrentWindowOptions(identity, message, ack) {
-    ack(dataAck(Window.getOptions(identity)));
+function getCurrentWindowOptions(identity, message) {
+    return Window.getOptions(identity);
 }
 
-function getWindowInfo(identity, message, ack) {
-    ack(dataAck(Window.getWindowInfo(getWinId(message))));
+function getWindowInfo(identity, message) {
+    return Window.getWindowInfo(getWinId(message));
 }
 
-function getWindowNativeId(identity, message, ack) {
-    ack(dataAck(Window.getNativeId(getWinId(message))));
+function getWindowNativeId(identity, message) {
+    return Window.getNativeId(getWinId(message));
 }
 
-function getWindowGroup(identity, message, ack) {
+function getWindowGroup(identity, message) {
     // NOTE: the Window API returns a wrapped window with 'name' as a member,
     // while the adaptor expects it to be 'windowName'
-    ack(dataAck(Window.getGroup(getWinId(message)).map(window => {
+    return Window.getGroup(getWinId(message)).map(window => {
         const windowName = window.name;
         if (message.payload.crossApp === true) {
             return Object.assign({}, window, { windowName });
         } else {
             return windowName; // backwards compatible
         }
-    })));
+    });
 }
 
-function getWindowBounds(identity, message, ack) {
-    ack(dataAck(Window.getBounds(getWinId(message))));
+function getWindowBounds(identity, message) {
+    return Window.getBounds(getWinId(message));
 }
 
-function focusWindow(identity, message, ack) {
+function focusWindow(identity, message) {
     Window.focus(getWinId(message));
-    ack(successAck);
 }
 
-function flashWindow(identity, message, ack) {
+function flashWindow(identity, message) {
     Window.flash(getWinId(message));
-    ack(successAck);
 }
 
-function enableWindowFrame(identity, message, ack) {
+function enableWindowFrame(identity, message) {
     Window.enableFrame(getWinId(message));
-    ack(successAck);
 }
 
 function executeJavascript(identity, message, ack, nack) {
@@ -305,12 +274,14 @@ function executeJavascript(identity, message, ack, nack) {
 
     while (pUuid) {
         if (pUuid === identity.uuid) {
-            return Window.executeJavascript(getWinId(message), message.payload.code, (err, result) => {
-                if (err) {
-                    nack(err);
-                } else {
-                    ack(dataAck(result));
-                }
+            return new Promise((resolve, reject) => {
+                Window.executeJavascript(getWinId(message), message.payload.code, (err, result) => {
+                    if (err) {
+                        reject(err);
+                    } else {
+                        resolve(result);
+                    }
+                });
             });
         }
         pUuid = Application.getParentApplication({
@@ -318,67 +289,63 @@ function executeJavascript(identity, message, ack, nack) {
         });
     }
 
-    return nack(new Error('Rejected, target window is not owned by requesting identity'));
+    return Promise.reject(new Error('Rejected, target window is not owned by requesting identity'));
 }
 
-function disableWindowFrame(identity, message, ack) {
+function disableWindowFrame(identity, message) {
     Window.disableFrame(getWinId(message));
-    ack(successAck);
 }
 
-function windowEmbedded(identity, message, ack) {
+function windowEmbedded(identity, message) {
     const { payload } = message;
 
     // Ensure expected shape for getTargetWindowIdentity (called by getWinId)
     payload.uuid = payload.targetUuid;
 
     Window.embed(getWinId(message), `0x${payload.parentHwnd}`);
-    ack(successAck);
 }
 
-function closeWindow(identity, message, ack) {
-    Window.close(getWinId(message), !!message.payload.force, () => {
-        ack(successAck);
+function closeWindow(identity, message) {
+    return new Promise(resolve => {
+        Window.close(getWinId(message), !!message.payload.force, resolve);
     });
 }
 
-function bringWindowToFront(identity, message, ack) {
+function bringWindowToFront(identity, message) {
     Window.bringToFront(getWinId(message));
-    ack(successAck);
 }
 
-function blurWindow(identity, message, ack) {
+function blurWindow(identity, message) {
     Window.blur(getWinId(message));
-    ack(successAck);
 }
 
-function animateWindow(identity, message, ack) {
-    const { transitions, options } = message.payload;
-    Window.animate(getWinId(message), transitions, options, () => { ack(successAck); });
-}
-
-function dockWindow(identity, message, ack) {
-    //Pending runtime.
-    ack(successAck);
-}
-
-function windowExists(identity, message, ack) {
-    ack(dataAck(Window.exists(getWinId(message))));
-}
-
-function getCachedBounds(identity, message, ack, nack) {
-    Window.getBoundsFromDisk(getWinId(message), data => {
-        ack(dataAck(data));
-    }, nack);
-}
-
-function getZoomLevel(identity, message, ack) {
-    Window.getZoomLevel(getWinId(message), result => {
-        ack(dataAck(result));
+function animateWindow(identity, message) {
+    return new Promise(resolve => {
+        const { transitions, options } = message.payload;
+        Window.animate(getWinId(message), transitions, options, resolve);
     });
 }
 
-function setZoomLevel(identity, message, ack) {
+function dockWindow(identity, message) {
+    //Pending runtime.
+}
+
+function windowExists(identity, message) {
+    return Window.exists(getWinId(message));
+}
+
+function getCachedBounds(identity, message) {
+    return new Promise((resolve, reject) => {
+        Window.getBoundsFromDisk(getWinId(message), resolve, reject);
+    });
+}
+
+function getZoomLevel(identity, message) {
+    return new Promise(resolve => {
+        Window.getZoomLevel(getWinId(message), resolve);
+    });
+}
+
+function setZoomLevel(identity, message) {
     Window.setZoomLevel(getWinId(message), message.payload.level);
-    ack(successAck);
 }

--- a/src/browser/api_protocol/api_handlers/window.js
+++ b/src/browser/api_protocol/api_handlers/window.js
@@ -19,7 +19,7 @@ const Window = require('../../api/window').Window;
 const Application = require('../../api/application').Application;
 
 // some local sugar
-const getWinId = message => apiProtocolBase.getTargetWindowIdentity(message.payload);
+const getTargetWinId = message => apiProtocolBase.getTargetWindowIdentity(message.payload);
 const getGroupingWinId = message => apiProtocolBase.getGroupingWindowIdentity(message.payload);
 
 module.exports.windowApiMap = {
@@ -82,7 +82,7 @@ module.exports.init = function() {
 
 function windowAuthenticate(identity, message) {
     const { userName, password } = message.payload;
-    Window.authenticate(getWinId(message), userName, password, err => {
+    Window.authenticate(getTargetWinId(message), userName, password, err => {
         if (err) {
             throw err;
         }
@@ -97,16 +97,16 @@ function redirectWindowToUrl(identity, message) {
 
 function updateWindowOptions(identity, rawMessage) {
     const message = JSON.parse(JSON.stringify(rawMessage));
-    Window.updateOptions(getWinId(message), message.payload.options);
+    Window.updateOptions(getTargetWinId(message), message.payload.options);
 }
 
 function stopFlashWindow(identity, message) {
-    Window.stopFlashing(getWinId(message));
+    Window.stopFlashing(getTargetWinId(message));
 }
 
 function setWindowBounds(identity, message) {
     const { left, top, width, height } = message.payload;
-    Window.setBounds(getWinId(message), left, top, width, height);
+    Window.setBounds(getTargetWinId(message), left, top, width, height);
 }
 
 function setWindowPreloadState(identity, message) {
@@ -115,35 +115,35 @@ function setWindowPreloadState(identity, message) {
 }
 
 function setForegroundWindow(identity, message) {
-    Window.setAsForeground(getWinId(message));
+    Window.setAsForeground(getTargetWinId(message));
 }
 
 function showAtWindow(identity, message) {
     const { left, top, force } = message.payload;
-    Window.showAt(getWinId(message), left, top, !!force);
+    Window.showAt(getTargetWinId(message), left, top, !!force);
 }
 
 function showMenu(identity, message) {
     const { x, y, editable, hasSelectedText } = message.payload;
-    Window.showMenu(getWinId(message), x, y, editable, hasSelectedText);
+    Window.showMenu(getTargetWinId(message), x, y, editable, hasSelectedText);
 }
 
 function showWindow(identity, message) {
-    Window.show(getWinId(message), !!message.payload.force);
+    Window.show(getTargetWinId(message), !!message.payload.force);
 }
 
 function restoreWindow(identity, message) {
-    Window.restore(getWinId(message));
+    Window.restore(getTargetWinId(message));
 }
 
 function resizeWindow(identity, message) {
     const { width, height, anchor } = message.payload;
-    Window.resizeTo(getWinId(message), width, height, anchor);
+    Window.resizeTo(getTargetWinId(message), width, height, anchor);
 }
 
 function resizeWindowBy(identity, message) {
     const { deltaWidth, deltaHeight, anchor } = message.payload;
-    Window.resizeBy(getWinId(message), deltaWidth, deltaHeight, anchor);
+    Window.resizeBy(getTargetWinId(message), deltaWidth, deltaHeight, anchor);
 }
 
 function undockWindow(identity, message) {
@@ -152,65 +152,65 @@ function undockWindow(identity, message) {
 
 function moveWindow(identity, message) {
     const { left, top } = message.payload;
-    Window.moveTo(getWinId(message), left, top);
+    Window.moveTo(getTargetWinId(message), left, top);
 }
 
 function moveWindowBy(identity, message) {
     const { deltaLeft, deltaTop } = message.payload;
-    Window.moveBy(getWinId(message), deltaLeft, deltaTop);
+    Window.moveBy(getTargetWinId(message), deltaLeft, deltaTop);
 }
 
 function navigateWindow(identity, message) {
-    Window.navigate(getWinId(message), message.payload.url);
+    Window.navigate(getTargetWinId(message), message.payload.url);
 }
 
 function navigateWindowBack(identity, message) {
-    Window.navigateBack(getWinId(message));
+    Window.navigateBack(getTargetWinId(message));
 }
 
 function navigateWindowForward(identity, message) {
-    Window.navigateForward(getWinId(message));
+    Window.navigateForward(getTargetWinId(message));
 }
 
 function stopWindowNavigation(identity, message) {
-    Window.stopNavigation(getWinId(message));
+    Window.stopNavigation(getTargetWinId(message));
 }
 
 function reloadWindow(identity, message) {
-    Window.reload(getWinId(message), !!message.payload.ignoreCache);
+    Window.reload(getTargetWinId(message), !!message.payload.ignoreCache);
 }
 
 function minimizeWindow(identity, message) {
-    Window.minimize(getWinId(message));
+    Window.minimize(getTargetWinId(message));
 }
 
 function mergeWindowGroups(identity, message) {
-    Window.mergeGroups(getWinId(message), getGroupingWinId(message));
+    Window.mergeGroups(getTargetWinId(message), getGroupingWinId(message));
 }
 
 function maximizeWindow(identity, message) {
-    Window.maximize(getWinId(message));
+    Window.maximize(getTargetWinId(message));
 }
 
 function leaveWindowGroup(identity, message) {
-    Window.leaveGroup(getWinId(message));
+    Window.leaveGroup(getTargetWinId(message));
 }
 
 function joinWindowGroup(identity, message) {
-    Window.joinGroup(getWinId(message), getGroupingWinId(message));
+    Window.joinGroup(getTargetWinId(message), getGroupingWinId(message));
 }
 
 function isWindowShowing(identity, message) {
-    return Window.isShowing(getWinId(message));
+    return Window.isShowing(getTargetWinId(message));
 }
 
 function hideWindow(identity, message) {
-    Window.hide(getWinId(message));
+    Window.hide(getTargetWinId(message));
 }
 
 function getWindowSnapshot(identity, message) {
     return new Promise((resolve, reject) => {
-        Window.getSnapshot(getWinId(message), (err, result) => {
+        Window.getSnapshot(getTargetWinId(message), (err, result) => {
             if (err) {
                 reject(err);
             } else {
@@ -221,11 +221,11 @@ function getWindowSnapshot(identity, message) {
 }
 
 function getWindowState(identity, message) {
-    return Window.getState(getWinId(message));
+    return Window.getState(getTargetWinId(message));
 }
 
 function getWindowOptions(identity, message) {
-    return Window.getOptions(getWinId(message));
+    return Window.getOptions(getTargetWinId(message));
 }
 
 function getCurrentWindowOptions(identity, message) {
@@ -233,17 +233,17 @@ function getCurrentWindowOptions(identity, message) {
 }
 
 function getWindowInfo(identity, message) {
-    return Window.getWindowInfo(getWinId(message));
+    return Window.getWindowInfo(getTargetWinId(message));
 }
 
 function getWindowNativeId(identity, message) {
-    return Window.getNativeId(getWinId(message));
+    return Window.getNativeId(getTargetWinId(message));
 }
 
 function getWindowGroup(identity, message) {
     // NOTE: the Window API returns a wrapped window with 'name' as a member,
     // while the adaptor expects it to be 'windowName'
-    return Window.getGroup(getWinId(message)).map(window => {
+    return Window.getGroup(getTargetWinId(message)).map(window => {
         const windowName = window.name;
         if (message.payload.crossApp === true) {
             return Object.assign({}, window, { windowName });
@@ -254,28 +254,28 @@ function getWindowGroup(identity, message) {
 }
 
 function getWindowBounds(identity, message) {
-    return Window.getBounds(getWinId(message));
+    return Window.getBounds(getTargetWinId(message));
 }
 
 function focusWindow(identity, message) {
-    Window.focus(getWinId(message));
+    Window.focus(getTargetWinId(message));
 }
 
 function flashWindow(identity, message) {
-    Window.flash(getWinId(message));
+    Window.flash(getTargetWinId(message));
 }
 
 function enableWindowFrame(identity, message) {
-    Window.enableFrame(getWinId(message));
+    Window.enableFrame(getTargetWinId(message));
 }
 
 function executeJavascript(identity, message, ack, nack) {
-    let pUuid = getWinId(message).uuid;
+    let pUuid = getTargetWinId(message).uuid;
 
     while (pUuid) {
         if (pUuid === identity.uuid) {
             return new Promise((resolve, reject) => {
-                Window.executeJavascript(getWinId(message), message.payload.code, (err, result) => {
+                Window.executeJavascript(getTargetWinId(message), message.payload.code, (err, result) => {
                     if (err) {
                         reject(err);
                     } else {
@@ -293,7 +293,7 @@ function executeJavascript(identity, message, ack, nack) {
 }
 
 function disableWindowFrame(identity, message) {
-    Window.disableFrame(getWinId(message));
+    Window.disableFrame(getTargetWinId(message));
 }
 
 function windowEmbedded(identity, message) {
@@ -302,27 +302,27 @@ function windowEmbedded(identity, message) {
     // Ensure expected shape for getTargetWindowIdentity (called by getWinId)
     payload.uuid = payload.targetUuid;
 
-    Window.embed(getWinId(message), `0x${payload.parentHwnd}`);
+    Window.embed(getTargetWinId(message), `0x${payload.parentHwnd}`);
 }
 
 function closeWindow(identity, message) {
     return new Promise(resolve => {
-        Window.close(getWinId(message), !!message.payload.force, resolve);
+        Window.close(getTargetWinId(message), !!message.payload.force, resolve);
     });
 }
 
 function bringWindowToFront(identity, message) {
-    Window.bringToFront(getWinId(message));
+    Window.bringToFront(getTargetWinId(message));
 }
 
 function blurWindow(identity, message) {
-    Window.blur(getWinId(message));
+    Window.blur(getTargetWinId(message));
 }
 
 function animateWindow(identity, message) {
     return new Promise(resolve => {
         const { transitions, options } = message.payload;
-        Window.animate(getWinId(message), transitions, options, resolve);
+        Window.animate(getTargetWinId(message), transitions, options, resolve);
     });
 }
 
@@ -331,21 +331,21 @@ function dockWindow(identity, message) {
 }
 
 function windowExists(identity, message) {
-    return Window.exists(getWinId(message));
+    return Window.exists(getTargetWinId(message));
 }
 
 function getCachedBounds(identity, message) {
     return new Promise((resolve, reject) => {
-        Window.getBoundsFromDisk(getWinId(message), resolve, reject);
+        Window.getBoundsFromDisk(getTargetWinId(message), resolve, reject);
     });
 }
 
 function getZoomLevel(identity, message) {
     return new Promise(resolve => {
-        Window.getZoomLevel(getWinId(message), resolve);
+        Window.getZoomLevel(getTargetWinId(message), resolve);
     });
 }
 
 function setZoomLevel(identity, message) {
-    Window.setZoomLevel(getWinId(message), message.payload.level);
+    Window.setZoomLevel(getTargetWinId(message), message.payload.level);
 }

--- a/src/browser/api_protocol/transport_strategy/ack.ts
+++ b/src/browser/api_protocol/transport_strategy/ack.ts
@@ -25,11 +25,13 @@ export class AckMessage {
 // ToDo following duplicated in src/shapes.ts
 
 export class AckPayload {
-    public success: true;
+    public readonly success: true = true;
     public data?: any;
 
     constructor(data: any) {
-        this.data = data;
+        if (data !== undefined) {
+            this.data = data;
+        }
     }
 }
 

--- a/src/browser/api_protocol/transport_strategy/elipc_strategy.ts
+++ b/src/browser/api_protocol/transport_strategy/elipc_strategy.ts
@@ -40,15 +40,9 @@ export class ElipcStrategy extends ApiTransportBase<MessagePackage> {
                     // singleFrameOnly check first so to prevent frame superceding when disabled.
                     if (!data.singleFrameOnly === false || e.sender.isValidWithFrameConnect(e.frameRoutingId)) {
                         Promise.resolve()
-                            .then(() => endpoint.apiFunc(identity, data, ack, nack))
-                            .then(result => {
-                                // older action calls will invoke ack internally, newer ones will return a value
-                                if (result !== undefined) {
-                                    ack(new AckPayload(result));
-                                }
-                            }).catch(err => {
-                                nack(err);
-                            });
+                            .then(() => endpoint.apiFunc(identity, data))
+                            .then(result => { ack(new AckPayload(result)); })
+                            .catch(err => { nack(err); });
                     } else {
                         nack('API access has been superseded by another frame in this window.');
                     }

--- a/src/browser/api_protocol/transport_strategy/elipc_strategy.ts
+++ b/src/browser/api_protocol/transport_strategy/elipc_strategy.ts
@@ -42,7 +42,7 @@ export class ElipcStrategy extends ApiTransportBase<MessagePackage> {
                         Promise.resolve()
                             .then(() => endpoint.apiFunc(identity, data))
                             .then(result => { ack(new AckPayload(result)); })
-                            .catch(err => { nack(err); });
+                            .catch(nack);
                     } else {
                         nack('API access has been superseded by another frame in this window.');
                     }

--- a/src/browser/session.ts
+++ b/src/browser/session.ts
@@ -15,6 +15,7 @@ limitations under the License.
 */
 import { EventEmitter } from 'events';
 import { BrowserWindow, app, idleState, nativeTimer } from 'electron';
+import { WindowsMessages } from '../microsoft';
 
 class Session extends EventEmitter {
     private idleState: idleState;
@@ -61,14 +62,12 @@ class Session extends EventEmitter {
 
         // Windows-only
         if (process.platform === 'win32') {
-            const WM_WTSSESSION_CHANGE = 0x02B1;
-
             const bw = new BrowserWindow({
                 show: false
             });
 
             // Listen to session changes using hidden Electron's browser window
-            bw.hookWindowMessage(WM_WTSSESSION_CHANGE, wParam => {
+            bw.hookWindowMessage(WindowsMessages.WM_WTSSESSION_CHANGE, wParam => {
                 let reason: string;
 
                 switch (wParam.readIntLE()) {

--- a/src/microsoft.ts
+++ b/src/microsoft.ts
@@ -1,0 +1,44 @@
+/*
+Copyright 2017 OpenFin Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export enum SetWindowPosition {
+    SWP_HIDEWINDOW = 0x80,
+    SWP_SHOWWINDOW = 0x40
+}
+
+export enum SysCommands {
+    SC_MAXIMIZE = 0xF030,
+    SC_MINIMIZE = 0xF020,
+    SC_RESTORE = 0xF120
+}
+
+export enum WindowsMessages {
+    WM_DESTROY = 0x0002,
+    WM_SETFOCUS = 0x0007,
+    WM_KILLFOCUS = 0x0008,
+    WM_WINDOWPOSCHANGED = 0x0047,
+    WM_SYSCOMMAND = 0x0112,
+    WM_NCLBUTTONDBLCLK = 0x00a3,
+    WM_KEYDOWN = 0x0100,
+    WM_KEYUP = 0x0101,
+    WM_SYSKEYDOWN = 0x0104,
+    WM_SYSKEYUP = 0x0105,
+    WM_SIZING = 0x0214,
+    WM_MOVING = 0x0216,
+    WM_ENTERSIZEMOVE = 0x0231,
+    WM_EXITSIZEMOVE = 0x0232,
+    WM_WTSSESSION_CHANGE = 0x02B1
+}


### PR DESCRIPTION
This mostly: normalizes code that
1. Gets `appIdentity` or `windowIdentity`
2. Microsoft constants

and: Removes `ack` and `nack` from all api handler functions, relying instead on `ElipcStrategy` to:
* normal return from api func _without_ response data: call `ack` with a simple `AckPayload` (just `success: true`)
* normal return from api func _with_ response data: call `ack` with an `AckPayload` with a `data` property
* handles async api funcs (that return a promise).

Integration & Regression [tested](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59ac3207d2a02971da3a63a5).