### PR TITLE
RUN-3508: Feature/iframe context menu

### DIFF
--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -317,10 +317,10 @@ limitations under the License.
             if (!e.defaultPrevented) {
                 e.preventDefault();
 
-                const options = getCurrentWindowOptionsSync();
+                const identity = entityInfo.entityType === 'iframe' ? entityInfo.parent : entityInfo;
+                const options = getWindowOptionsSync(identity);
 
                 if (options.contextMenu) {
-                    const identity = getWindowIdentitySync();
                     syncApiCall('show-menu', {
                         uuid: identity.uuid,
                         name: identity.name,


### PR DESCRIPTION
Branch off https://github.com/HadoukenIO/core/pull/207.  The new changes are:

~~~javascript
-                const options = getWindowOptionsSync();
+                const identity = entityInfo.entityType === 'iframe' ? entityInfo.parent : entityInfo;
+                const options = getWindowOptionsSync(identity);
 
                 if (options.contextMenu) {
-                    const identity = getWindowIdentitySync();

~~~

Tests:

[W10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59f1fbabaf26a25be2ffc96d)
[W7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59f1fb68af26a25be2ffc96c)