### PR TITLE
RUN-3336 revert ready-to-show refactor

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -379,11 +379,6 @@ Window.create = function(id, opts) {
 
         browserWindow = BrowserWindow.fromId(id);
 
-        // set this listener up as soon as possible
-        browserWindow._whenReadyToShow = new Promise(ready => {
-            browserWindow.once('ready-to-show', ready);
-        });
-
         // this is a first pass at teardown. for now, push the unsubscribe
         // function for each subscription you make, on closed, remove them all
         // if you listen on 'closed' it will crash as your resources are
@@ -1750,11 +1745,14 @@ function applyAdditionalOptionsToWindowOnVisible(browserWindow, callback) {
     } else {
         browserWindow.once('visibility-changed', (event, isVisible) => {
             if (isVisible) {
-                if (browserWindow._readyToShowFiredAlready) {
+                if (browserWindow.isVisible()) {
                     callback();
-                } else {
                     // Version 8: Will be visible on the next tick
-                    browserWindow._whenReadyToShow.then(callback);
+                    // TODO: Refactor to also use 'ready-to-show'
+                } else {
+                    setTimeout(() => {
+                        callback();
+                    }, 1);
                 }
             }
         });


### PR DESCRIPTION
No longer waiting for the "no-show" `ready-to-show`.

Reverts #155 (RUN-3161).

Based on `8.56.24/staging` (currently aka `develop`).

Tested locally; I can see the resize options are properly applied now.