### PR TITLE
RUN-3563 RUN-3564 RUN-3565 remove in-memory preload scripts caching

### DIFF
--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -456,7 +456,9 @@ Application.run = function(identity, configUrl = '', userAppConfigArgs = undefin
     } else {
         // Flow through preload script logic (eg. re-download of failed preload scripts)
         // only if app is not already running.
-        System.downloadPreloadScripts(windowIdentity, mainWindowOpts.preloadScripts, proceed);
+        System.downloadPreloadScripts(windowIdentity, mainWindowOpts.preloadScripts)
+            .then(proceed)
+            .catch(proceed);
     }
 };
 

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -47,7 +47,6 @@ let WindowGroups = require('../window_groups.js');
 import { validateNavigation, navigationValidator } from '../navigation_validation';
 import { toSafeInt } from '../../common/safe_int';
 import route from '../../common/route';
-import { getPreloadScriptState, getIdentifier } from '../preload_scripts';
 import { FrameInfo } from './frame';
 import { System } from './system';
 // constants
@@ -806,12 +805,7 @@ Window.create = function(id, opts) {
     winObj.plugins = JSON.parse(JSON.stringify(plugins || []));
 
     // Set preload scripts' final loading states
-    winObj.preloadScripts = (_options.preloadScripts || _options.preload || []).map(preload => {
-        return {
-            url: getIdentifier(preload),
-            state: getPreloadScriptState(getIdentifier(preload))
-        };
-    });
+    winObj.preloadScripts = (_options.preloadScripts || []);
     winObj.framePreloadScripts = {}; // frame ID => [{url, state}]
 
     if (!coreState.getWinObjById(id)) {
@@ -1193,9 +1187,9 @@ Window.setWindowPreloadState = function(identity, payload) {
             if (!frameState) {
                 frameState = openfinWindow.framePreloadScripts[name] = [];
             }
-            preloadScripts = frameState.find(e => e.url === getIdentifier(payload));
+            preloadScripts = frameState.find(e => e.url === url);
             if (!preloadScripts) {
-                frameState.push(preloadScripts = { url: getIdentifier(payload) });
+                frameState.push(preloadScripts = { url });
             }
             preloadScripts = [preloadScripts];
         } else {
@@ -1204,7 +1198,7 @@ Window.setWindowPreloadState = function(identity, payload) {
         if (preloadScripts) {
             preloadScripts[0].state = state;
         } else {
-            log.writeToLog('info', `setWindowPreloadState missing preloadState ${uuid} ${name} ${getIdentifier(payload)} `);
+            log.writeToLog('info', `setWindowPreloadState missing preloadState ${uuid} ${name} ${url} `);
         }
     }
 

--- a/src/browser/cached_resource_fetcher.ts
+++ b/src/browser/cached_resource_fetcher.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import {app, net} from 'electron'; // Electron app
-import {stat, mkdir, writeFileSync, createWriteStream} from 'fs';
+import {stat, mkdir, createWriteStream} from 'fs';
 import {join, parse} from 'path';
 import {parse as parseUrl} from 'url';
 import {createHash} from 'crypto';

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -564,61 +564,48 @@ limitations under the License.
     };
 
     /**
-     * Preload script eval
+     * An event indicating the moment OpenFin API is injected
      */
     ipc.once(`post-api-injection-${renderFrameId}`, () => {
         const { uuid, name } = initialOptions;
-        const identity = { uuid, name };
-        const windowOptions = entityInfo.entityType === 'iframe' ? getWindowOptionsSync(entityInfo.parent) :
-            getCurrentWindowOptionsSync();
-        const windowIsNotification = syncApiCall('window-is-notification-type', {
-            uuid: windowOptions.uuid,
-            name: windowOptions.name
-        });
+        const windowIsNotification = syncApiCall('window-is-notification-type', { uuid, name });
 
-        // Don't execute preload scripts and plugin modules in notifications
-        if (windowIsNotification) {
-            return;
-        }
-
-        let { preloadScripts } = convertOptionsToElectronSync(windowOptions);
-
-        evalPlugins(identity);
-
-        if (typeof preloadScripts === 'object' && preloadScripts.length) {
-            evalPreloadScripts(identity, preloadScripts);
+        if (!windowIsNotification) {
+            evalPlugins(uuid, name);
+            evalPreloadScripts(uuid, name);
         }
     });
 
     /**
-     * Requests plugin modules from the Core and evals them in the current window
+     * Request plugin modules from the Core and execute them in the current window
      */
-    function evalPlugins(identity) {
+    function evalPlugins(uuid, name) {
         const action = 'set-window-plugin-state';
         const plugins = syncApiCall('get-plugin-modules');
-        let logBase = `[plugin] [${identity.uuid}]-[${identity.name}]: `;
+        const log = (msg) => {
+            asyncApiCall('write-to-log', {
+                level: 'info',
+                message: `[plugins] [${uuid}]-[${name}]: ${msg}`
+            });
+        };
 
         plugins.forEach((plugin) => {
-            // _content - contains module code as a string to eval in this window
+            // _content: contains plugin module code as a string to eval in this window
             const { name, version, _content } = plugin;
 
             if (!_content) {
+                log(`Skipped execution of plugin module [${name} ${version}], ` +
+                    `because the content is not available`);
                 return;
             }
 
             try {
                 window.eval(_content); /* jshint ignore:line */
+                log(`Succeeded execution of plugin module [${name} ${version}]`);
                 asyncApiCall(action, { name, version, state: 'succeeded' });
-                syncApiCall('write-to-log', {
-                    level: 'info',
-                    message: logBase + `eval succeeded for ${name} ${version}`
-                });
             } catch (err) {
+                log(`Failed execution of plugin module [${name} ${version}]`);
                 asyncApiCall(action, { name, version, state: 'failed' });
-                syncApiCall('write-to-log', {
-                    level: 'info',
-                    message: logBase + `eval failed for ${name} ${version}`
-                });
             }
         });
 
@@ -626,34 +613,46 @@ limitations under the License.
     }
 
     /**
-     * Requests preload scripts contents from the Core and evals them in the current window
+     * Request preload scripts from the Core and execute them in the current window
      */
-    function evalPreloadScripts(identity, preloadOption) {
+    function evalPreloadScripts(uuid, name) {
         const action = 'set-window-preload-state';
-        let logBase = `[preload] [${identity.uuid}]-[${identity.name}]: `;
-        let preloadScripts;
+        const preloadScripts = syncApiCall('get-preload-scripts');
+        const requiredScriptsFailed = preloadScripts.some(e => !e._content && !e.optional);
+        const log = (msg) => {
+            asyncApiCall('write-to-log', {
+                level: 'info',
+                message: `[preloadScripts] [${uuid}]-[${name}]: ${msg}`
+            });
+        };
 
-        try {
-            preloadScripts = syncApiCall('get-selected-preload-scripts', preloadOption);
-        } catch (error) {
-            preloadScripts = [];
-            syncApiCall('write-to-log', { level: 'error', message: logBase + error });
-        }
+        if (requiredScriptsFailed) {
+            // Don't evaluate preload scripts when there
+            // is at least one load-failed that is required
+            log(`Aborted execution of preload scripts, ` +
+                `because at least one required preload script failed to load`);
 
-        preloadScripts.forEach((preloadScript) => {
-            const { url, content } = preloadScript;
+        } else {
+            preloadScripts.forEach((preloadScript) => {
+                // _content: contains preload script code as a string to eval in this window
+                const { url, _content } = preloadScript;
 
-            if (content) {
-                try {
-                    window.eval(content); /* jshint ignore:line */
-                    asyncApiCall(action, { url, state: 'succeeded' });
-                    syncApiCall('write-to-log', { level: 'info', message: logBase + `eval succeeded for ${url}` });
-                } catch (err) {
-                    asyncApiCall(action, { url, state: 'failed' });
-                    syncApiCall('write-to-log', { level: 'error', message: logBase + `eval failed for ${err}` });
+                if (!_content) {
+                    log(`Skipped execution of preload script for URL [${url}], ` +
+                        `because the content is not available`);
+                    return;
                 }
-            }
-        });
+
+                try {
+                    window.eval(_content); /* jshint ignore:line */
+                    log(`Succeeded execution of preload script for URL [${url}]`);
+                    asyncApiCall(action, { url, state: 'succeeded' });
+                } catch (error) {
+                    log(`Failed execution of preload script for URL [${url}]: ${error}`);
+                    asyncApiCall(action, { url, state: 'failed' });
+                }
+            });
+        }
 
         asyncApiCall(action, { allDone: true });
     }

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -96,11 +96,7 @@ export interface OpenFinWindow {
     id: number;
     name: string;
     plugins: PluginState[];
-    preloadScripts: {
-        optional?: boolean;
-        state: 'load-started'|'load-failed'|'load-succeeded'|'failed'|'succeeded';
-        url: string;
-    }[];
+    preloadScripts: PreloadScriptState[];
     uuid: string;
 }
 
@@ -301,4 +297,13 @@ export interface Plugin {
 
 export interface PluginState extends Plugin {
     state: 'load-failed'|'load-succeeded'|'failed'|'succeeded';
+}
+
+export interface PreloadScript {
+    optional?: boolean;
+    url: string;
+}
+
+export interface PreloadScriptState extends PreloadScript {
+    state: 'load-started'|'load-failed'|'load-succeeded'|'failed'|'succeeded';
 }


### PR DESCRIPTION
⚠️ Sorry about one massive change in a single PR. When I was removing in-memory caching, there was so much to change and later fix, that I just ended up fully refactoring. Splitting this into multiple phases would be hard and time consuming.
On a positive side, I believe that this change, although massive, removes **a lot** of complexity (56%) around preload scripts and will be pleasure to work with for possible future bugs and edge cases.
Forgive me for my _big changes_ sin

ℹ️ This PR:
1. removes in-memory caching for preload scripts
2. refactors and cleans up preload scripts logic
3. fixes correct event order for "preload-scripts-state-changing" when window.reloads

➕ New test: [Preload scripts: window.reload (preload-scripts-state-changing)](https://testing-dashboard.openfin.co/#/app/tests/5a046ed91573627ee43842bb/edit)

✅ Test results:
• [Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a0f59b69a4b9e06a9723a41)
• [Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a0f5a029a4b9e06a9723a42)