### PR TITLE
RUN-3499 delete default max-Height/Width

### DIFF
--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -233,6 +233,13 @@ module.exports = {
                 newOptions.width = defaultWidth;
             }
 
+            if (maxHeight === -1) {
+                delete newOptions.maxHeight;
+            }
+            if (maxWidth === -1) {
+                delete newOptions.maxWidth;
+            }
+
             newOptions.center = newOptions.defaultCentered;
             if (!newOptions.center) {
                 newOptions.x = newOptions.defaultLeft;


### PR DESCRIPTION
When converting window-options, delete default maxHeight and maxWidth (which is set to be -1 at base options) that the default value[ set to be no limit](https://github.com/openfin/runtime/blob/develop/atom/browser/native_window.cc#L130) at runtime correctly.