### PR TITLE
RUN-3306 add back the ability to toggle the context menu

### DIFF
--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -76,15 +76,19 @@ limitations under the License.
         }
     }
 
-    function getWindowOptionsSync() {
+    function getCachedWindowOptionsSync() {
         if (!cachedOptions) {
-            cachedOptions = syncApiCall('get-current-window-options');
+            cachedOptions = getWindowOptionsSync();
         }
         return cachedOptions;
     }
 
+    function getWindowOptionsSync() {
+        return syncApiCall('get-current-window-options');
+    }
+
     function getWindowIdentitySync() {
-        let winOpts = getWindowOptionsSync();
+        let winOpts = getCachedWindowOptionsSync();
 
         return {
             uuid: winOpts.uuid,
@@ -305,10 +309,12 @@ limitations under the License.
         }
     }
 
-    function wireUpMenu(global, options) {
+    function wireUpMenu(global) {
         global.addEventListener('contextmenu', e => {
             if (!e.defaultPrevented) {
                 e.preventDefault();
+
+                const options = getWindowOptionsSync();
 
                 if (options.contextMenu) {
                     const identity = getWindowIdentitySync();
@@ -355,10 +361,10 @@ limitations under the License.
         //---------------------------------------------------------------
         // TODO: extract this, used to be bound to ready
         //---------------------------------------------------------------
-        let winOpts = getWindowOptionsSync();
+        let winOpts = getCachedWindowOptionsSync();
 
         showOnReady(glbl, winOpts);
-        wireUpMenu(glbl, winOpts);
+        wireUpMenu(glbl);
         wireUpZoomEvents();
         raiseReadyEvents(winOpts);
 
@@ -404,7 +410,7 @@ limitations under the License.
 
     function onContentReady(bindObject, callback) {
 
-        let winOpts = getWindowOptionsSync();
+        let winOpts = getCachedWindowOptionsSync();
 
         if (currPageHasLoaded && (getOpenerSuccessCallbackCalled() || window.opener === null || winOpts.rawWindowOpen)) {
             deferByTick(() => {
@@ -417,7 +423,7 @@ limitations under the License.
 
     function createChildWindow(options, cb) {
         let requestId = ++childWindowRequestId;
-        let winOpts = getWindowOptionsSync();
+        let winOpts = getCachedWindowOptionsSync();
         // initialize what's needed to create a child window via window.open
         let url = ((options || {}).url || undefined);
         let uniqueKey = generateGuidSync();
@@ -479,7 +485,7 @@ limitations under the License.
 
     global.chrome.desktop = {
         getDetails: cb => {
-            let winOpts = getWindowOptionsSync();
+            let winOpts = getCachedWindowOptionsSync();
             let details = {};
             let currSocketServerState = getSocketServerStateSync();
 
@@ -526,7 +532,7 @@ limitations under the License.
             windowExists: windowExistsSync,
             ipcconfig: getIpcConfigSync(),
             createChildWindow: createChildWindow,
-            getWindowOptions: getWindowOptionsSync,
+            getCachedWindowOptionsSync: getCachedWindowOptionsSync,
             openerSuccessCBCalled: openerSuccessCBCalled,
             emitNoteProxyReady: emitNoteProxyReady
         }
@@ -536,7 +542,7 @@ limitations under the License.
      * Preload script eval
      */
     ipc.once(`post-api-injection-${renderFrameId}`, () => {
-        const winOpts = getWindowOptionsSync();
+        const winOpts = getCachedWindowOptionsSync();
         const preloadOption = typeof winOpts.preload === 'string' ? [{ url: winOpts.preload }] : winOpts.preload;
         const action = 'set-window-preload-state';
 


### PR DESCRIPTION
@HarsimranSingh @rdepena @joneit 

Ensure that we are always getting the current option set. Also, rename the `getWindowOptions` call to `getCachedWindowOptions` as that is what its actually doing... there is a **required** sister [adapter PR here](https://github.com/openfin/javascript-adapter/pull/338).

[Tests well](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59b6da9d3d90dd51ca4f1011) compared to a [vanilla build](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59b6ddfa3d90dd51ca4f1012) 

Verify using the manual [test app](https://dl.openfin.co/services/download?fileName=Test%20Apps&config=http://test.openf.in/test_apps/config.json) go to the Window tab and under Options scroll to contextMenu