### PR TITLE
RUN-3143 always set logging level to 'verbose' when in diagnostics mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -391,12 +391,14 @@ function includeFlashPlugin() {
 }
 
 function initializeCrashReporter(argo) {
+    if (!isInDiagnosticsMode(argo)) {
+        return;
+    }
+
     const configUrl = argo['startup-url'] || argo['config'];
     const diagnosticMode = argo['diagnostics'] || false;
 
-    if (isInDiagnosticsMode(argo)) {
-        crashReporter.startOFCrashReporter({ diagnosticMode, configUrl });
-    }
+    crashReporter.startOFCrashReporter({ diagnosticMode, configUrl });
 }
 
 function rotateLogs(argo) {
@@ -654,5 +656,5 @@ function registerShortcuts() {
 }
 
 function isInDiagnosticsMode(argo) {
-    return !!argo['diagnostics'] || !!argo['enable-crash-reporting'];
+    return !!(argo['diagnostics'] || argo['enable-crash-reporting']);
 }

--- a/index.js
+++ b/index.js
@@ -393,10 +393,8 @@ function includeFlashPlugin() {
 function initializeCrashReporter(argo) {
     const configUrl = argo['startup-url'] || argo['config'];
     const diagnosticMode = argo['diagnostics'] || false;
-    const enableCrashReporting = argo['enable-crash-reporting'];
-    const shouldStartCrashReporter = enableCrashReporting || diagnosticMode;
 
-    if (shouldStartCrashReporter) {
+    if (isInDiagnosticsMode(argo)) {
         crashReporter.startOFCrashReporter({ diagnosticMode, configUrl });
     }
 }
@@ -500,6 +498,11 @@ function initServer() {
 //is essential for proper runtime startup and adapter connectivity. we want to split into smaller independent parts.
 //please see the discussion on https://github.com/openfin/runtime-core/pull/194
 function launchApp(argo, startExternalAdapterServer) {
+
+    if (isInDiagnosticsMode(argo)) {
+        log.setToVerbose();
+    }
+
     convertOptions.fetchOptions(argo, configuration => {
         const {
             configUrl,
@@ -648,4 +651,8 @@ function registerShortcuts() {
 
     app.on('browser-window-closed', unhookShortcuts);
     app.on('browser-window-blur', unhookShortcuts);
+}
+
+function isInDiagnosticsMode(argo) {
+    return !!argo['diagnostics'] || !!argo['enable-crash-reporting'];
 }

--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -490,7 +490,8 @@ exports.System = {
     },
     setMinLogLevel: function(level) {
         try {
-            const mappedLevel = log.logLevelMappings.get(level + '');
+            const levelAsString = String(level); // We only accept log levels as strings here
+            const mappedLevel = log.logLevelMappings.get(levelAsString);
 
             if (mappedLevel === undefined) {
                 throw new Error(`Invalid logging level: ${level}`);

--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -39,23 +39,6 @@ import ofEvents from '../of_events';
 const ProcessTracker = require('../process_tracker.js');
 import route from '../../common/route';
 import { fetchAndLoadPreloadScripts } from '../preload_scripts';
-const verbose = 'verbose';
-const info = 'info';
-const warning = 'warning';
-const error = 'error';
-const fatal = 'fatal';
-const logLevelMappings = new Map([
-    [verbose, -1],
-    [info, 0],
-    [warning, 1],
-    [error, 2],
-    [fatal, 3],
-    [-1, verbose],
-    [0, info],
-    [1, warning],
-    [2, error],
-    [3, fatal]
-]);
 
 const defaultProc = {
     getCpuUsage: function() {
@@ -407,7 +390,7 @@ exports.System = {
         try {
             const logLevel = electronApp.getMinLogLevel();
 
-            return logLevelMappings.get(logLevel);
+            return log.logLevelMappings.get(logLevel);
         } catch (e) {
             return e;
         }
@@ -507,7 +490,7 @@ exports.System = {
     },
     setMinLogLevel: function(level) {
         try {
-            const mappedLevel = logLevelMappings.get(level + '');
+            const mappedLevel = log.logLevelMappings.get(level + '');
 
             if (mappedLevel === undefined) {
                 throw new Error(`Invalid logging level: ${level}`);
@@ -549,6 +532,8 @@ exports.System = {
     startCrashReporter: function(identity, options) {
         const configUrl = coreState.argo['startup-url'] || coreState.argo['config'];
         const reporterOptions = Object.assign({ configUrl }, options);
+
+        log.setToVerbose();
         crashReporter.startOFCrashReporter(reporterOptions);
 
         return crashReporter.crashReporterState();

--- a/src/browser/log.ts
+++ b/src/browser/log.ts
@@ -16,6 +16,19 @@ limitations under the License.
 import {app} from 'electron';
 import {errorToPOJO} from '../common/errors';
 
+export const logLevelMappings = new Map<any, any>([
+    ['verbose', -1],
+    ['info', 0],
+    ['warning', 1],
+    ['error', 2],
+    ['fatal', 3],
+    [-1, 'verbose'],
+    [0, 'info'],
+    [1, 'warning'],
+    [2, 'error'],
+    [3, 'fatal']
+]);
+
 /**
  * Parses log messages and uses Electron's APIs to log them to console
  */
@@ -50,4 +63,12 @@ export function writeToLog(level: any, message: any, debug?: boolean): any {
     } else {
         return app.log(level, parsedMessage);
     }
+}
+
+/**
+ * Sets runtime log level to 'verbose'
+ */
+export function setToVerbose(): void {
+    const verboseLogLevel = logLevelMappings.get('verbose');
+    app.setMinLogLevel(verboseLogLevel);
 }

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -21,14 +21,15 @@ limitations under the License.
 
 declare module 'electron' {
     namespace app {
-        export function log(level: string, message: any): any;
-        export function vlog(level: number, message: any): any;
-        export function getPath(str: string): string;
-        export function getTickCount(): number;
-        export function on(event: string, callback: () => void): void;
         export function generateGUID(): string;
         export function getCommandLineArguments(): string;
         export function getCommandLineArgv(): string[];
+        export function getPath(str: string): string;
+        export function getTickCount(): number;
+        export function log(level: string, message: any): any;
+        export function on(event: string, callback: () => void): void;
+        export function setMinLogLevel(level: number): void;
+        export function vlog(level: number, message: any): any;
     }
 
     namespace BrowserWindow {

--- a/tslint.json
+++ b/tslint.json
@@ -77,7 +77,6 @@
         "no-angle-bracket-type-assertion": false,
         "no-any": false,
         "no-arg": true,
-        "no-backbone-get-set-outside-model": true,
         "no-banned-terms": false,
         "no-bitwise": true,
         "no-boolean-literal-compare": false,


### PR DESCRIPTION
ℹ️  **About**
These changes switch logging level to verbose whenever the core is in the "diagnostics" mode

➕  **New test**
[fin.desktop.System.startCrashReporter (verbose logging)](https://testing-dashboard.openfin.co/#/app/tests/59aeb1aed2a02971da3a63a6/edit)

✅  **Test results**
[Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59af5ae6d2a02971da3a63bf)
[Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59af5c20d2a02971da3a63c0)