### PR TITLE
RUN-3443 changed 'plugin' to 'plugins'

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -802,7 +802,7 @@ Window.create = function(id, opts) {
     };
 
     const { manifest } = coreState.getManifest(identity);
-    const { plugin: plugins } = manifest || {};
+    const { plugins } = manifest || {};
     winObj.plugins = JSON.parse(JSON.stringify(plugins || []));
 
     // Set preload scripts' final loading states

--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -204,11 +204,7 @@ function fetchLocalConfig(configUrl, successCallback, errorCallback) {
 module.exports = {
 
     getStartupAppOptions: function(appJson) {
-        let opts = appJson['startup_app'];
-        if (opts) {
-            opts.plugin = appJson['plugin'];
-        }
-        return opts;
+        return appJson['startup_app'];
     },
 
     convertToElectron: function(options, returnAsString) {

--- a/src/browser/plugins.ts
+++ b/src/browser/plugins.ts
@@ -30,7 +30,7 @@ const pluginPaths: Map<string, string> = new Map();
  */
 export async function getModules(identity: Identity): Promise<PluginWithContent[]> {
     const { url, manifest } = getManifest(identity);
-    const { plugin: plugins = [] } = manifest || {};
+    const { plugins = [] } = manifest || {};
     const promises = plugins.map((plugin: Plugin) => getModule(identity, url, plugin));
     return await Promise.all(promises);
 }

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -262,7 +262,7 @@ export interface Manifest {
     };
     licenseKey: string;
     offlineAccess?: boolean;
-    plugin?: Plugin[];
+    plugins?: Plugin[];
     proxy?: ProxySettings;
     runtime: {
         arguments?: string;


### PR DESCRIPTION
Changed `plugin` to `plugins` (manifest)

✅ Test results:
• [Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a134f2d9a4b9e06a9723a58)
• [Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a134ecb9a4b9e06a9723a57)