### PR TITLE
RUN-3382 isMeshEnabled bug

### DIFF
--- a/src/browser/connection_manager.ts
+++ b/src/browser/connection_manager.ts
@@ -61,7 +61,7 @@ function buildNoopConnectionManager() {
     connectionManager.connections = [];
 }
 
-function isMeshEnabled(args: ArgMap) {
+function isMeshEnabled(args: ArgMap = {}) {
     let enabled = false;
     const enableMesh = args[enableMeshCommandLineFlag];
     const securityRealm = args[securityRealmFlag];


### PR DESCRIPTION
Connection Manager's `isMeshEnabled` blows up when using an old .NET adapter

✅ Test Results:
• [Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59d54c617cb79f732d10c445)
• [Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59d54ced7cb79f732d10c446)