### PR TITLE
RUN-3319 Preload scripts not injected on window.open

### DIFF
--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -445,8 +445,9 @@ Application.run = function(identity, configUrl = '', userAppConfigArgs = undefin
     }
 
     const app = createAppObj(identity.uuid, null, configUrl);
-    const proceed = () => run(identity, app._options, userAppConfigArgs);
-    const { uuid, name, preload } = app._options;
+    const mainWindowOpts = convertOpts.convertToElectron(app._options);
+    const proceed = () => run(identity, mainWindowOpts, userAppConfigArgs);
+    const { uuid, name, preload } = mainWindowOpts;
     const windowIdentity = { uuid, name };
 
     System.downloadPreloadScripts(windowIdentity, preload, proceed);

--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -667,7 +667,11 @@ exports.System = {
     clearPreloadCache,
 
     downloadPreloadScripts: function(identity, preloadOption, cb) {
-        fetchAndLoadPreloadScripts(identity, preloadOption, cb);
+        if (!preloadOption) {
+            cb();
+        } else {
+            fetchAndLoadPreloadScripts(identity, preloadOption, cb);
+        }
     },
 
     setPreloadScript: function(url, scriptText) {

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -395,7 +395,7 @@ Window.create = function(id, opts) {
         // each window now inherits the main window's base options. this can
         // be made to be the parent's options if that makes more sense...
         baseOpts = coreState.getMainWindowOptions(id) || {};
-        _options = _.extend(_.clone(baseOpts), convertOptions.convertToElectron(opts));
+        _options = convertOptions.convertToElectron(Object.assign({}, baseOpts, opts));
 
         // (taskbar) a child window should be grouped in with the application
         // if a taskbarIconGroup isn't specified
@@ -765,7 +765,7 @@ Window.create = function(id, opts) {
     };
 
     // Set preload scripts' final loading states
-    winObj.preloadState = _options.preload.map(preload => {
+    winObj.preloadState = (_options.preload || []).map(preload => {
         return {
             url: preload.url,
             state: getPreloadScriptState(preload.url)

--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -265,14 +265,18 @@ module.exports = {
         }
 
         const preload = options.preload;
-        if (!preload) {
-            // for all falsy values
-            newOptions.preload = [];
-        } else if (typeof preload === 'string') {
-            // backward compatibility
-            newOptions.preload = [{ url: preload }];
-        } else {
-            newOptions.preload = preload;
+        if (preload) {
+            if (typeof preload === 'string') {
+                // convert legacy `preload` option into modern `preload` option
+                newOptions.preload = [{ url: preload }];
+            } else if (
+                Array.isArray(preload) &&
+                preload.every(eachPreload => typeof eachPreload === 'object' && typeof eachPreload.url === 'string')
+            ) {
+                newOptions.preload = preload;
+            } else {
+                log.writeToLog('warning', 'Expected `preload` option to be a string primitive OR an array of objects with `url` string properties.');
+            }
         }
 
         if (options.customRequestHeaders !== undefined) {


### PR DESCRIPTION
## There were two issues here

### Issue 1

Default `preloads` was defined (in convert_options::`convertToElectron`) as `[]` (empty array), which was not sufficiently falsy to avoid overwriting underlying parent options.

Code in convert_options was also transforming the legacy form of the `preload` option to modern form. This is a reasonable place for it (despite the outdated name "convertToElectron" which referred to converting v5 options object for use with v6), but is was inadequately implemented as the same logic appeared in at least two other places.

Solution was to:
1. Make the default undefined rather than empty array
2. Remove the "convert" logic repetitions from other places where found
3. Ensure `convertToElectron` is called for all cases
4. Only use `preload` when defined (or convert undefined to empty array before using)
5. Duplicated some of the logic clean-up also found in preload_scripts.ts (see #171 = RUN-3316)

### Issue 2

Main window options are correctly converted when they are first used. However, unlike with `win._options`, the converted main window options are _not_ saved in `app._options` (`eOpts`, defined [here](https://github.com/HadoukenIO/core/blob/runtime-v8.56.24.39/src/browser/api/application.js#L987), is not being saved). So this is the original (unmutated) object. The problem is it is also the source of core_state::`getMainWindowOptions()`. I think a better source might be the actual main window object's `_options` object (if there is such a thing) — because it _is_ converted.

The problem with this situation is that the code was doing [this](https://github.com/HadoukenIO/core/pull/177/files#diff-d5752a5b2c3b7ce27c77d78f1b9278a6L398):
```js
_options = _.extend(_.clone(baseOpts), convertOptions.convertToElectron(opts));
```
The above draws from the unconverted main window options. This has the unfortunate effect that when the parent option is _not_ being overridden you can unexpectedly end up with an unconverted value. Possible reason this hasn't been (much of) an issue before is that for the most part "conversion" here means copying values to different option names. Only the `preload` option really does critical transformations on its value (which is why I didn't want this code here in the first place, but now it seems reasonable to put it here).

Solution: Although I think we should fix `GetMainWindowOptions` (to use the window's `_options` object, if available, rather than the app's). For now I was able to make this work changing the above to [this](https://github.com/HadoukenIO/core/pull/177/files#diff-d5752a5b2c3b7ce27c77d78f1b9278a6R398):
```js
_options = convertOptions.convertToElectron(Object.assign({}, baseOpts, opts));
```
Ignore the introduction of `assign`, which is not the point; the important part is this: Rather than converting (just) the child window options and superimposing them over the parent options, this new version first does the superimposing of the raw options; then does the converting (including converting the main window's options).

But I also had to make sure to call `convertToElectron` again for the `app._options` usage [here](https://github.com/HadoukenIO/core/pull/177/files#diff-a08b93ff0f46d39099ebdc2bb86958a1R448). So really this is getting messier and it would be better to get rid of `app._options`.