### PR TITLE
RUN-3474 removed repetitive preload script state to keep correct order

### DIFF
--- a/src/browser/preload_scripts.ts
+++ b/src/browser/preload_scripts.ts
@@ -150,8 +150,6 @@ function loadFromCache(opts: FetchResponse): Promise<boolean> {
             const { identity, scriptPath } = opts;
             const id = getIdentifier(preload);
 
-            logPreload('info', identity, 'load started', id);
-
             fs.readFile(scriptPath, 'utf8', (readError: Error, scriptText: string) => {
                 // todo: remove following workaround when RUN-3162 issue fixed
                 //BEGIN WORKAROUND (RUN-3162 fetchError null on 404)

--- a/src/browser/preload_scripts.ts
+++ b/src/browser/preload_scripts.ts
@@ -151,7 +151,6 @@ function loadFromCache(opts: FetchResponse): Promise<boolean> {
             const id = getIdentifier(preload);
 
             logPreload('info', identity, 'load started', id);
-            updatePreloadState(identity, preload, 'load-started');
 
             fs.readFile(scriptPath, 'utf8', (readError: Error, scriptText: string) => {
                 // todo: remove following workaround when RUN-3162 issue fixed


### PR DESCRIPTION
ℹ️ This PR fixes state order for successfully loaded and executed preload scripts

➕ New test:
• [window.addEventListener (preload-state-changing) (succeeded)](https://testing-dashboard.openfin.co/#/app/tests/59ee5761af26a25be2ffc922/edit)

✅ Test results:
• [Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59f23f71af26a25be2ffc975)
• [Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59f23faaaf26a25be2ffc976)