### PR TITLE
RUN-3390 (phase 2) separate plugins from preload scripts

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -357,6 +357,7 @@ module.exports = (grunt) => {
             'src/browser/rvm/utils.ts',
             'src/browser/external_window_event_adapter.js',
             'src/browser/connection_manager.ts',
+            'src/browser/plugins.ts',
             'src/browser/transport.ts',
             'src/browser/transports/socket_server.js',
             'src/browser/transports/wm_copydata.ts',

--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -447,10 +447,6 @@ Application.run = function(identity, configUrl = '', userAppConfigArgs = undefin
     const app = createAppObj(identity.uuid, null, configUrl);
     const mainWindowOpts = convertOpts.convertToElectron(app._options);
 
-    let forPreload = [];
-    if (Array.isArray(mainWindowOpts.preload) && mainWindowOpts.preload[0] !== undefined) { forPreload = forPreload.concat(mainWindowOpts.preload); }
-    if (Array.isArray(mainWindowOpts.plugin) && mainWindowOpts.plugin[0] !== undefined) { forPreload = forPreload.concat(mainWindowOpts.plugin); }
-
     const proceed = () => run(identity, mainWindowOpts, userAppConfigArgs);
     const { uuid, name } = mainWindowOpts;
     const windowIdentity = { uuid, name };
@@ -460,7 +456,7 @@ Application.run = function(identity, configUrl = '', userAppConfigArgs = undefin
     } else {
         // Flow through preload script logic (eg. re-download of failed preload scripts)
         // only if app is not already running.
-        System.downloadPreloadScripts(windowIdentity, forPreload, proceed);
+        System.downloadPreloadScripts(windowIdentity, mainWindowOpts.preload, proceed);
     }
 };
 

--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -41,6 +41,7 @@ const ProcessTracker = require('../process_tracker.js');
 import route from '../../common/route';
 import { fetchAndLoadPreloadScripts, getIdentifier } from '../preload_scripts';
 import { FrameInfo } from './frame';
+import * as plugins from '../plugins';
 
 const defaultProc = {
     getCpuUsage: function() {
@@ -698,6 +699,10 @@ exports.System = {
         } else {
             fetchAndLoadPreloadScripts(identity, preloadOption, cb);
         }
+    },
+
+    getPluginModules: function(cb) {
+        return plugins.getModules().then(cb);
     },
 
     // identitier is preload script url or plugin name

--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -701,8 +701,8 @@ exports.System = {
         }
     },
 
-    getPluginModules: function(cb) {
-        return plugins.getModules().then(cb);
+    getPluginModules: function() {
+        return plugins.getModules();
     },
 
     // identitier is preload script url or plugin name

--- a/src/browser/api_protocol/api_handlers/system.js
+++ b/src/browser/api_protocol/api_handlers/system.js
@@ -481,11 +481,13 @@ function SystemApiHandler() {
     }
 
     function getPluginModules(identity, message, ack, nack) {
-        System.getPluginModules((pluginModules) => {
-            const dataAck = _.clone(successAck);
-            dataAck.data = pluginModules;
-            ack(dataAck);
-        });
+        System.getPluginModules()
+            .then((pluginModules) => {
+                const dataAck = _.clone(successAck);
+                dataAck.data = pluginModules;
+                ack(dataAck);
+            })
+            .catch(nack);
     }
 }
 

--- a/src/browser/api_protocol/api_handlers/system.js
+++ b/src/browser/api_protocol/api_handlers/system.js
@@ -51,6 +51,7 @@ function SystemApiHandler() {
         'get-proxy-settings': getProxySettings,
         'get-remote-config': { apiFunc: getRemoteConfig, apiPath: '.getRemoteConfig' },
         'get-rvm-info': getRvmInfo,
+        'get-plugin-modules': getPluginModules,
         'get-selected-preload-scripts': getSelectedPreloadScripts,
         'get-version': getVersion,
         'get-websocket-state': getWebSocketState,
@@ -477,6 +478,14 @@ function SystemApiHandler() {
                 ack(dataAck);
             })
             .catch(nack);
+    }
+
+    function getPluginModules(identity, message, ack, nack) {
+        System.getPluginModules((pluginModules) => {
+            const dataAck = _.clone(successAck);
+            dataAck.data = pluginModules;
+            ack(dataAck);
+        });
     }
 }
 

