### PR TITLE
RUN-3321 RUN-3434 move to net module

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -2167,6 +2167,7 @@ function setIcon(browserWindow, iconFilepath, errorCallback = () => {}) {
         if (icon.isEmpty()) {
             errorCallback();
         } else {
+            browserWindow.setIcon(icon);
         }
     }
 }

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -2162,14 +2162,11 @@ function setTaskbarIcon(browserWindow, iconUrl, errorCallback = () => {}) {
 }
 
 function setIcon(browserWindow, iconFilepath, errorCallback = () => {}) {
-    log.writeToLog(1, `GO GET IT! ${iconFilepath}`, true);
     if (!browserWindow.isDestroyed()) {
         let icon = nativeImage.createFromPath(iconFilepath);
         if (icon.isEmpty()) {
-            log.writeToLog(1, 'yeah it was empty', true);
             errorCallback();
         } else {
-            browserWindow.setIcon(icon);
         }
     }
 }

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -2162,9 +2162,11 @@ function setTaskbarIcon(browserWindow, iconUrl, errorCallback = () => {}) {
 }
 
 function setIcon(browserWindow, iconFilepath, errorCallback = () => {}) {
+    log.writeToLog(1, `GO GET IT! ${iconFilepath}`, true);
     if (!browserWindow.isDestroyed()) {
         let icon = nativeImage.createFromPath(iconFilepath);
         if (icon.isEmpty()) {
+            log.writeToLog(1, 'yeah it was empty', true);
             errorCallback();
         } else {
             browserWindow.setIcon(icon);

--- a/src/browser/cached_resource_fetcher.ts
+++ b/src/browser/cached_resource_fetcher.ts
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import {app, resourceFetcher, net} from 'electron'; // Electron app
+import {app, net} from 'electron'; // Electron app
 import {stat, mkdir, writeFileSync, createWriteStream} from 'fs';
 import {join, parse} from 'path';
 import {parse as parseUrl} from 'url';
@@ -133,7 +133,7 @@ function generateHash(str: string): string {
 /**
  * Downloads the file from given url using Resource Fetcher and saves it into specified path
  */
-function download(fileUrl: string, filePath: string): Promise<any> {
+function download(fileUrl: string, filePath: string): Promise<void> {
     return new Promise((resolve, reject) => {
         const request = net.request(fileUrl);
         const binaryWriteStream = createWriteStream(filePath, {

--- a/src/browser/cached_resource_fetcher.ts
+++ b/src/browser/cached_resource_fetcher.ts
@@ -44,7 +44,7 @@ export async function cachedFetch(appUuid: string, fileUrl: string, callback: (e
         if (isURI(fileUrl)) {
             callback(null, uriToPath(fileUrl));
         } else {
-            // this is c:\whatever\
+            // this is C:\whatever\
             stat(fileUrl, (err: null|Error) => {
                 if (err) {
                     callback(new Error(`Invalid file url: '${fileUrl}'`));
@@ -59,6 +59,7 @@ export async function cachedFetch(appUuid: string, fileUrl: string, callback: (e
     const appCacheDir = getAppCacheDir(appUuid);
     const filePath = getFilePath(appCacheDir, fileUrl);
     let err: Error;
+
     try {
         await prepDownloadLocation(appCacheDir, filePath);
         await download(fileUrl, filePath);
@@ -136,8 +137,7 @@ function download(fileUrl: string, filePath: string): Promise<any> {
     return new Promise((resolve, reject) => {
         const request = net.request(fileUrl);
         const binaryWriteStream = createWriteStream(filePath, {
-            // encoding: 'binary',
-            defaultEncoding: 'binary'
+            encoding: 'binary'
         });
 
         request.once('response', (response: any) => {
@@ -157,5 +157,4 @@ function download(fileUrl: string, filePath: string): Promise<any> {
         });
         request.end();
     });
-
 }

--- a/src/browser/cached_resource_fetcher.ts
+++ b/src/browser/cached_resource_fetcher.ts
@@ -28,7 +28,7 @@ app.on('quit', () => { appQuiting = true; });
 /**
  * Downloads a file if it doesn't exist in cache yet.
  */
-export async function cachedFetch(appUuid: string, fileUrl: string, callback: (error: null|Error, path?: string) => any): Promise<void> {
+export async function cachedFetch(appUuid: string, fileUrl: string, callback: (error: null|Error, path?: string) => any): Promise<any> {
     if (!fileUrl || typeof fileUrl !== 'string') {
         callback(new Error(`Bad file url: '${fileUrl}'`));
         return;
@@ -133,7 +133,7 @@ function generateHash(str: string): string {
 /**
  * Downloads the file from given url using Resource Fetcher and saves it into specified path
  */
-function download(fileUrl: string, filePath: string): Promise<void> {
+function download(fileUrl: string, filePath: string): Promise<any> {
     return new Promise((resolve, reject) => {
         const request = net.request(fileUrl);
         const binaryWriteStream = createWriteStream(filePath, {

--- a/src/browser/cached_resource_fetcher.ts
+++ b/src/browser/cached_resource_fetcher.ts
@@ -67,28 +67,6 @@ export async function cachedFetch(appUuid: string, fileUrl: string, callback: (e
     }
 
     callback(err, filePath);
-
-    // stat(filePath, (err: null | Error) => {
-    //     if (err) {
-    //         if (!appQuiting) {
-    //             stat(appCacheDir, (err: null | Error) => {
-    //                 if (err) {
-    //                     if (!appQuiting) {
-    //                         mkdir(appCacheDir, () => {
-    //                             download(fileUrl, filePath, callback);
-    //                         });
-    //                     }
-    //                 } else {
-    //                     download(fileUrl, filePath, callback);
-    //                 }
-    //             });
-    //         }
-    //     } else if (remoteFileIsYoungerThanCachedFile(fileUrl, filePath)) {
-    //         download(fileUrl, filePath, callback);
-    //     } else {
-    //         callback(null, filePath);
-    //     }
-    // });
 }
 
 function prepDownloadLocation(appCacheDir: string, filePath: string) {

--- a/src/browser/cached_resource_fetcher.ts
+++ b/src/browser/cached_resource_fetcher.ts
@@ -19,7 +19,6 @@ import {join, parse} from 'path';
 import {parse as parseUrl} from 'url';
 import {createHash} from 'crypto';
 import {isURL, isURI, uriToPath} from '../common/regex';
-import * as log from './log';
 
 let appQuiting: Boolean = false;
 

--- a/src/browser/cached_resource_fetcher.ts
+++ b/src/browser/cached_resource_fetcher.ts
@@ -121,6 +121,7 @@ function generateHash(str: string): string {
 function download(fileUrl: string, filePath: string, callback: (error: null|Error, filePath: string) => any): void {
     // const fetcher = new resourceFetcher('file');
     // file uris are not getting cached??
+    // WE NEED TO HANDLE THE ERR CASE AS WELL LIKE REAL PROGRAMMERS!!
     const request = net.request(fileUrl);
     let res = '';
     const bws = createWriteStream(filePath, {
@@ -141,10 +142,11 @@ function download(fileUrl: string, filePath: string, callback: (error: null|Erro
         log.writeToLog(1, fileUrl, true);
 
         // writeFileSync(filePath, res);
+        bws.once('close', callback.bind(null, null, filePath));
         bws.end();
-        setTimeout(() => { // wtf do we need to time out here?!?!?
-            callback(null, filePath);
-        }, 1000);
+        // setTimeout(() => { // wtf do we need to time out here?!?!?
+        //     callback(null, filePath);
+        // }, 1000);
 
       });
     });

--- a/src/browser/cached_resource_fetcher.ts
+++ b/src/browser/cached_resource_fetcher.ts
@@ -94,13 +94,6 @@ function prepDownloadLocation(appCacheDir: string, filePath: string) {
     });
 }
 
-function remoteFileIsYoungerThanCachedFile(remoteUrl: string, cachedFilePath: string) {
-    //todo: make a RESTful HEAD request and if file at remoteUrl is missing, return false;
-    //todo: else if file at remoteUrl is younger than file at cachedFilePath, return true;
-    //todo: else return false
-    return true; //for now we are always fetching
-}
-
 /**
  * Generates a folder name for the app to store the file in.
  */

--- a/src/browser/cached_resource_fetcher.ts
+++ b/src/browser/cached_resource_fetcher.ts
@@ -28,7 +28,7 @@ app.on('quit', () => { appQuiting = true; });
 /**
  * Downloads a file if it doesn't exist in cache yet.
  */
-export async function cachedFetch(appUuid: string, fileUrl: string, callback: (error: null|Error, path?: string) => any): Promise<any> {
+export async function cachedFetch(appUuid: string, fileUrl: string, callback: (error: null|Error, path?: string) => any): Promise<void> {
     if (!fileUrl || typeof fileUrl !== 'string') {
         callback(new Error(`Bad file url: '${fileUrl}'`));
         return;

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -33,6 +33,10 @@ declare module 'electron' {
         export function vlog(level: number, message: any): any;
     }
 
+    export namespace net {
+        export function request(url: string): any;
+    }
+
     export interface Rectangle {
         x: number;
         y: number;


### PR DESCRIPTION
@HarsimranSingh @whyn07m3 

This swaps out our custom, native backed `resourceFetcher` with the standard electron [net](https://electron.atom.io/docs/api/net/) module. We still will write the response to disk (we can eval later if keeping in memory is appropriate for all cases, I wish it was, as it is already on disc per Chrome cache rules). 

[tests well](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59f8bcf6af26a25be2ffc9b9)
