### PR TITLE
RUN-3313 added uuid property to 'desktop-icon-clicked' event

### DIFF
--- a/index.js
+++ b/index.js
@@ -548,7 +548,8 @@ function launchApp(argo, startExternalAdapterServer) {
 
         app.emit('synth-desktop-icon-clicked', {
             mouse: System.getMousePosition(),
-            tickCount: app.getTickCount()
+            tickCount: app.getTickCount(),
+            uuid
         });
     }, error => {
         log.writeToLog(1, error, true);


### PR DESCRIPTION
ℹ️ **About**
By adding `uuid` property to `desktop-icon-clicked` event we now can figure out which application is being launched

➕ **New tests**
• [System.addEventListener (desktop-icon-clicked)](https://testing-dashboard.openfin.co/#/app/tests/59c0232e7cb79f732d10c363/edit)
• [System.addEventListener (desktop-icon-clicked) T2](https://testing-dashboard.openfin.co/#/app/tests/59c011107cb79f732d10c362/edit)

✅  **Test results**
• [Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59c027917cb79f732d10c364)
• [Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59c028267cb79f732d10c365)

👫 Coupled with [this PR](https://github.com/openfin/javascript-adapter/pull/339)