--- a/src/browser/api_protocol/api_handlers/window.js
+++ b/src/browser/api_protocol/api_handlers/window.js
@@ -138,7 +138,7 @@ function setWindowPluginState(identity, message, ack) {
     const { payload } = message;
     const windowIdentity = apiProtocolBase.getTargetWindowIdentity(identity);
 
-    Window.setWindowPreloadState(windowIdentity, payload);
+    Window.setWindowPluginState(windowIdentity, payload);
     ack();
 }
 

--- a/src/browser/core_state.ts
+++ b/src/browser/core_state.ts
@@ -209,13 +209,13 @@ export function getUuidBySourceUrl(sourceUrl: string): string|boolean {
     return app && app.appObj && app.appObj.uuid;
 }
 
-export function getConfigUrlByUuid(uuid: string): string|boolean {
+export function getConfigUrlByUuid(uuid: string): string {
     const app = getAppAncestor(uuid);
     if  (app && app._configUrl) {
         return app._configUrl;
     } else {
         const externalApp = getExternalAncestor(uuid);
-        return externalApp && externalApp.configUrl;
+        return (externalApp && externalApp.configUrl) || '';
     }
 }
 

--- a/src/browser/plugins.ts
+++ b/src/browser/plugins.ts
@@ -38,17 +38,15 @@ export async function getModules(): Promise<PluginWithContent[]> {
  */
 async function getModule(sourceUrl: string, plugin: Plugin): Promise<PluginWithContent> {
     const id = `${plugin.name}: ${plugin.version}`;
+    let pluginPath;
 
-    // Plugin path is already available
     if (pluginPaths.has(id)) {
-        const pluginPath = pluginPaths.get(id);
-        return await addContent(plugin, pluginPath);
+        pluginPath = pluginPaths.get(id);
+    } else {
+        const {payload} = await rvmMessageBus.getPluginInfo(sourceUrl, plugin);
+        pluginPath = !payload.error ? path.join(payload.path, payload.target) : '';
+        pluginPaths.set(id, pluginPath);
     }
-
-    const {payload} = await rvmMessageBus.getPluginInfo(sourceUrl, plugin);
-    const pluginPath = !payload.error ? path.join(payload.path, payload.target) : '';
-
-    pluginPaths.set(id, pluginPath);
 
     return await addContent(plugin, pluginPath);
 }

--- a/src/browser/plugins.ts
+++ b/src/browser/plugins.ts
@@ -1,0 +1,73 @@
+/*
+Copyright 2017 OpenFin Inc.
+
+Licensed under OpenFin Commercial License you may not use this file except in compliance with your Commercial License.
+Please contact OpenFin Inc. at sales@openfin.co to obtain a Commercial License.
+*/
+
+import * as path from 'path';
+import { getStartManifest, StartManifest } from './core_state';
+import { Plugin } from '../shapes';
+import { readFile } from 'fs';
+import { rvmMessageBus } from './rvm/rvm_message_bus';
+
+interface PluginWithContent extends Plugin {
+    _content: string;
+}
+
+/**
+ * A map of already-retrieved plugin module paths.
+ *
+ * Examples:
+ * 'pluginName: 1.0.0' -> 'path\to\plugin\injectable\script.js'
+ * 'pluginName2: 0.0.1' -> '' // plugin/version doesn't exist
+ */
+const pluginPaths: Map<string, string> = new Map();
+
+/**
+ * Gets all plugins defined in app's manifest
+ */
+export async function getModules(): Promise<PluginWithContent[]> {
+    const {url, data: {plugin: plugins = []}} = <StartManifest>getStartManifest();
+    const promises = plugins.map((plugin: Plugin) => getModule(url, plugin));
+    return await Promise.all(promises);
+}
+
+/**
+ * Gets a single plugin module
+ */
+async function getModule(sourceUrl: string, plugin: Plugin): Promise<PluginWithContent> {
+    const id = `${plugin.name}: ${plugin.version}`;
+
+    // Plugin path is already available
+    if (pluginPaths.has(id)) {
+        const pluginPath = pluginPaths.get(id);
+        return await addContent(plugin, pluginPath);
+    }
+
+    const {payload} = await rvmMessageBus.getPluginInfo(sourceUrl, plugin);
+    const pluginPath = !payload.error ? path.join(payload.path, payload.target) : '';
+
+    pluginPaths.set(id, pluginPath);
+
+    return await addContent(plugin, pluginPath);
+}
+
+/**
+ * Reads and adds module content to plugin
+ */
+function addContent(plugin: Plugin, pluginPath: string): Promise<PluginWithContent> {
+    return new Promise((resolve) => {
+        if (!pluginPath) {
+            return resolve({...plugin, _content: ''});
+        }
+
+        readFile(pluginPath, 'utf8', (err, data) => {
+            if (err) {
+                resolve({...plugin, _content: ''});
+            } else {
+                resolve({...plugin, _content: data});
+            }
+        });
+    });
+}

--- a/src/browser/rvm/rvm_message_bus.ts
+++ b/src/browser/rvm/rvm_message_bus.ts
@@ -8,6 +8,7 @@ import { WMCopyData } from '../transport';
 import { EventEmitter } from 'events';
 import * as log from '../log';
 import route from '../../common/route';
+import { Plugin } from '../../shapes';
 
 import { app } from 'electron';
 const _ = require('underscore');
@@ -131,11 +132,14 @@ export interface AppAssetsDownloadAsset extends RvmMsgBase {
 export interface PluginQuery extends RvmMsgBase {
     topic: applicationTopic;
     action: pluginQueryAction;
-    messageId: string;
     name: string;
     version: string;
     optional?: boolean;
-    sourceUrl: string | boolean;
+    sourceUrl: string;
+}
+
+export interface PluginQueryResponse extends RvmMsgBase {
+    payload: any;
 }
 
 // topic: cleanup -----
@@ -351,6 +355,26 @@ export class RVMMessageBus extends EventEmitter  {
                 }, timeToLiveInMS);
             }
         }
