### PR TITLE
RUN-3346 - added API to get focused window

### DIFF
--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -304,6 +304,28 @@ exports.System = {
             return process.env[varsToExpand] || null;
         }
     },
+    getFocusedWindow: function() {
+        let allWindows = coreState.getAllWindows();
+        for (var i = 0; i < allWindows.length; i++) {
+            let winMeta = allWindows[i];
+            let uuid = winMeta.uuid;
+            //check main window
+            let ofMainWin = coreState.getWindowByUuidName(uuid, winMeta.mainWindow.name);
+            if (ofMainWin && ofMainWin.browserWindow && ofMainWin.browserWindow.isFocused()) {
+                return ofMainWin;
+            } else {
+                //check child window
+                for (var j = 0; j < winMeta.childWindows.length; j++) {
+                    let childWin = winMeta.childWindows[j];
+                    let ofWin = coreState.getWindowByUuidName(uuid, childWin.name);
+                    if (ofWin && ofWin.browserWindow && ofWin.browserWindow.isFocused()) {
+                        return ofWin;
+                    }
+                }
+            }
+        }
+        return null;
+    },
     getHostSpecs: function() {
         return {
             cpus: os.cpus(),

--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -19,6 +19,7 @@ const fs = require('fs');
 const os = require('os');
 const electron = require('electron');
 const electronApp = electron.app;
+const electronBrowserWindow = electron.BrowserWindow;
 const ResourceFetcher = electron.resourceFetcher;
 const session = electron.session;
 const shell = electron.shell;
@@ -305,26 +306,17 @@ exports.System = {
         }
     },
     getFocusedWindow: function() {
-        let allWindows = coreState.getAllWindows();
-        for (var i = 0; i < allWindows.length; i++) {
-            let winMeta = allWindows[i];
-            let uuid = winMeta.uuid;
-            //check main window
-            let ofMainWin = coreState.getWindowByUuidName(uuid, winMeta.mainWindow.name);
-            if (ofMainWin && ofMainWin.browserWindow && ofMainWin.browserWindow.isFocused()) {
-                return ofMainWin;
+        const fWin = electronBrowserWindow.getFocusedWindow();
+        if (fWin) {
+            const win = coreState.getWinById(fWin.id);
+            if (win && win.openfinWindow) {
+                return { 'uuid': win.openfinWindow.uuid, 'name': win.openfinWindow.name };
             } else {
-                //check child window
-                for (var j = 0; j < winMeta.childWindows.length; j++) {
-                    let childWin = winMeta.childWindows[j];
-                    let ofWin = coreState.getWindowByUuidName(uuid, childWin.name);
-                    if (ofWin && ofWin.browserWindow && ofWin.browserWindow.isFocused()) {
-                        return ofWin;
-                    }
-                }
+                return null;
             }
+        } else {
+            return null;
         }
-        return null;
     },
     getHostSpecs: function() {
         return {

--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -306,17 +306,9 @@ exports.System = {
         }
     },
     getFocusedWindow: function() {
-        const fWin = electronBrowserWindow.getFocusedWindow();
-        if (fWin) {
-            const ofWin = coreState.getWinObjById(fWin.id);
-            if (ofWin) {
-                return { 'uuid': ofWin.uuid, 'name': ofWin.name };
-            } else {
-                return null;
-            }
-        } else {
-            return null;
-        }
+        const { id } = electronBrowserWindow.getFocusedWindow() || {};
+        const { uuid, name } = coreState.getWinObjById(id) || {};
+        return uuid ? { uuid, name } : null;
     },
     getHostSpecs: function() {
         return {

--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -308,9 +308,9 @@ exports.System = {
     getFocusedWindow: function() {
         const fWin = electronBrowserWindow.getFocusedWindow();
         if (fWin) {
-            const win = coreState.getWinById(fWin.id);
-            if (win && win.openfinWindow) {
-                return { 'uuid': win.openfinWindow.uuid, 'name': win.openfinWindow.name };
+            const ofWin = coreState.getWinObjById(fWin.id);
+            if (ofWin) {
+                return { 'uuid': ofWin.uuid, 'name': ofWin.name };
             } else {
                 return null;
             }

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -517,6 +517,16 @@ Window.create = function(id, opts) {
             emitToAppAndWin('crashed', 'out-of-memory');
         });
 
+        browserWindow.on('blur', () => {
+            ofEvents.emit(route.application('window-blurred', uuid), { topic: 'application', type: 'window-blurred', uuid, name });
+            ofEvents.emit(route.system('window-blurred'), { topic: 'system', type: 'window-blurred', uuid, name });
+        });
+
+        browserWindow.on('focus', () => {
+            ofEvents.emit(route.application('window-focused', uuid), { topic: 'application', type: 'window-focused', uuid, name });
+            ofEvents.emit(route.system('window-focused'), { topic: 'system', type: 'window-focused', uuid, name });
+        });
+
         browserWindow.on('responsive', () => {
             emitToAppAndWin('responding');
         });

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -1860,16 +1860,14 @@ function closeRequestedDecorator(payload) {
 }
 
 function blurredDecorator(payload, args) {
-    const uuid = payload.uuid;
-    const name = payload.name;
+    const { uuid, name } = payload;
     ofEvents.emit(route.application('window-blurred', uuid), { topic: 'application', type: 'window-blurred', uuid, name });
     ofEvents.emit(route.system('window-blurred'), { topic: 'system', type: 'window-blurred', uuid, name });
     return true;
 }
 
 function focusedDecorator(payload, args) {
-    const uuid = payload.uuid;
-    const name = payload.name;
+    const { uuid, name } = payload;
     ofEvents.emit(route.application('window-focused', uuid), { topic: 'application', type: 'window-focused', uuid, name });
     ofEvents.emit(route.system('window-focused'), { topic: 'system', type: 'window-focused', uuid, name });
     return true;

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -68,7 +68,8 @@ let browserWindowEventMap = {
         topic: 'api-injection-failed'
     },
     'blur': {
-        topic: 'blurred'
+        topic: 'blurred',
+        decorator: blurredDecorator
     },
     'synth-bounds-change': {
         topic: 'bounds-changing', // or bounds-changed
@@ -87,7 +88,8 @@ let browserWindowEventMap = {
         decorator: disabledFrameBoundsChangeDecorator
     },
     'focus': {
-        topic: 'focused'
+        topic: 'focused',
+        decorator: focusedDecorator
     },
     'opacity-changed': {
         decorator: opacityChangedDecorator
@@ -515,16 +517,6 @@ Window.create = function(id, opts) {
 
         webContents.on('crashed', () => {
             emitToAppAndWin('crashed', 'out-of-memory');
-        });
-
-        browserWindow.on('blur', () => {
-            ofEvents.emit(route.application('window-blurred', uuid), { topic: 'application', type: 'window-blurred', uuid, name });
-            ofEvents.emit(route.system('window-blurred'), { topic: 'system', type: 'window-blurred', uuid, name });
-        });
-
-        browserWindow.on('focus', () => {
-            ofEvents.emit(route.application('window-focused', uuid), { topic: 'application', type: 'window-focused', uuid, name });
-            ofEvents.emit(route.system('window-focused'), { topic: 'system', type: 'window-focused', uuid, name });
         });
 
         browserWindow.on('responsive', () => {
@@ -1867,6 +1859,21 @@ function closeRequestedDecorator(payload) {
     return propagate;
 }
 
+function blurredDecorator(payload, args) {
+    const uuid = payload.uuid;
+    const name = payload.name;
+    ofEvents.emit(route.application('window-blurred', uuid), { topic: 'application', type: 'window-blurred', uuid, name });
+    ofEvents.emit(route.system('window-blurred'), { topic: 'system', type: 'window-blurred', uuid, name });
+    return true;
+}
+
+function focusedDecorator(payload, args) {
+    const uuid = payload.uuid;
+    const name = payload.name;
+    ofEvents.emit(route.application('window-focused', uuid), { topic: 'application', type: 'window-focused', uuid, name });
+    ofEvents.emit(route.system('window-focused'), { topic: 'system', type: 'window-focused', uuid, name });
+    return true;
+}
 
 function boundsChangeDecorator(payload, args) {
     let boundsChangePayload = args[0];

--- a/src/browser/api_protocol/api_handlers/system.js
+++ b/src/browser/api_protocol/api_handlers/system.js
@@ -41,6 +41,7 @@ function SystemApiHandler() {
         'get-device-user-id': getDeviceUserId,
         'get-el-ipc-config': getElIPCConfig,
         'get-environment-variable': { apiFunc: getEnvironmentVariable, apiPath: '.getEnvironmentVariable' },
+        'get-focused-window': getFocusedWindow,
         'get-host-specs': { apiFunc: getHostSpecs, apiPath: '.getHostSpecs' },
         'get-min-log-level': getMinLogLevel,
         'get-monitor-info': getMonitorInfo, // apiPath: '.getMonitorInfo' -> called by js adapter during init so can't be disabled
@@ -248,6 +249,12 @@ function SystemApiHandler() {
     function getDeviceId(identity, message, ack) {
         var dataAck = _.clone(successAck);
         dataAck.data = System.getDeviceId();
+        ack(dataAck);
+    }
+
+    function getFocusedWindow(identity, message, ack) {
+        var dataAck = _.clone(successAck);
+        dataAck.data = System.getFocusedWindow();
         ack(dataAck);
     }
 


### PR DESCRIPTION
also added the ability to listen to system and application level window focused/blurred events.

Pull request for javascript-adapter: https://github.com/openfin/javascript-adapter/pull/341

:heavy_plus_sign: New Tests
* [System.getFocusedWindow](https://testing-dashboard.openfin.co/#/app/tests/59ca57c57cb79f732d10c3b6/edit)
* [System.addEventListener (window-focused)](https://testing-dashboard.openfin.co/#/app/tests/59ca4c337cb79f732d10c3b2/edit)
* [System.addEventListener (window-blurred)](https://testing-dashboard.openfin.co/#/app/tests/59ca53327cb79f732d10c3b3/edit)
* [Application.addEventListener (window-focused)](https://testing-dashboard.openfin.co/#/app/tests/59ca55c37cb79f732d10c3b4/edit)
* [Application.addEventListener (window-blurred)](https://testing-dashboard.openfin.co/#/app/tests/59ca56437cb79f732d10c3b5/edit)

:white_check_mark: Test Results
* [Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59ca5def7cb79f732d10c3b8)
* [Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59ca5e457cb79f732d10c3b9)
