### PR TITLE
RUN-3489 prevent preload scripts & plugin modules in notifications

### DIFF
--- a/src/browser/api/notifications/subscriptions.ts
+++ b/src/browser/api/notifications/subscriptions.ts
@@ -97,7 +97,7 @@ ofEvents.on(route.window('closed', '*'), (e: any) => {
             if (/\//.test(source)) {
                 let [uuid, name] = source.split('/');
 
-                if (windowIsNotification(name)) {
+                if (Window.isNotification(name)) {
                     seqs.removes.onNext({uuid, name});
                 }
             }
@@ -155,7 +155,7 @@ ofEvents.on(route.application('window-end-load', '*'), (e: any) => {
             try {
                 Window.close({
                     uuid,
-                    name: 'queueCounter'
+                    name: Window.QUEUE_COUNTER_NAME
                 });
             } catch (e){
                 writeToLog('info', e)
@@ -243,7 +243,7 @@ function noteStackCount() {
                         --pendingNotYetCounted;
                     }
 
-                    return windowIsNotification(name);
+                    return Window.isNotification(name);
                 });
 
             return prev.concat(childNoteWindows);
@@ -264,7 +264,7 @@ function getCurrNotes (): Array<Identity> {
 
 function childWindowsAsIdentities(childWindows: Array<any>, appUuid: string): Array<Identity> {
     return childWindows
-        .filter((win: any) => windowIsNotification(win.name))
+        .filter((win: any) => Window.isNotification(win.name))
         .map((win: any) => {
 
             return {
@@ -682,12 +682,6 @@ function noteTopicStr(uuid: string, name: string, isGeneral?: boolean): string {
     return isGeneral
         ? route('notifications', 'listener/') // legacy trailing slash; do not remove!
         : route('notifications', 'listener', uuid, name, true);
-}
-
-function windowIsNotification(name: string ): boolean {
-    const noteGuidRegex = /^A21B62E0-16B1-4B10-8BE3-BBB6B489D862/;
-
-    return noteGuidRegex.test(name);
 }
 
 function closeNotification(req: NotificationMessage): void {

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -67,7 +67,9 @@ const WindowsMessages = {
     WM_SYSKEYUP: 0x0105,
 };
 
-let Window = {};
+let Window = {
+    QUEUE_COUNTER_NAME: 'queueCounter'
+};
 
 let browserWindowEventMap = {
     'api-injection-failed': {
@@ -1251,6 +1253,21 @@ Window.hide = function(identity) {
     browserWindow.hide();
 };
 
+Window.isNotification = function(name) {
+    const noteGuidRegex = /^A21B62E0-16B1-4B10-8BE3-BBB6B489D862/;
+    return noteGuidRegex.test(name);
+};
+
+Window.isNotificationType = function(identity, callback = () => {}) {
+    const { name } = identity;
+
+    const isNotification = Window.isNotification(name);
+    const isQueueCounter = name === Window.QUEUE_COUNTER_NAME;
+    const isNotificationType = isNotification || isQueueCounter;
+
+    callback(isNotificationType);
+    return isNotificationType;
+};
 
 Window.isShowing = function(identity) {
     let browserWindow = getElectronBrowserWindow(identity);

--- a/src/browser/api_protocol/api_handlers/middleware_entity_existence.ts
+++ b/src/browser/api_protocol/api_handlers/middleware_entity_existence.ts
@@ -28,7 +28,8 @@ const apisToIgnore = new Set([
     //TODO: we do not check run for .NET, the adapter will create an application then run it without waiting for the ack.
     'run-application',
     // Window
-    'window-exists'
+    'window-exists',
+    'window-is-notification-type'
 ]);
 
 /**

--- a/src/browser/api_protocol/api_handlers/window.js
+++ b/src/browser/api_protocol/api_handlers/window.js
@@ -73,10 +73,11 @@ module.exports.windowApiMap = {
     'stop-flash-window': stopFlashWindow,
     'undock-window': undockWindow,
     'update-window-options': updateWindowOptions,
+    'window-authenticate': windowAuthenticate,
     'window-embedded': windowEmbedded,
     'window-exists': windowExists,
     'window-get-cached-bounds': getCachedBounds,
-    'window-authenticate': windowAuthenticate
+    'window-is-notification-type': windowIsNotificationType
 };
 
 module.exports.init = function() {
@@ -569,4 +570,15 @@ function setZoomLevel(identity, message, ack) {
 
     Window.setZoomLevel(windowIdentity, level);
     ack(successAck);
+}
+
+function windowIsNotificationType(identity, message, ack) {
+    const { payload } = message;
+    const windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+
+    Window.isNotificationType(windowIdentity, (isNotification) => {
+        const dataAck = _.clone(successAck);
+        dataAck.data = isNotification;
+        ack(dataAck);
+    });
 }

--- a/src/browser/api_protocol/api_handlers/window.js
+++ b/src/browser/api_protocol/api_handlers/window.js
@@ -146,7 +146,7 @@ function setWindowPreloadState(identity, message, ack) {
     const payload = message.payload;
     const windowIdentity = apiProtocolBase.getTargetWindowIdentity(identity);
 
-    Window.setWindowPreloadState(windowIdentity, payload);
+    Window.setWindowPluginState(windowIdentity, payload);
     ack();
 }
 

--- a/src/browser/api_protocol/api_handlers/window.js
+++ b/src/browser/api_protocol/api_handlers/window.js
@@ -146,7 +146,7 @@ function setWindowPreloadState(identity, message, ack) {
     const payload = message.payload;
     const windowIdentity = apiProtocolBase.getTargetWindowIdentity(identity);
 
-    Window.setWindowPluginState(windowIdentity, payload);
+    Window.setWindowPreloadState(windowIdentity, payload);
     ack();
 }
 

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -76,8 +76,8 @@ declare module 'electron' {
 
     export class resourceFetcher {
         constructor(type: string);
-        on(event: string, callback: (event: string, status: string) => any): void;
-        once(event: string, callback: (event: string, status: string) => any): void;
+        on(event: string, callback: (event: string, status: string, data: string, headers: any) => any): void;
+        once(event: string, callback: (event: string, status: string, data: string, headers: any) => any): void;
         setFilePath(path: string): void;
         fetch(url: string): void;
     }

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -643,9 +643,7 @@ limitations under the License.
         preloadScripts.forEach((preloadScript) => {
             const { url, content } = preloadScript;
 
-            if (content !== null) {
-                // TODO: handle empty script for bad urls
-
+            if (content) {
                 try {
                     window.eval(content); /* jshint ignore:line */
                     asyncApiCall(action, { url, state: 'succeeded' });

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -483,8 +483,12 @@ limitations under the License.
 
         const convertedOpts = convertOptionsToElectronSync(options);
         const { preload } = 'preload' in convertedOpts ? convertedOpts : initialOptions;
+        const windowIsNotification = syncApiCall('window-is-notification-type', {
+            uuid: convertedOpts.uuid,
+            name: convertedOpts.name
+        });
 
-        if (!(preload && preload.length)) {
+        if (!(preload && preload.length) || windowIsNotification) {
             proceed(); // short-circuit preload scripts fetch
         } else {
             const preloadScriptsPayload = {
@@ -568,6 +572,15 @@ limitations under the License.
         const identity = { uuid, name };
         const windowOptions = entityInfo.entityType === 'iframe' ? getWindowOptionsSync(entityInfo.parent) :
             getCurrentWindowOptionsSync();
+        const windowIsNotification = syncApiCall('window-is-notification-type', {
+            uuid: windowOptions.uuid,
+            name: windowOptions.name
+        });
+
+        // Don't execute preload scripts and plugin modules in notifications
+        if (windowIsNotification) {
+            return;
+        }
 
         let { preload } = convertOptionsToElectronSync(windowOptions);
 


### PR DESCRIPTION
ℹ️ This PR prevents execution of preload scripts and plugin modules in notifications (including queue counter)

➕ New tests:
• [Notification (no preload scripts)](https://testing-dashboard.openfin.co/#/app/tests/59f8ce3caf26a25be2ffc9bb/edit)
• [Notification (no plugin modules)](https://testing-dashboard.openfin.co/#/app/tests/59fb2517af26a25be2ffc9e9/edit)

✅ Test results:
• [Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59fb24ccaf26a25be2ffc9e8)
• [Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/59fb2533af26a25be2ffc9ea)