### PR TITLE
RUN-3349 avoid preload script logic when not initial app launch

### DIFF
--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -455,7 +455,13 @@ Application.run = function(identity, configUrl = '', userAppConfigArgs = undefin
     const { uuid, name } = mainWindowOpts;
     const windowIdentity = { uuid, name };
 
-    System.downloadPreloadScripts(windowIdentity, forPreload, proceed);
+    if (coreState.getAppRunningState(uuid)) {
+        proceed();
+    } else {
+        // Flow through preload script logic (eg. re-download of failed preload scripts)
+        // only if app is not already running.
+        System.downloadPreloadScripts(windowIdentity, forPreload, proceed);
+    }
 };
 
 function run(identity, mainWindowOpts, userAppConfigArgs) {


### PR DESCRIPTION
ℹ️ **About**

**Bug scenario:**
1. App has an invalid preload script and is already running (without its preload script, because the URL is broken and the *Core* failed to download it)
2. When launching this same app again, the *Core* tries to re-download that failed preload script again.

**Fix:** avoid preload script logic for apps that are already running

✅ **Test results**
• [Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59c948d07cb79f732d10c39c)
• [Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59c949307cb79f732d10c39d)