### PR TITLE
RUN-3358 remote subscription loop

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,8 @@ import {
 import {
     default as connectionManager,
     meshEnabled,
-    isMeshEnabled
+    isMeshEnabled,
+    getMeshUuid
 } from './src/browser/connection_manager';
 
 import * as log from './src/browser/log';
@@ -136,12 +137,14 @@ app.on('select-client-certificate', function(event, webContents, url, list, call
 portDiscovery.on('runtime/launched', (portInfo) => {
     //check if the ports match:
     const myPortInfo = coreState.getSocketServerState();
+    const myUuid = getMeshUuid();
+
     log.writeToLog('info', `Port discovery message received ${JSON.stringify(portInfo)}`);
 
-    //TODO: Include REALM in the determination.
+    //TODO include old runtimes in the determination.
     if (meshEnabled && portInfo.port !== myPortInfo.port && isMeshEnabled(portInfo.options)) {
 
-        connectionManager.connectToRuntime(`${myPortInfo.version}:${myPortInfo.port}`, portInfo).then((runtimePeer) => {
+        connectionManager.connectToRuntime(myUuid, portInfo).then((runtimePeer) => {
             //one connected we broadcast our port discovery message.
             staggerPortBroadcast(myPortInfo);
             log.writeToLog('info', `Connected to runtime ${JSON.stringify(runtimePeer.portInfo)}`);

--- a/src/browser/api_protocol/api_handlers/event_listener.js
+++ b/src/browser/api_protocol/api_handlers/event_listener.js
@@ -29,7 +29,8 @@ import {
     ExternalApplication
 } from '../../api/external_application';
 import {
-    default as connectionManager
+    default as connectionManager,
+    keyFromPortInfo
 } from '../../connection_manager';
 const coreState = require('../../core_state');
 const addNoteListener = require('../../api/notifications/subscriptions').addEventListener;
@@ -42,10 +43,10 @@ import {
 const successAck = {
     success: true
 };
-
+//TODO: this needs to be owned by external connections. RUN-3363 will take care of this.
 function isBrowserClient(uuid) {
     return connectionManager.connections.map((conn) => {
-        return conn.portInfo.version + ':' + conn.portInfo.port;
+        return keyFromPortInfo(conn.portInfo);
     }).filter((id) => id === uuid).length > 0;
 }
 

--- a/src/browser/api_protocol/transport_strategy/ws_strategy.ts
+++ b/src/browser/api_protocol/transport_strategy/ws_strategy.ts
@@ -9,6 +9,7 @@ import { ApiTransportBase, MessagePackage, Identity } from './api_transport_base
 import { default as RequestHandler } from './base_handler';
 import { Endpoint, ActionMap } from '../shapes';
 import route from '../../../common/route';
+import * as log from '../../log';
 
 declare var require: any;
 
@@ -49,6 +50,11 @@ export class WebSocketStrategy extends ApiTransportBase<MessagePackage> {
     }
 
     public send(externalConnection: any, payload: any): void {
+        try {
+            log.writeToLog('info', `sent external-adapter <= ${externalConnection.id} ${JSON.stringify(payload)}`);
+        } catch (err) {
+            /* tslint:disable: no-empty */
+        }
         socketServer.send(externalConnection.id, JSON.stringify(payload));
     }
 

--- a/src/browser/connection_manager.ts
+++ b/src/browser/connection_manager.ts
@@ -12,15 +12,15 @@ Please contact OpenFin Inc. at sales@openfin.co to obtain a Commercial License.
 // built-in modules
 declare const process: any;
 import { EventEmitter } from 'events';
-import { Identity } from './api_protocol/transport_strategy/api_transport_base';
-import { ArgMap, PortInfo } from './port_discovery';
 
 // npm modules
 // (none)
 
 // local modules
-const coreState = require('./core_state');
+import { Identity } from './api_protocol/transport_strategy/api_transport_base';
+import { ArgMap, PortInfo } from './port_discovery';
 import * as log from './log';
+const coreState = require('./core_state');
 
 //TODO: pre-release flag, this will go away once we release multi runtime.
 const multiRuntimeCommandLineFlag = 'enable-multi-runtime';
@@ -73,10 +73,19 @@ function isMeshEnabled(args: ArgMap) {
     return enabled;
 }
 
+function keyFromPortInfo(portInfo: PortInfo): string {
+    const { version, port, securityRealm } = portInfo;
+    return `${version}/${port}/${securityRealm ? securityRealm : ''}`;
+}
+
 if (multiRuntimeEnabled && isMeshEnabled(coreState.argo)) {
     startConnectionManager();
 }
 
+function getMeshUuid(): string {
+    const portInfo = <PortInfo>coreState.getSocketServerState();
+    return keyFromPortInfo(portInfo);
+}
 /*
   Note that these should match the definitions found here:
   https://github.com/openfin/runtime-p2p/blob/master/src/connection_manager.ts
@@ -86,7 +95,6 @@ interface PeerRuntime {
     portInfo: PortInfo;
     fin: any;
     isDisconnected: boolean;
-    identity: Identity;
 }
 
 interface IdentityAddress {
@@ -102,4 +110,4 @@ interface ConnectionManager extends EventEmitter {
 }
 
 export default <ConnectionManager>connectionManager;
-export { meshEnabled, PeerRuntime, isMeshEnabled  };
+export { meshEnabled, PeerRuntime, isMeshEnabled, keyFromPortInfo, getMeshUuid };

--- a/src/browser/connection_manager.ts
+++ b/src/browser/connection_manager.ts
@@ -20,7 +20,7 @@ import { EventEmitter } from 'events';
 import { Identity } from './api_protocol/transport_strategy/api_transport_base';
 import { ArgMap, PortInfo } from './port_discovery';
 import * as log from './log';
-const coreState = require('./core_state');
+import * as  coreState from './core_state';
 
 //TODO: pre-release flag, this will go away once we release multi runtime.
 const multiRuntimeCommandLineFlag = 'enable-multi-runtime';
@@ -74,8 +74,8 @@ function isMeshEnabled(args: ArgMap) {
 }
 
 function keyFromPortInfo(portInfo: PortInfo): string {
-    const { version, port, securityRealm } = portInfo;
-    return `${version}/${port}/${securityRealm ? securityRealm : ''}`;
+    const { version, port, securityRealm = '' } = portInfo;
+    return `${version}/${port}/${securityRealm}`;
 }
 
 if (multiRuntimeEnabled && isMeshEnabled(coreState.argo)) {


### PR DESCRIPTION
We were missing the runtimeUuid stamp on the events raised in a multi-runtime environment.  Additionally we had scenarios where securityRealm was not taken into consideration while matching subscriptions.

### Tests:
[Win10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59c959b07cb79f732d10c3a9)
[Win7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59c959b07cb79f732d10c3a9)
