### PR TITLE
RUN-3390 (phase 1) separate plugins from preload scripts

### DIFF
--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -727,7 +727,10 @@ exports.System = {
         }
 
         // when load/fetch failed, mapped object will be `undefined` (stringifies as `null`)
-        const scriptSet = preloadOption.map(preload => preloadScriptsCache[getIdentifier(preload)]);
+        const scriptSet = preloadOption.map((preload) => {
+            preload.content = preloadScriptsCache[getIdentifier(preload)];
+            return preload;
+        });
         return Promise.resolve(scriptSet);
     }
 };

--- a/src/browser/api_protocol/api_handlers/window.js
+++ b/src/browser/api_protocol/api_handlers/window.js
@@ -66,6 +66,7 @@ module.exports.windowApiMap = {
     'show-window': showWindow,
     'set-foreground-window': setForegroundWindow,
     'set-window-bounds': setWindowBounds,
+    'set-window-plugin-state': setWindowPluginState,
     'set-window-preload-state': setWindowPreloadState,
     'set-zoom-level': setZoomLevel,
     'show-at-window': showAtWindow,
@@ -131,6 +132,14 @@ function setWindowBounds(identity, message, ack) {
 
     Window.setBounds(windowIdentity, payload.left, payload.top, payload.width, payload.height);
     ack(successAck);
+}
+
+function setWindowPluginState(identity, message, ack) {
+    const payload = message.payload;
+    const windowIdentity = apiProtocolBase.getTargetWindowIdentity(identity);
+
+    Window.setWindowPreloadState(windowIdentity, payload);
+    ack();
 }
 
 function setWindowPreloadState(identity, message, ack) {

--- a/src/browser/api_protocol/api_handlers/window.js
+++ b/src/browser/api_protocol/api_handlers/window.js
@@ -135,7 +135,7 @@ function setWindowBounds(identity, message, ack) {
 }
 
 function setWindowPluginState(identity, message, ack) {
-    const payload = message.payload;
+    const { payload } = message;
     const windowIdentity = apiProtocolBase.getTargetWindowIdentity(identity);
 
     Window.setWindowPreloadState(windowIdentity, payload);

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -95,12 +95,19 @@ export interface OpenFinWindow {
     hideReason: string;
     id: number;
     name: string;
-    uuid: string;
+    pluginState: {
+        link?: string;
+        name: string;
+        optional?: boolean;
+        state: 'load-failed'|'load-succeeded'|'failed'|'succeeded';
+        version: string;
+    }[];
     preloadState: {
         optional?: boolean;
         state: 'load-started'|'load-failed'|'load-succeeded'|'failed'|'succeeded';
         url: string;
     }[];
+    uuid: string;
 }
 
 export interface BrowserWindow {


### PR DESCRIPTION
This is **Phase 1** of _plugin-preload separation/refactor/cleanup/fix_.

All plugin/preload tests will be written when all phases are completed.

This 1st phase:
• separates plugin/preload logic in api-decorator and window handler files
• ensures plugins are eval'ed 1st
• fixes preload script updates to final states

✅ Test results:
• [Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59e7bae7af26a25be2ffc8f9)
• [Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59e7bb7baf26a25be2ffc8fa)