### PR TITLE
RUN-3316 Log preload script progress

### DIFF
--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -47,7 +47,6 @@ import { validateNavigationRules } from '../navigation_validation';
 import * as log from '../log';
 import SubscriptionManager from '../subscription_manager';
 import route from '../../common/route';
-import { fetchAndLoadPreloadScripts } from '../preload_scripts';
 
 const subscriptionManager = new SubscriptionManager();
 const TRAY_ICON_KEY = 'tray-icon-events';
@@ -439,21 +438,18 @@ Application.revokeWindowAccess = function() {
 };
 
 // userAppConfigArgs must be set to 'undefined' because
-// regular paramaters cannot come after default paramaters.
+// regular parameters cannot come after default parameters.
 Application.run = function(identity, configUrl = '', userAppConfigArgs = undefined) {
     if (!identity) {
         return;
     }
 
     const app = createAppObj(identity.uuid, null, configUrl);
-    const mainWindowOpts = _.clone(app._options);
-    const proceed = () => run(identity, mainWindowOpts, userAppConfigArgs);
-    const windowIdentity = {
-        uuid: mainWindowOpts.uuid,
-        name: mainWindowOpts.name
-    };
+    const proceed = () => run(identity, app._options, userAppConfigArgs);
+    const { uuid, name, preload } = app._options;
+    const windowIdentity = { uuid, name };
 
-    fetchAndLoadPreloadScripts(windowIdentity, mainWindowOpts.preload, proceed);
+    System.downloadPreloadScripts(windowIdentity, preload, proceed);
 };
 
 function run(identity, mainWindowOpts, userAppConfigArgs) {
@@ -558,7 +554,7 @@ function run(identity, mainWindowOpts, userAppConfigArgs) {
 
 
     //for backwards compatibility main window needs to have name === uuid
-    mainWindowOpts.name = uuid;
+    mainWindowOpts = Object.assign({}, mainWindowOpts, { name: uuid }); //avoid mutating original object
 
     const win = Window.create(app.id, mainWindowOpts);
     coreState.setWindowObj(app.id, win);

--- a/src/browser/preload_scripts.ts
+++ b/src/browser/preload_scripts.ts
@@ -24,6 +24,7 @@ import * as log from './log';
 import { Identity } from '../shapes';
 import ofEvents from './of_events';
 import route from '../common/route';
+import { Timer } from '../common/timer';
 
 
 // some local type definitions
@@ -32,10 +33,7 @@ interface PreloadInstance {
     url: string; // URI actually: http:// or file://
     optional?: boolean; // not used herein but used by api_decorator at script execution time
 }
-interface PreloadFetched extends PreloadInstance {
-    scriptPath: string; // location on disc of cached fetch
-}
-type FetchResolver = (value?: PreloadInstance | PreloadFetched | FetchResponse) => void;
+type FetchResolver = (value?: FetchResponse) => void;
 type Resolver = (value?: any) => void;
 type Rejector = (reason?: Error) => void;
 
@@ -50,6 +48,8 @@ interface FetchResponse {
     preloadScript: PreloadInstance;
     scriptPath: string;
 }
+
+type LoadResponses = boolean[];
 
 /** Returns a `Promise` once all preload scripts have been fetched and loaded or have failed to fetch or load.
  *
@@ -72,8 +72,9 @@ export function fetchAndLoadPreloadScripts(
     identity: Identity,
     preloadOption: PreloadOption,
     proceed?: () => void
-): Promise<undefined> {
-    let allLoaded: Promise<undefined>;
+): Promise<LoadResponses> {
+    const timer = new Timer();
+    let result: Promise<LoadResponses>;
 
     if (!preloadOption) {
         preloadOption = [];
@@ -85,50 +86,62 @@ export function fetchAndLoadPreloadScripts(
     if (!isPreloadOption(preloadOption)) {
         const message = 'Expected `preload` option to be a string primitive OR an array of objects with `url` props.';
         const err = new Error(message);
-        allLoaded = Promise.reject(err);
+        result = Promise.reject(err);
     } else {
         const loadedScripts: Promise<undefined>[] = preloadOption.map((preload: PreloadInstance) => {
-            updatePreloadState(identity, preload, 'load-started');
-
-            // following if clause avoids re-fetch for resources already in memory
-            // todo: following if clause slated for removal (RUN-3227, blocked by RUN-3162)
+            // following if clause avoids re-fetch for remote resources already in memory
+            // todo: following if clause slated for removal (RUN-3227, blocked by RUN-3162), i.e., return always
             if (
-                !REGEX_FILE_SCHEME.test(preload.url) && // except when resource does NOT use "file" scheme...
-                System.getPreloadScript(preload.url)   // ...is resource already in memory?
+                !REGEX_FILE_SCHEME.test(preload.url) && // not a local file AND...
+                System.getPreloadScript(preload.url)   // ...is already in memory?
             ) {
                 // previously downloaded
+                logPreload('info', identity, 'previously cached:', preload.url);
                 updatePreloadState(identity, preload, 'load-succeeded');
-                return Promise.resolve();
+                return Promise.resolve(true);
             } else {
                 // not previously downloaded *OR* previous downloaded failed
-                return fetch(identity, preload).then(load);
+                return fetchToCache(identity, preload).then(loadFromCache);
             }
         });
 
         // wait for them all to resolve
-        allLoaded = Promise.all(loadedScripts);
+        result = Promise.all(loadedScripts);
     }
 
-    allLoaded.catch(err => {
-        log.writeToLog(1, err, true);
+    result.catch((error: Error | string) => {
+        logPreload('error', identity, 'error', '', error);
+        return error;
+    }).then((values: LoadResponses) => {
+        const compact = values.filter(b => b);
+        logPreload('info', identity, 'summary: fetch/load',  `${compact.length} of ${values.length} scripts`, timer);
+        return values;
     });
 
     if (proceed) {
-        allLoaded.catch(proceed).then(proceed);
+        result.catch(proceed).then(proceed);
     }
 
-    return allLoaded;
+    return result;
 }
 
 
 // resolves to type `PreloadFetched` on success
-// resolves to `undefined` when fetch fails to download asset to Chromium cache
-function fetch(identity: Identity, preloadScript: PreloadInstance): Promise<FetchResponse> {
+// resolves to `undefined` when fetch fails to cache the asset
+function fetchToCache(identity: Identity, preloadScript: PreloadInstance): Promise<FetchResponse> {
+    const timer = new Timer();
+    const { url } = preloadScript;
+
+    logPreload('info', identity, 'fetch started', url);
+    updatePreloadState(identity, preloadScript, 'load-started');
+
     return new Promise((resolve: FetchResolver, reject: Rejector) => {
-        cachedFetch(identity.uuid, preloadScript.url, (fetchError: null | Error, scriptPath: string | undefined) => {
+        cachedFetch(identity.uuid, url, (fetchError: Error, scriptPath: string) => {
             if (!fetchError) {
+                logPreload('info', identity, 'fetch succeeded', url, timer);
                 resolve({identity, preloadScript, scriptPath});
             } else {
+                logPreload(preloadScript.optional ? 'warning' : 'error', identity, 'fetch failed', url, fetchError);
                 updatePreloadState(identity, preloadScript, 'load-failed');
                 resolve();
             }
@@ -136,35 +149,38 @@ function fetch(identity: Identity, preloadScript: PreloadInstance): Promise<Fetc
     });
 }
 
-// resolves to type `PreloadLoaded` on success
-// resolves to `undefined` when above fetch failed or when successfully fetched asset fails to load from Chromium cache
-function load(opts: FetchResponse): Promise<undefined> {
+function loadFromCache(opts: FetchResponse): Promise<boolean> {
     return new Promise((resolve: Resolver, reject: Rejector) => {
         if (!opts || !opts.scriptPath) {
-            resolve(); // got fetchError above OR no error but no scriptPath either; in any case don't attempt to load
+            resolve(false); // got fetchError above OR no error but no scriptPath either; in any case don't attempt to load
         } else {
-            const {identity, preloadScript, scriptPath} = opts;
+            const { identity, preloadScript, preloadScript: { url }, scriptPath } = opts;
 
-            fs.readFile(scriptPath, 'utf8', (readError: null | Error, scriptText: string | undefined) => {
+            logPreload('info', identity, 'load started', url);
+            updatePreloadState(identity, preloadScript, 'load-started');
 
+            fs.readFile(scriptPath, 'utf8', (readError: Error, scriptText: string) => {
                 // todo: remove following workaround when RUN-3162 issue fixed
                 //BEGIN WORKAROUND (RUN-3162 fetchError null on 404)
                 if (!readError && /^(Cannot GET |<\?xml)/.test(scriptText)) {
-                    // got a 404 but response was cached as a file
+                    // got a 404 but response was cached as a
+                    logPreload(preloadScript.optional ? 'warning' : 'error', identity, 'load failed', url, 404);
                     updatePreloadState(identity, preloadScript, 'load-failed');
-                    resolve();
+                    resolve(false);
                     return;
                 }
                 //END WORKAROUND
 
                 if (!readError) {
+                    logPreload('info', identity, 'load succeeded', url);
                     updatePreloadState(identity, preloadScript, 'load-succeeded');
                     System.setPreloadScript(preloadScript.url, scriptText);
                 } else {
+                    logPreload(preloadScript.optional ? 'warning' : 'error', identity, 'load failed', url, readError);
                     updatePreloadState(identity, preloadScript, 'load-failed');
                 }
 
-                resolve();
+                resolve(!readError);
             });
         }
     });
@@ -188,15 +204,40 @@ function isPreloadScript(preloadScript: PreloadInstance): preloadScript is Prelo
     );
 }
 
-const updatePreloadState = (identity: Identity, preloadScript: PreloadInstance, state: string): void => {
-    const {uuid, name} = identity;
+function logPreload(
+    level: string,
+    identity: Identity,
+    state: string,
+    url: string,
+    timerOrError?: Timer | Error | string | number
+): void {
+    if (url) {
+        state += ` for ${url}`;
+    }
+
+    if (timerOrError instanceof Timer) {
+        state += timerOrError.toString(' in #.### secs.');
+    } else if (timerOrError) {
+        state += `: ${JSON.stringify(timerOrError)}`;
+    }
+
+    log.writeToLog(level, `[PRELOAD] [${identity.uuid}]-[${identity.name}] ${state}`);
+}
+
+function updatePreloadState(
+    identity: Identity,
+    preloadScript: PreloadInstance,
+    state?: string
+): void {
+    const { url } = preloadScript;
+
+    const { uuid, name } = identity;
     const eventRoute = route.window('preload-state-changing', uuid, name);
-    const preloadState = Object.assign({}, preloadScript, {state});
+    const preloadState = Object.assign({}, preloadScript, { state });
 
-    preloadStates.set(preloadScript.url, state);
-
+    preloadStates.set(url, state);
     ofEvents.emit(eventRoute, {name, uuid, preloadState});
-};
+}
 
 export const getPreloadScriptState = (url: string): string => {
     return preloadStates.get(url);

--- a/src/common/timer.ts
+++ b/src/common/timer.ts
@@ -1,0 +1,51 @@
+/*
+Copyright 2017 OpenFin Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+export type msecs = number;
+export type secs = number;
+
+export class Timer {
+
+    private startTime: msecs;
+
+    public static format: string = '#.###';
+
+    constructor() {
+        this.reset();
+    }
+
+    public reset(): void {
+        this.startTime = Date.now();
+    }
+
+    get msecs(): msecs {
+        return Date.now() - this.startTime;
+    }
+
+    get secs(): secs {
+        return this.msecs / 1000;
+    }
+
+    public toString(format: string = Timer.format): string {
+        const match: string[] = format.match(/#+(\.#+)?/);
+        let result = this.secs.toFixed(match ? match[1].length - 1 : 0);
+        if (match) {
+            result = format.replace(match[0], result);
+        }
+        return result;
+    }
+
+}


### PR DESCRIPTION
To extract just the preload log items, do something like this:
```bash
grep ' \[PRELOAD\]' /c/Users/Jonathan/AppData/Local/OpenFin/cache/8.56.24.30/debug.log
```
(Note the leading space in the search arg, which gives better filtering of verbose logs, filtering out the `write-to-log` API calls containing [PRELOAD] made by api-decorator which are redundant.)

See sample log output in Jira [RUN-3316](https://appoji.jira.com/browse/RUN-3316).