### PR TITLE
RUN-3049 Extend drag area for frameless window

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -164,8 +164,8 @@ let optionSetters = {
             // reapply resize region
             applyAdditionalOptionsToWindowOnVisible(browserWin, () => {
                 let resizeRegion = getOptFromBrowserWin('resizeRegion', browserWin, {
-                    size: 2,
-                    bottomRightCorner: 4
+                    size: 4,
+                    bottomRightCorner: 6
                 });
                 browserWin.setResizeRegion(resizeRegion.size);
                 browserWin.setResizeRegionBottomRight(resizeRegion.bottomRightCorner);

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -164,8 +164,8 @@ let optionSetters = {
             // reapply resize region
             applyAdditionalOptionsToWindowOnVisible(browserWin, () => {
                 let resizeRegion = getOptFromBrowserWin('resizeRegion', browserWin, {
-                    size: 4,
-                    bottomRightCorner: 6
+                    size: 7,
+                    bottomRightCorner: 9
                 });
                 browserWin.setResizeRegion(resizeRegion.size);
                 browserWin.setResizeRegionBottomRight(resizeRegion.bottomRightCorner);

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -56,6 +56,12 @@ import {
 import route from '../../common/route';
 import { getPreloadScriptState } from '../preload_scripts';
 
+// constants
+import {
+    DEFAULT_RESIZE_REGION_SIZE,
+    DEFAULT_RESIZE_REGION_BOTTOM_RIGHT_CORNER
+} from '../../shapes.ts';
+
 const subscriptionManager = new SubscriptionManager();
 const isWin32 = process.platform === 'win32';
 const windowPosCacheFolder = 'winposCache';
@@ -164,8 +170,8 @@ let optionSetters = {
             // reapply resize region
             applyAdditionalOptionsToWindowOnVisible(browserWin, () => {
                 let resizeRegion = getOptFromBrowserWin('resizeRegion', browserWin, {
-                    size: 7,
-                    bottomRightCorner: 9
+                    size: DEFAULT_RESIZE_REGION_SIZE,
+                    bottomRightCorner: DEFAULT_RESIZE_REGION_BOTTOM_RIGHT_CORNER
                 });
                 browserWin.setResizeRegion(resizeRegion.size);
                 browserWin.setResizeRegionBottomRight(resizeRegion.bottomRightCorner);

--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -84,8 +84,8 @@ function five0BaseOptions() {
         'resizable': true,
         'resize': true,
         'resizeRegion': {
-            'bottomRightCorner': 4,
-            'size': 2
+            'bottomRightCorner': 6,
+            'size': 4
         },
         'saveWindowState': true,
         'shadow': false,

--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -31,6 +31,12 @@ let coreState = require('./core_state.js');
 let log = require('./log');
 let regex = require('../common/regex');
 
+// constants
+import {
+    DEFAULT_RESIZE_REGION_SIZE,
+    DEFAULT_RESIZE_REGION_BOTTOM_RIGHT_CORNER
+} from '../../shapes.ts';
+
 // this is the 5.0 base to be sure that we are only extending what is already expected
 function five0BaseOptions() {
     return {
@@ -84,8 +90,8 @@ function five0BaseOptions() {
         'resizable': true,
         'resize': true,
         'resizeRegion': {
-            'bottomRightCorner': 9,
-            'size': 7
+            'bottomRightCorner': DEFAULT_RESIZE_REGION_BOTTOM_RIGHT_CORNER,
+            'size': DEFAULT_RESIZE_REGION_SIZE
         },
         'saveWindowState': true,
         'shadow': false,

--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -84,8 +84,8 @@ function five0BaseOptions() {
         'resizable': true,
         'resize': true,
         'resizeRegion': {
-            'bottomRightCorner': 6,
-            'size': 4
+            'bottomRightCorner': 9,
+            'size': 7
         },
         'saveWindowState': true,
         'shadow': false,

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -230,6 +230,9 @@ export interface WindowOptions {
     y?: number;
 }
 
+export const DEFAULT_RESIZE_REGION_SIZE = 7;
+export const DEFAULT_RESIZE_REGION_BOTTOM_RIGHT_CORNER = 9;
+
 export interface Manifest {
     appAssets?: {
         alias: string;


### PR DESCRIPTION
The default drag are really small I extended it to 4 pixels and 6 pixels on corners.