+    }
+
+    /**
+     * Retrieves information about a plugin
+     */
+    public getPluginInfo(manifestUrl: string, opts: Plugin): Promise<PluginQueryResponse> {
+        return new Promise((resolve) => {
+            const {name, version, optional} = opts;
+
+            const rvmMsg: PluginQuery = {
+                topic: 'application',
+                action: 'query-plugin',
+                name,
+                version,
+                optional,
+                sourceUrl: manifestUrl
+            };
+
+            this.publish(rvmMsg, resolve);
+        });
     }
 }
 

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -587,6 +587,7 @@ limitations under the License.
         let logBase = `[plugin] [${identity.uuid}]-[${identity.name}]: `;
 
         plugins.forEach((plugin) => {
+            // _content - contains module code as a string to eval in this window
             const { name, version, _content } = plugin;
 
             if (!_content) {

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -95,13 +95,7 @@ export interface OpenFinWindow {
     hideReason: string;
     id: number;
     name: string;
-    pluginState: {
-        link?: string;
-        name: string;
-        optional?: boolean;
-        state: 'load-failed'|'load-succeeded'|'failed'|'succeeded';
-        version: string;
-    }[];
+    pluginState: PluginState[];
     preloadState: {
         optional?: boolean;
         state: 'load-started'|'load-failed'|'load-succeeded'|'failed'|'succeeded';
@@ -268,6 +262,7 @@ export interface Manifest {
     };
     licenseKey: string;
     offlineAccess?: boolean;
+    plugin?: Plugin[];
     proxy?: ProxySettings;
     runtime: {
         arguments?: string;
@@ -295,4 +290,15 @@ export interface Manifest {
         forwardErrorReports?: boolean;
         enableErrorReporting?: boolean;
     };
+}
+
+export interface Plugin {
+    link?: string;
+    name: string;
+    optional?: boolean;
+    version: string;
+}
+
+export interface PluginState extends Plugin {
+    state: 'load-failed'|'load-succeeded'|'failed'|'succeeded';
 }


### PR DESCRIPTION
This is **Phase 2** of _plugin-preload separation/refactor/cleanup/fix_.

All plugin/preload tests will be written when all phases are completed.

This 2nd phase:
• separates plugin logic from preload scripts logic in places that deal with plugin retrieval

✅ Test results:
• [Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59e9fea1af26a25be2ffc907)
• [Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59e9feecaf26a25be2ffc908)