### PR TITLE
RUN-3356 fixed bug that returned wrong main window in getAllWindows

### DIFF
--- a/src/browser/core_state.ts
+++ b/src/browser/core_state.ts
@@ -456,7 +456,7 @@ export function getAllWindows(): WindowMeta[] {
     const getBounds = require('./api/window.js').Window.getBounds; // do not move this line!
     return apps.map(app => {
         const windowBounds = app.children
-            .filter(win => win.openfinWindow && win.id !== app.id)
+            .filter(win => win.openfinWindow)
             .map(win => {
                 const bounds = getBounds({
                     name: win.openfinWindow.name,
@@ -466,9 +466,14 @@ export function getAllWindows(): WindowMeta[] {
                 return bounds;
             });
 
+        const mainWin = windowBounds[0] || {};
+        if (windowBounds.length > 0) {
+            windowBounds.splice(0, 1); //child windows should not contain main window
+        }
+
         return {
             childWindows: windowBounds,
-            mainWindow: windowBounds[0] || {},
+            mainWindow: mainWin,
             uuid: app.uuid
         };
     });


### PR DESCRIPTION
:white_check_mark: Test Results
* [Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59c912487cb79f732d10c395)
* [Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59c912ba7cb79f732d10c396)