### PR TITLE
RUN-3317 Missing preload script has "succeeded" status

### DIFF
--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -686,12 +686,14 @@ exports.System = {
             return urls;
         }, []);
 
-        if (!missingRequiredScripts.length) {
-            // when load/fetch failed, mapped value will be `undefined`, which stringify translates to `null`
-            return preloadOption.map(preload => preloadScriptsCache[preload.url]);
-        } else {
-            return `Execution of preload scripts canceled because of missing required script(s) ${JSON.stringify(missingRequiredScripts)}`;
+        if (missingRequiredScripts.length) {
+            const err = `Execution of preload scripts canceled because of missing required script(s) ${JSON.stringify(missingRequiredScripts)}`;
+            return Promise.reject(err);
         }
+
+        // when load/fetch failed, mapped object will be `undefined` (stringifies as `null`)
+        const scriptSet = preloadOption.map(preload => preloadScriptsCache[preload.url]);
+        return Promise.resolve(scriptSet);
     }
 };
 

--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -679,8 +679,6 @@ exports.System = {
     },
 
     getSelectedPreloadScripts: function(preloadOption) {
-        const response = {};
-
         const missingRequiredScripts = preloadOption.reduce((urls, preload) => {
             if (!preload.optional && !(preload.url in preloadScriptsCache)) {
                 urls.push(preload.url);
@@ -689,13 +687,10 @@ exports.System = {
         }, []);
 
         if (!missingRequiredScripts.length) {
-            const missingOptionalScript = '';
-            response.scripts = preloadOption.map(preload => preloadScriptsCache[preload.url] || missingOptionalScript);
+            return preloadOption.map(preload => preloadScriptsCache[preload.url]); // null when load/fetch failed
         } else {
-            response.error = `Execution of preload scripts canceled because of missing required script(s) ${JSON.stringify(missingRequiredScripts)}`;
+            return `Execution of preload scripts canceled because of missing required script(s) ${JSON.stringify(missingRequiredScripts)}`;
         }
-
-        return response;
     }
 };
 

--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -687,7 +687,8 @@ exports.System = {
         }, []);
 
         if (!missingRequiredScripts.length) {
-            return preloadOption.map(preload => preloadScriptsCache[preload.url]); // null when load/fetch failed
+            // when load/fetch failed, mapped value will be `undefined`, which stringify translates to `null`
+            return preloadOption.map(preload => preloadScriptsCache[preload.url]);
         } else {
             return `Execution of preload scripts canceled because of missing required script(s) ${JSON.stringify(missingRequiredScripts)}`;
         }

--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -687,7 +687,9 @@ exports.System = {
         }, []);
 
         if (missingRequiredScripts.length) {
-            const err = `Execution of preload scripts canceled because of missing required script(s) ${JSON.stringify(missingRequiredScripts)}`;
+            const list = JSON.stringify(missingRequiredScripts);
+            const message = `Execution of preload scripts canceled because of missing required script(s) ${list}`;
+            const err = new Error(message);
             return Promise.reject(err);
         }
 

--- a/src/browser/api_protocol/api_handlers/system.js
+++ b/src/browser/api_protocol/api_handlers/system.js
@@ -455,9 +455,15 @@ function SystemApiHandler() {
 
     function getSelectedPreloadScripts(identity, message, ack, nack) {
         const { payload } = message;
-        const dataAck = _.clone(successAck);
-        dataAck.data = System.getSelectedPreloadScripts(payload, ack, nack);
-        ack(dataAck);
+        const response = System.getSelectedPreloadScripts(payload);
+
+        if (Array.isArray(response)) {
+            const dataAck = _.clone(successAck);
+            dataAck.data = response;
+            ack(dataAck);
+        } else {
+            nack(response);
+        }
     }
 }
 

--- a/src/browser/api_protocol/api_handlers/system.js
+++ b/src/browser/api_protocol/api_handlers/system.js
@@ -455,15 +455,14 @@ function SystemApiHandler() {
 
     function getSelectedPreloadScripts(identity, message, ack, nack) {
         const { payload } = message;
-        const response = System.getSelectedPreloadScripts(payload);
 
-        if (Array.isArray(response)) {
-            const dataAck = _.clone(successAck);
-            dataAck.data = response;
-            ack(dataAck);
-        } else {
-            nack(response);
-        }
+        System.getSelectedPreloadScripts(payload)
+            .then(scriptSet => {
+                const dataAck = _.clone(successAck);
+                dataAck.data = scriptSet;
+                ack(dataAck);
+            })
+            .catch(nack);
     }
 }
 

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -549,8 +549,8 @@ limitations under the License.
             let response;
             try {
                 response = syncApiCall('get-selected-preload-scripts', preloadOption);
-            } catch (err) {
-                console.error(response.error);
+            } catch (error) {
+                console.error(error);
             }
 
             if (response) {

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -546,20 +546,25 @@ limitations under the License.
         const action = 'set-window-preload-state';
 
         if (preloadOption.length) { // short-circuit
-            const response = syncApiCall('get-selected-preload-scripts', preloadOption);
-
-            if (response.error) {
+            let response;
+            try {
+                response = syncApiCall('get-selected-preload-scripts', preloadOption);
+            } catch (err) {
                 console.error(response.error);
-            } else {
-                response.scripts.forEach((script, index) => {
-                    const { url } = preloadOption[index];
+            }
 
-                    try {
-                        window.eval(script); /* jshint ignore:line */
-                        asyncApiCall(action, { url, state: 'succeeded' });
-                    } catch (err) {
-                        console.error(`Execution failed for preload script "${url}".`, err);
-                        asyncApiCall(action, { url, state: 'failed' });
+            if (response) {
+                response.forEach((script, index) => {
+                    if (script !== null) {
+                        const { url } = preloadOption[index];
+
+                        try {
+                            window.eval(script); /* jshint ignore:line */
+                            asyncApiCall(action, { url, state: 'succeeded' });
+                        } catch (err) {
+                            console.error(`Execution failed for preload script "${url}".`, err);
+                            asyncApiCall(action, { url, state: 'failed' });
+                        }
                     }
                 });
             }


### PR DESCRIPTION
Issue was caused by returning to api-decorator `''` (empty string) for all missing scripts, which scripts were then executed "successfully" yielding `'succeeded`' status for each.

Fix was to:
1. Return `null` from `System` API ([here](https://github.com/HadoukenIO/core/pull/169/files#diff-f0315d374f54075fc6010e3dd131bea7R690)); and
2. Skip the `eval()` for such scripts in api-decorator by adding an `if` statement ([here](https://github.com/HadoukenIO/core/pull/169/files#diff-afd6093bc77cc147dad3d61fcfdec439R553)). This also skips updating the script status from `'load-failed'` to `'succeeded'`.

All the other edits in this PR have to do simplifying the `getSelectedPreloadScripts` API call to make proper use of `nack`.