### PR TITLE
RUN-3598 shows preload scripts' and plugins' eval errors in console

### DIFF
--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -614,6 +614,7 @@ limitations under the License.
                     message: logBase + `eval succeeded for ${name} ${version}`
                 });
             } catch (err) {
+                window.console.error(`${err.name}: ${err.message}\nPlugin: ${name} ${version}`);
                 asyncApiCall(action, { name, version, state: 'failed' });
                 syncApiCall('write-to-log', {
                     level: 'info',
@@ -649,6 +650,7 @@ limitations under the License.
                     asyncApiCall(action, { url, state: 'succeeded' });
                     syncApiCall('write-to-log', { level: 'info', message: logBase + `eval succeeded for ${url}` });
                 } catch (err) {
+                    window.console.error(`${err.name}: ${err.message}\nPreload script: ${url}`);
                     asyncApiCall(action, { url, state: 'failed' });
                     syncApiCall('write-to-log', { level: 'error', message: logBase + `eval failed for ${err}` });
                 }


### PR DESCRIPTION
ℹ️ Shows preload scripts' and plugins' eval errors in console
![screenshot](https://user-images.githubusercontent.com/5790216/33290169-e06b21e6-d38f-11e7-8e66-d18fbde4c681.png)

➕ New tests:
• [Preload scripts: print eval error to console](https://testing-dashboard.openfin.co/#/app/tests/5a1c2c629a4b9e06a9723a8b/edit)
• [Plugins: print eval error to console](https://testing-dashboard.openfin.co/#/app/tests/5a1c6fb29a4b9e06a9723a8e/edit)

✅ Test results:
• [Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a1c828f9a4b9e06a9723a94)
• [Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a1c82df9a4b9e06a9723a95)