### PR TITLE
RUN-3390 (phase 3) separate plugins from preload scripts

### DIFF
--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -701,8 +701,8 @@ exports.System = {
         }
     },
 
-    getPluginModules: function() {
-        return plugins.getModules();
+    getPluginModules: function(identity) {
+        return plugins.getModules(identity);
     },
 
     // identitier is preload script url or plugin name

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -794,7 +794,9 @@ Window.create = function(id, opts) {
         _window: browserWindow
     };
 
-    winObj.pluginState = []; // TODO
+    const { data } = coreState.getStartManifest();
+    const { plugin: plugins } = (data || {});
+    winObj.pluginState = JSON.parse(JSON.stringify(plugins || []));
 
     // Set preload scripts' final loading states
     winObj.preloadState = (_options.preload || []).map(preload => {

--- a/src/browser/api_protocol/api_handlers/system.js
+++ b/src/browser/api_protocol/api_handlers/system.js
@@ -481,7 +481,7 @@ function SystemApiHandler() {
     }
 
     function getPluginModules(identity, message, ack, nack) {
-        System.getPluginModules()
+        System.getPluginModules(identity)
             .then((pluginModules) => {
                 const dataAck = _.clone(successAck);
                 dataAck.data = pluginModules;

--- a/src/browser/plugins.ts
+++ b/src/browser/plugins.ts
@@ -5,9 +5,10 @@ Licensed under OpenFin Commercial License you may not use this file except in co
 Please contact OpenFin Inc. at sales@openfin.co to obtain a Commercial License.
 */
 
+const Window = require('./api/window.js').Window;
 import * as path from 'path';
 import { getStartManifest, StartManifest } from './core_state';
-import { Plugin } from '../shapes';
+import { Identity, Plugin } from '../shapes';
 import { readFile } from 'fs';
 import { rvmMessageBus } from './rvm/rvm_message_bus';
 
@@ -27,16 +28,16 @@ const pluginPaths: Map<string, string> = new Map();
 /**
  * Gets all plugins defined in app's manifest
  */
-export async function getModules(): Promise<PluginWithContent[]> {
+export async function getModules(identity: Identity): Promise<PluginWithContent[]> {
     const {url, data: {plugin: plugins = []}} = <StartManifest>getStartManifest();
-    const promises = plugins.map((plugin: Plugin) => getModule(url, plugin));
+    const promises = plugins.map((plugin: Plugin) => getModule(identity, url, plugin));
     return await Promise.all(promises);
 }
 
 /**
  * Gets a single plugin module
  */
-async function getModule(sourceUrl: string, plugin: Plugin): Promise<PluginWithContent> {
+async function getModule(identity: Identity, sourceUrl: string, plugin: Plugin): Promise<PluginWithContent> {
     const id = `${plugin.name}: ${plugin.version}`;
     let pluginPath;
 
@@ -48,22 +49,27 @@ async function getModule(sourceUrl: string, plugin: Plugin): Promise<PluginWithC
         pluginPaths.set(id, pluginPath);
     }
 
-    return await addContent(plugin, pluginPath);
+    return await addContent(identity, plugin, pluginPath);
 }
 
 /**
  * Reads and adds module content to plugin
  */
-function addContent(plugin: Plugin, pluginPath: string): Promise<PluginWithContent> {
+function addContent(identity: Identity, plugin: Plugin, pluginPath: string): Promise<PluginWithContent> {
     return new Promise((resolve) => {
+        Window.setWindowPluginState(identity, {...plugin, state: 'load-started'});
+
         if (!pluginPath) {
+            Window.setWindowPluginState(identity, {...plugin, state: 'load-failed'});
             return resolve({...plugin, _content: ''});
         }
 
         readFile(pluginPath, 'utf8', (err, data) => {
             if (err) {
+                Window.setWindowPluginState(identity, {...plugin, state: 'load-failed'});
                 resolve({...plugin, _content: ''});
             } else {
+                Window.setWindowPluginState(identity, {...plugin, state: 'load-succeeded'});
                 resolve({...plugin, _content: data});
             }
         });

--- a/src/browser/plugins.ts
+++ b/src/browser/plugins.ts
@@ -53,16 +53,11 @@ async function getModule(identity: Identity, sourceUrl: string, plugin: Plugin):
 }
 
 /**
- * Reads and adds module content to plugin
+ * Reads and adds module content to plugin while updating plugin state
  */
 function addContent(identity: Identity, plugin: Plugin, pluginPath: string): Promise<PluginWithContent> {
     return new Promise((resolve) => {
         Window.setWindowPluginState(identity, {...plugin, state: 'load-started'});
-
-        if (!pluginPath) {
-            Window.setWindowPluginState(identity, {...plugin, state: 'load-failed'});
-            return resolve({...plugin, _content: ''});
-        }
 
         readFile(pluginPath, 'utf8', (err, data) => {
             if (err) {


### PR DESCRIPTION
This is **Phase 3** of _plugin-preload separation/refactor/cleanup/fix_.

All plugin/preload tests will be written when all phases are completed.

This 2nd phase:
• adds plugin states (similar to preload states)

✅ Test results:
• [Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59ea5779af26a25be2ffc90e)
• [Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59ea57c2af26a25be2ffc90f)