### PR TITLE
RUN-3363 detect external conn as runtime

### DIFF
--- a/src/browser/api/external_application.ts
+++ b/src/browser/api/external_application.ts
@@ -60,6 +60,14 @@ export module ExternalApplication {
         });
     }
 
+    export function isRuntimeClient(uuid: string) {
+        const target = authenticatedConnections.find(c => {
+            return c.uuid === uuid;
+        });
+
+        return target ? target.runtimeClient === true : false;
+    }
+
     export function removeExternalConnection(externalConnection: Identity) {
         authenticatedConnections.splice(authenticatedConnections.indexOf(externalConnection), 1);
 

--- a/src/browser/api/external_application.ts
+++ b/src/browser/api/external_application.ts
@@ -10,7 +10,27 @@ import { Identity } from '../../shapes';
 import * as ProcessTracker from '../process_tracker.js';
 import route from '../../common/route';
 
-const authenticatedConnections: any[] = [];
+const authenticatedConnections: ExternalApplicationOptions[] = [];
+
+export interface ExternalApplicationClient {
+    type: string;
+    version: any;
+}
+
+export interface ExternalApplicationOptions extends Identity {
+    runtimeClient: boolean;
+    nonPersistent: boolean;
+    id: number;
+    licenseKey?: string;
+    configUrl?: string;
+    pid?: number;
+    client?: ExternalApplicationClient;
+    type?: string;
+}
+
+interface ExternalProcessInfo {
+    parent: Identity;
+}
 
 export module ExternalApplication {
     export function addEventListener(identity: Identity, type: string, listener: Function) {
@@ -33,7 +53,7 @@ export module ExternalApplication {
         };
     }
 
-    export function addExternalConnection(externalConnObj: Identity) {
+    export function addExternalConnection(externalConnObj: ExternalApplicationOptions) {
         const {
             uuid
         } = externalConnObj;
@@ -48,13 +68,13 @@ export module ExternalApplication {
         });
     }
 
-    export function getExternalConnectionByUuid(uuid: string) {
+    export function getExternalConnectionByUuid(uuid: string): ExternalApplicationOptions {
         return authenticatedConnections.find(c => {
             return c.uuid === uuid;
         });
     }
 
-    export function getExternalConnectionById(id: number) {
+    export function getExternalConnectionById(id: number): ExternalApplicationOptions {
         return authenticatedConnections.find(c => {
             return c.id === id;
         });
@@ -68,7 +88,7 @@ export module ExternalApplication {
         return target ? target.runtimeClient === true : false;
     }
 
-    export function removeExternalConnection(externalConnection: Identity) {
+    export function removeExternalConnection(externalConnection: ExternalApplicationOptions) {
         authenticatedConnections.splice(authenticatedConnections.indexOf(externalConnection), 1);
 
         ofEvents.emit(route.externalApplication('disconnected', externalConnection.uuid), {
@@ -85,7 +105,14 @@ export module ExternalApplication {
         return authenticatedConnections.slice(0);
     }
 
-    interface ExternalProcessInfo {
-        parent: Identity;
+    export function createExternalApplicationOptions(externalOpts: any): ExternalApplicationOptions {
+        const externalAppOptions: ExternalApplicationOptions = {
+            id: externalOpts.id,
+            uuid: externalOpts.uuid,
+            runtimeClient: false,
+            nonPersistent: false
+        };
+
+        return Object.assign(externalAppOptions, externalOpts);
     }
 }

--- a/src/browser/api/external_application.ts
+++ b/src/browser/api/external_application.ts
@@ -18,13 +18,13 @@ export interface ExternalApplicationClient {
 }
 
 export interface ExternalApplicationOptions extends Identity {
-    runtimeClient: boolean;
-    nonPersistent: boolean;
+    client?: ExternalApplicationClient;
+    configUrl?: string;
     id: number;
     licenseKey?: string;
-    configUrl?: string;
+    nonPersistent: boolean;
     pid?: number;
-    client?: ExternalApplicationClient;
+    runtimeClient: boolean;
     type?: string; // authorization type e.g., 'file-token'
 }
 

--- a/src/browser/api/external_application.ts
+++ b/src/browser/api/external_application.ts
@@ -13,8 +13,8 @@ import route from '../../common/route';
 const authenticatedConnections: ExternalApplicationOptions[] = [];
 
 export interface ExternalApplicationClient {
-    type: string;
-    version: any;
+    type: 'dotnet' | 'java' | 'air' | 'node' | 'silverlight';
+    version: string;
 }
 
 export interface ExternalApplicationOptions extends Identity {
@@ -25,7 +25,7 @@ export interface ExternalApplicationOptions extends Identity {
     configUrl?: string;
     pid?: number;
     client?: ExternalApplicationClient;
-    type?: string;
+    type?: string; // authorization type e.g., 'file-token'
 }
 
 interface ExternalProcessInfo {

--- a/src/browser/api_protocol/api_handlers/authorization.js
+++ b/src/browser/api_protocol/api_handlers/authorization.js
@@ -105,6 +105,8 @@ function onRequestAuthorization(id, data) {
         externalConnObj.configUrl = authObj.authReqPayload.configUrl;
     }
 
+    //issue with older adapters where part of the data is comming from different locations;
+    const externalApplicationOptions = ExternalApplication.createExternalApplicationOptions(Object.assign({}, authObj, externalConnObj));
     //Check if the file and token were written.
 
     authenticateUuid(authObj, data.payload, (success, error) => {
@@ -121,19 +123,19 @@ function onRequestAuthorization(id, data) {
 
         socketServer.send(id, JSON.stringify(authorizationResponse));
         if (success) {
-            ExternalApplication.addExternalConnection(externalConnObj);
+            ExternalApplication.addExternalConnection(externalApplicationOptions);
             socketServer.connectionAuthenticated(id, uuid);
 
             rvmMessageBus.registerLicenseInfo({
                 data: {
-                    licenseKey: authObj && authObj.authReqPayload && authObj.authReqPayload.licenseKey,
-                    client: authObj && authObj.authReqPayload && authObj.authReqPayload.client,
+                    licenseKey: externalApplicationOptions.licenseKey,
+                    client: externalApplicationOptions.client,
                     uuid,
                     parentApp: {
                         uuid: null
                     }
                 }
-            }, authObj && authObj.authReqPayload && authObj.authReqPayload.configUrl);
+            }, externalApplicationOptions.configUrl);
         } else {
             socketServer.closeConnection(id);
         }

--- a/src/browser/api_protocol/api_handlers/authorization.js
+++ b/src/browser/api_protocol/api_handlers/authorization.js
@@ -106,7 +106,7 @@ function onRequestAuthorization(id, data) {
     }
 
     //issue with older adapters where part of the data is comming from different locations;
-    const externalApplicationOptions = ExternalApplication.createExternalApplicationOptions(Object.assign({}, authObj, externalConnObj));
+    const externalApplicationOptions = ExternalApplication.createExternalApplicationOptions(Object.assign({}, authObj.authReqPayload, externalConnObj));
     //Check if the file and token were written.
 
     authenticateUuid(authObj, data.payload, (success, error) => {

--- a/src/browser/api_protocol/api_handlers/event_listener.js
+++ b/src/browser/api_protocol/api_handlers/event_listener.js
@@ -25,12 +25,11 @@ let apiProtocolBase = require('./api_protocol_base.js');
 let Window = require('../../api/window.js').Window;
 let Application = require('../../api/application.js').Application;
 let System = require('../../api/system.js').System;
+
 import {
     ExternalApplication
 } from '../../api/external_application';
-import {
-    default as connectionManager
-} from '../../connection_manager';
+
 const coreState = require('../../core_state');
 const addNoteListener = require('../../api/notifications/subscriptions').addEventListener;
 
@@ -42,12 +41,6 @@ import {
 const successAck = {
     success: true
 };
-
-function isBrowserClient(uuid) {
-    return connectionManager.connections.map((conn) => {
-        return conn.portInfo.version + ':' + conn.portInfo.port;
-    }).filter((id) => id === uuid).length > 0;
-}
 
 function EventListenerApiHandler() {
     const eventListenerActionMap = {
@@ -70,7 +63,7 @@ function EventListenerApiHandler() {
                 const islocalWindow = !!coreState.getWindowByUuidName(targetUuid, targetUuid);
                 const localUnsub = Window.addEventListener(identity, windowIdentity, type, cb);
                 let remoteUnSub;
-                const isExternalClient = isBrowserClient(identity.uuid);
+                const isExternalClient = ExternalApplication.isRuntimeClient(identity.uuid);
 
                 if (!islocalWindow && !isExternalClient) {
                     const subscription = {
@@ -105,7 +98,7 @@ function EventListenerApiHandler() {
                 const islocalApp = !!coreState.getWindowByUuidName(targetUuid, targetUuid);
                 const localUnsub = Application.addEventListener(appIdentity, type, cb);
                 let remoteUnSub;
-                const isExternalClient = isBrowserClient(identity.uuid);
+                const isExternalClient = ExternalApplication.isRuntimeClient(identity.uuid);
 
                 if (!islocalApp && !isExternalClient) {
                     const subscription = {


### PR DESCRIPTION
* Created types for External Application Objects
* Added isRuntimeClient function and check
* Consolidated External connections options

Please review the [External connection wiki](https://github.com/HadoukenIO/core/wiki/External-Connections) for background.

Tests:
* [Win10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59ce4ed57cb79f732d10c3f7)
* [Win7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59ce4e7e7cb79f732d10c3f6)
* Tested node-adapter with 1 expected failure
* Smoke tested .NET app and did not observe issues connecting/disconnecting