### PR TITLE
RUN-3127 Change default backgroundColor to #FFF

### DIFF
--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -104,7 +104,7 @@ function five0BaseOptions() {
         'url': 'about:blank',
         'uuid': '',
         'waitForPageLoad': true,
-        'backgroundColor': '#000',
+        'backgroundColor': '#FFF',
         'webSecurity': true
     };
 }


### PR DESCRIPTION
Currently default backgroundColor is set to #000, so when backgroundColor in other PR will be fixed the background color of js apps will be black. Currently background color of js apps are white because "backgroundColor" of js api doesn't work correctly. First to fix "backgroundColor" functionality I need to change default background color.   