### PR TITLE
RUN-3380 allow isRunning check when app is manifest created

### DIFF
--- a/src/browser/api_protocol/api_handlers/middleware_entity_existence.ts
+++ b/src/browser/api_protocol/api_handlers/middleware_entity_existence.ts
@@ -24,6 +24,7 @@ const apisToIgnore = new Set([
     // Application
     'create-application',
     'create-child-window',
+    'is-application-running',
     //TODO: we do not check run for .NET, the adapter will create an application then run it without waiting for the ack.
     'run-application',
     // Window


### PR DESCRIPTION
Just checking if an app is running should not toss an exception.

[tests well](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59e4f385af26a25be2ffc8e9)
[added test](https://testing-dashboard.openfin.co/#/app/tests/59e4ee38af26a25be2ffc8e2/edit)