### PR TITLE
RUN-3366 writeToLog use toString when avail

### DIFF
--- a/src/browser/log.ts
+++ b/src/browser/log.ts
@@ -33,25 +33,27 @@ export const logLevelMappings = new Map<any, any>([
  * Parses log messages and uses Electron's APIs to log them to console
  */
 export function writeToLog(level: any, message: any, debug?: boolean): any {
+    const isObj = typeof message === 'object';
     let parsedMessage: string;
 
     // Parse log message
     try {
 
-        if (typeof message === 'object') {
-            if (message instanceof Error) {
+        if (isObj && message instanceof Error) {
 
-                // Properly stringify error objects
-                parsedMessage = JSON.stringify(errorToPOJO(message));
-            } else {
+            // Properly stringify error objects (i.e., stack and message properties only)
+            parsedMessage = JSON.stringify(errorToPOJO(message));
 
-                // Stringify plain objects
-                parsedMessage = JSON.stringify(message);
-            }
+        } else if (isObj && (message === null || message.toString === Object.prototype.toString)) {
+
+            // Don't use Object's toString which just returns "[object Object]"
+            parsedMessage = JSON.stringify(message);
+
         } else {
 
-            // Convert non-object messages to a string
-            parsedMessage = message.toString();
+            // Use object's custom toString function OR convert primitive values to string
+            parsedMessage = message + ''; // .toString() does not work for undefined or NaN but concatenation does
+
         }
 
     } catch (err) {

--- a/src/browser/log.ts
+++ b/src/browser/log.ts
@@ -33,7 +33,7 @@ export const logLevelMappings = new Map<any, any>([
  * Parses log messages and uses Electron's APIs to log them to console
  */
 export function writeToLog(level: any, message: any, debug?: boolean): any {
-    const isObj = typeof message === 'object';
+    const isObj = typeof message === 'object' && message !== null;
     let parsedMessage: string;
 
     // Parse log message
@@ -44,15 +44,22 @@ export function writeToLog(level: any, message: any, debug?: boolean): any {
             // Properly stringify error objects (i.e., stack and message properties only)
             parsedMessage = JSON.stringify(errorToPOJO(message));
 
-        } else if (isObj && (message === null || message.toString === Object.prototype.toString)) {
+        } else if (isObj && message.toString === Object.prototype.toString) {
+
+            const className = message.constructor && message.constructor.name;
 
             // Don't use Object's toString which just returns "[object Object]"
             parsedMessage = JSON.stringify(message);
 
+            // Prefix object name to stringification when known
+            if (className !== 'Object' && className !== 'Function') {
+                parsedMessage = `${className}: ${parsedMessage}`;
+            }
+
         } else {
 
             // Use object's custom toString function OR convert primitive values to string
-            parsedMessage = message + ''; // .toString() does not work for undefined or NaN but concatenation does
+            parsedMessage = message + ''; // concatenation better than .toString(): handles null, undefined, NaN
 
         }
 

--- a/test/log.test.ts
+++ b/test/log.test.ts
@@ -25,11 +25,28 @@ import * as log from '../src/browser/log';
 describe('log', () => {
     describe('writeToLog', () => {
 
-        it('should stringify the object passed', () => {
+        it('should use plain object\'s toString', () => {
+            /* tslint:disable: no-invalid-this */
+            const obj = { a: 'a', b: 1, toString: function() { return `${this.a}@${this.b}`; } };
+            /* tslint:enable: no-invalid-this */
+
+            log.writeToLog('info', obj);
+            assert(lastLogValue === 'a@1');
+        });
+
+        it('should stringify the object passed when no own toString', () => {
             const obj = { a: 'a', b: 1 };
 
             log.writeToLog('info', obj);
             assert(lastLogValue === JSON.stringify(obj));
+        });
+
+        it('should prepend known class name to stringified object when no own toString', () => {
+            class Abc { public a = 7; public b = 1; }
+            const obj = new Abc();
+
+            log.writeToLog('info', obj);
+            assert(lastLogValue === `Abc: ${JSON.stringify(obj)}`);
         });
 
         it('should write strings', () => {


### PR DESCRIPTION
Please see Jira [RUN-3366](https://appoji.jira.com/browse/RUN-3366) for explanation.

**[Tests](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59c96bde7cb79f732d10c3ab).**

This is another casual general improvement PR and can slip to next sprint considering this sprint has so much to merge already.