### PR TITLE
RUN-3472 fixes fetching non-existent preload scripts

### DIFF
--- a/src/browser/cached_resource_fetcher.ts
+++ b/src/browser/cached_resource_fetcher.ts
@@ -119,9 +119,10 @@ function generateHash(str: string): string {
  */
 function download(fileUrl: string, filePath: string, callback: (error: null|Error, filePath: string) => any): void {
     const fetcher = new resourceFetcher('file');
+    const expectedStatusCode = /^[23]/; // 2xx & 3xx HTTP status codes are ok
 
-    fetcher.once('fetch-complete', (event: string, status: string) => {
-        if (status === 'success') {
+    fetcher.once('fetch-complete', (event: string, status: string, data: string, headers: any) => {
+        if (status === 'success' && expectedStatusCode.test(headers.statusCode)) {
             callback(null, filePath);
         } else {
             callback(new Error(`Failed to download file from ${fileUrl}`), filePath);

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -72,8 +72,8 @@ declare module 'electron' {
 
     export class resourceFetcher {
         constructor(type: string);
-        on(event: string, callback: (event: string, status: string) => any): void;
-        once(event: string, callback: (event: string, status: string) => any): void;
+        on(event: string, callback: (event: string, status: string, data: string, headers: any) => any): void;
+        once(event: string, callback: (event: string, status: string, data: string, headers: any) => any): void;
         setFilePath(path: string): void;
         fetch(url: string): void;
     }

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -630,9 +630,7 @@ limitations under the License.
         preloadScripts.forEach((preloadScript) => {
             const { url, content } = preloadScript;
 
-            if (content !== null) {
-                // TODO: handle empty script for bad urls
-
+            if (content) {
                 try {
                     window.eval(content); /* jshint ignore:line */
                     asyncApiCall(action, { url, state: 'succeeded' });


### PR DESCRIPTION
ℹ️ This PR fixes fetching non-existent preload scripts, which in turn fixes their states

➕ New test: [window.addEventListener (preload-state-changing) (load-failed)](https://testing-dashboard.openfin.co/#/app/tests/59ee481baf26a25be2ffc920/edit)

✅ Test results:
• [Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59f89658af26a25be2ffc9aa)
• [Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59f896c3af26a25be2ffc9ab)