### PR TITLE
RUN-3501 fix plugins for apps from manifest

### DIFF
--- a/index.js
+++ b/index.js
@@ -517,6 +517,8 @@ function launchApp(argo, startExternalAdapterServer) {
             configObject: { licenseKey }
         } = configuration;
 
+        coreState.setManifest(configUrl, configObject);
+
         if (argo['user-app-config-args']) {
             const tempUrl = configObject['startup_app'].url;
             const delimiter = tempUrl.indexOf('?') < 0 ? '?' : '&';

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -799,8 +799,8 @@ Window.create = function(id, opts) {
         _window: browserWindow
     };
 
-    const { data } = coreState.getStartManifest();
-    const { plugin: plugins } = (data || {});
+    const { manifest } = coreState.getManifest(identity);
+    const { plugin: plugins } = manifest || {};
     winObj.pluginState = JSON.parse(JSON.stringify(plugins || []));
 
     // Set preload scripts' final loading states

--- a/src/browser/api_protocol/api_handlers/window.js
+++ b/src/browser/api_protocol/api_handlers/window.js
@@ -146,7 +146,7 @@ function setWindowPreloadState(identity, message, ack) {
     const payload = message.payload;
     const windowIdentity = apiProtocolBase.getTargetWindowIdentity(identity);
 
-    Window.setWindowPreloadState(windowIdentity, payload);
+    Window.setWindowPluginState(windowIdentity, payload);
     ack();
 }
 

--- a/src/browser/api_protocol/api_handlers/window.js
+++ b/src/browser/api_protocol/api_handlers/window.js
@@ -146,7 +146,7 @@ function setWindowPreloadState(identity, message, ack) {
     const payload = message.payload;
     const windowIdentity = apiProtocolBase.getTargetWindowIdentity(identity);
 
-    Window.setWindowPluginState(windowIdentity, payload);
+    Window.setWindowPreloadState(windowIdentity, payload);
     ack();
 }
 

--- a/src/browser/core_state.ts
+++ b/src/browser/core_state.ts
@@ -53,6 +53,11 @@ interface WindowMeta {
     uuid: string;
 }
 
+interface ManifestInfo {
+    url: string;
+    manifest?: Shapes.Manifest;
+}
+
 export const args = app.getCommandLineArguments(); // arguments as a string
 export const argv = app.getCommandLineArgv(); // arguments as an array
 export const argo = minimist(argv); // arguments as an object
@@ -60,6 +65,7 @@ export const argo = minimist(argv); // arguments as an object
 const apps: Shapes.App[] = [];
 
 let startManifest = {};
+const manifests: Map <string, Shapes.Manifest> = new Map();
 
 // TODO: This needs to go go away, pending socket server refactor.
 let socketServerState = {};
@@ -69,6 +75,17 @@ const manifestProxySettings: Shapes.ProxySettings = {
     proxyPort: 0,
     type: 'system'
 };
+
+export function setManifest(url: string, manifest: Shapes.Manifest): void {
+    const manifestCopy = JSON.parse(JSON.stringify(manifest));
+    manifests.set(url, manifestCopy);
+}
+
+export function getManifest(identity: Shapes.Identity): ManifestInfo {
+    const url = getConfigUrlByUuid(identity.uuid);
+    const manifest = manifests.get(url);
+    return { url, manifest };
+}
 
 export function setStartManifest(url: string, data: Shapes.Manifest): void {
     startManifest = { url, data };

--- a/src/browser/plugins.ts
+++ b/src/browser/plugins.ts
@@ -7,7 +7,7 @@ Please contact OpenFin Inc. at sales@openfin.co to obtain a Commercial License.
 
 const Window = require('./api/window.js').Window;
 import * as path from 'path';
-import { getStartManifest, StartManifest } from './core_state';
+import { getManifest } from './core_state';
 import { Identity, Plugin } from '../shapes';
 import { readFile } from 'fs';
 import { rvmMessageBus } from './rvm/rvm_message_bus';
@@ -29,7 +29,8 @@ const pluginPaths: Map<string, string> = new Map();
  * Gets all plugins defined in app's manifest
  */
 export async function getModules(identity: Identity): Promise<PluginWithContent[]> {
-    const {url, data: {plugin: plugins = []}} = <StartManifest>getStartManifest();
+    const { url, manifest } = getManifest(identity);
+    const { plugin: plugins = [] } = manifest || {};
     const promises = plugins.map((plugin: Plugin) => getModule(identity, url, plugin));
     return await Promise.all(promises);
 }


### PR DESCRIPTION
ℹ️ This PR fixes the problem where consecutive apps that are started with a manifest and using the same runtime couldn't find plugins

➕ New tests:
• [window.getInfo (pluginState)](https://testing-dashboard.openfin.co/#/app/tests/59f08e56af26a25be2ffc953/edit)
• majority of the future plugins tests are all going to depend on this functionality

✅ Test results:
• [Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59f0f17daf26a25be2ffc968)
• [Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59f0f1cfaf26a25be2ffc969)