### PR TITLE
RUN-3475 fix emission of final state for load-failed preload scripts

### DIFF
--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -637,7 +637,8 @@ limitations under the License.
         try {
             preloadScripts = syncApiCall('get-selected-preload-scripts', preloadOption);
         } catch (error) {
-            return syncApiCall('write-to-log', { level: 'error', message: logBase + error });
+            preloadScripts = [];
+            syncApiCall('write-to-log', { level: 'error', message: logBase + error });
         }
 
         preloadScripts.forEach((preloadScript) => {


### PR DESCRIPTION
ℹ️ This PR ensures final "preload-scripts-state-changed" event is emitted when at least one required preload script failed to load

➕ New test: [window.addEventListener (preload-scripts-state-changed) (load-failed)](https://testing-dashboard.openfin.co/#/app/tests/59ef3a4faf26a25be2ffc925/edit)

✅ Test results:
• [Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a00e6e61573627ee4384254)
• [Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a00e74b1573627ee4384255)