### PR TITLE
RUN-3442 Updated runtime-p2p to latest using npm hadouken-js-adapter

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -33,7 +33,7 @@ const srcFiles = ['src/**/*.js', 'index.js', 'Gruntfile.js'];
 
 //optional dependencies that we ship.
 const optionalDependencies = [
-    'node-adapter/**',
+    'hadouken-js-adapter/**',
     'runtime-p2p/**'
 ];
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/openfin/openfin",
   "optionalDependencies": {
     "openfin-sign": "git+ssh://git@github.com:openfin/openfin-sign.git#caee55ecbe6f81e6ed9630790781fe4d1835cb03",
-    "runtime-p2p": "git+ssh://git@github.com:openfin/runtime-p2p.git#e5d4bd60324bf0a54d1d880b80ac944c27e4caed"
+    "runtime-p2p": "git+ssh://git@github.com:openfin/runtime-p2p.git#24c57c1770b1ae2896e544197e12cb688dbf6de2"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.0",


### PR DESCRIPTION
[js-adapter](https://github.com/HadoukenIO/js-adapter) now required via npm.

Test results:
[Win7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59e6088caf26a25be2ffc8ea)
[Win10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59e60908af26a25be2ffc8eb)