### PR TITLE
RUN-3617: ENOENT from cachedFetch 8.56.26 2nd round

### DIFF
--- a/src/browser/cached_resource_fetcher.ts
+++ b/src/browser/cached_resource_fetcher.ts
@@ -77,6 +77,8 @@ export async function cachedFetch(appUuid: string, fileUrl: string, callback: (e
                 app.vlog(1, `cachedFetch uuid ${appUuid} url ${fileUrl} file ${filePath} err ${e.message}`);
                 callback(err, filePath);
                 reject(err);
+            } finally {
+                fetchMap.delete(filePath);
             }
         });
         fetchMap.set(filePath, p);

--- a/src/browser/cached_resource_fetcher.ts
+++ b/src/browser/cached_resource_fetcher.ts
@@ -22,6 +22,8 @@ import {isURL, isURI, uriToPath} from '../common/regex';
 
 let appQuiting: Boolean = false;
 
+const fetchMap: Map<string, Promise<any>> = new Map();
+
 app.on('quit', () => { appQuiting = true; });
 
 /**
@@ -60,15 +62,25 @@ export async function cachedFetch(appUuid: string, fileUrl: string, callback: (e
     const filePath = getFilePath(appCacheDir, fileUrl);
     let err: Error;
 
-    try {
-        await prepDownloadLocation(appCacheDir);
-        await download(fileUrl, filePath);
-    } catch (e) {
-        err = e;
-        app.vlog(1, `cachedFetch uuid ${appUuid} url ${fileUrl} file ${filePath} err ${e.message}`);
+    app.vlog(1, `cachedFetch ${fileUrl} ${filePath}`);
+    if (fetchMap.has(filePath)) {
+        fetchMap.get(filePath).then(() => callback(null, filePath)).catch(callback);
+    } else {
+        const p = new Promise( async (resolve, reject) => {
+            try {
+                await prepDownloadLocation(appCacheDir);
+                await download(fileUrl, filePath);
+                callback(null, filePath);
+                resolve(filePath);
+            } catch (e) {
+                err = e;
+                app.vlog(1, `cachedFetch uuid ${appUuid} url ${fileUrl} file ${filePath} err ${e.message}`);
+                callback(err, filePath);
+                reject(err);
+            }
+        });
+        fetchMap.set(filePath, p);
     }
-
-    callback(err, filePath);
 }
 
 function pathExists (location: string): Promise<boolean> {
@@ -175,6 +187,7 @@ function download(fileUrl: string, filePath: string): Promise<any> {
 
         request.once('response', (response: any) => {
             const { statusCode } = response;
+            app.vlog(1, `cachedFetch download status ${filePath} ${statusCode} `);
 
             response.setEncoding('binary');
             response.on('data', (chunk: any) => {


### PR DESCRIPTION
Tests:

[W10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a15ac689a4b9e06a9723a77)
[W7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a15ac1d9a4b9e06a9723a76)