### PR TITLE
RUN-3444 replaces 'optional' option with 'mandatory' for preload scripts

### DIFF
--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -456,7 +456,9 @@ Application.run = function(identity, configUrl = '', userAppConfigArgs = undefin
     } else {
         // Flow through preload script logic (eg. re-download of failed preload scripts)
         // only if app is not already running.
-        System.downloadPreloadScripts(windowIdentity, mainWindowOpts.preloadScripts, proceed);
+        System.downloadPreloadScripts(windowIdentity, mainWindowOpts.preloadScripts)
+            .then(proceed)
+            .catch(proceed);
     }
 };
 

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -47,7 +47,6 @@ let WindowGroups = require('../window_groups.js');
 import { validateNavigation, navigationValidator } from '../navigation_validation';
 import { toSafeInt } from '../../common/safe_int';
 import route from '../../common/route';
-import { getPreloadScriptState, getIdentifier } from '../preload_scripts';
 import { FrameInfo } from './frame';
 import { System } from './system';
 // constants
@@ -806,12 +805,7 @@ Window.create = function(id, opts) {
     winObj.plugins = JSON.parse(JSON.stringify(plugins || []));
 
     // Set preload scripts' final loading states
-    winObj.preloadScripts = (_options.preloadScripts || _options.preload || []).map(preload => {
-        return {
-            url: getIdentifier(preload),
-            state: getPreloadScriptState(getIdentifier(preload))
-        };
-    });
+    winObj.preloadScripts = (_options.preloadScripts || []);
     winObj.framePreloadScripts = {}; // frame ID => [{url, state}]
 
     if (!coreState.getWinObjById(id)) {
@@ -1193,9 +1187,9 @@ Window.setWindowPreloadState = function(identity, payload) {
             if (!frameState) {
                 frameState = openfinWindow.framePreloadScripts[name] = [];
             }
-            preloadScripts = frameState.find(e => e.url === getIdentifier(payload));
+            preloadScripts = frameState.find(e => e.url === url);
             if (!preloadScripts) {
-                frameState.push(preloadScripts = { url: getIdentifier(payload) });
+                frameState.push(preloadScripts = { url });
             }
             preloadScripts = [preloadScripts];
         } else {
@@ -1204,7 +1198,7 @@ Window.setWindowPreloadState = function(identity, payload) {
         if (preloadScripts) {
             preloadScripts[0].state = state;
         } else {
-            log.writeToLog('info', `setWindowPreloadState missing preloadState ${uuid} ${name} ${getIdentifier(payload)} `);
+            log.writeToLog('info', `setWindowPreloadState missing preloadState ${uuid} ${name} ${url} `);
         }
     }
 

--- a/src/browser/cached_resource_fetcher.ts
+++ b/src/browser/cached_resource_fetcher.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import {app, net} from 'electron'; // Electron app
-import {stat, mkdir, writeFileSync, createWriteStream} from 'fs';
+import {stat, mkdir, createWriteStream} from 'fs';
 import {join, parse} from 'path';
 import {parse as parseUrl} from 'url';
 import {createHash} from 'crypto';

--- a/src/browser/rvm/rvm_message_bus.ts
+++ b/src/browser/rvm/rvm_message_bus.ts
@@ -363,14 +363,13 @@ export class RVMMessageBus extends EventEmitter  {
      */
     public getPluginInfo(manifestUrl: string, opts: Plugin): Promise<PluginQueryResponse> {
         return new Promise((resolve) => {
-            const {name, version, optional} = opts;
+            const {name, version} = opts;
 
             const rvmMsg: PluginQuery = {
                 topic: 'application',
                 action: 'query-plugin',
                 name,
                 version,
-                optional,
                 sourceUrl: manifestUrl
             };
 

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -564,61 +564,48 @@ limitations under the License.
     };
 
     /**
-     * Preload script eval
+     * An event indicating the moment OpenFin API is injected
      */
     ipc.once(`post-api-injection-${renderFrameId}`, () => {
         const { uuid, name } = initialOptions;
-        const identity = { uuid, name };
-        const windowOptions = entityInfo.entityType === 'iframe' ? getWindowOptionsSync(entityInfo.parent) :
-            getCurrentWindowOptionsSync();
-        const windowIsNotification = syncApiCall('window-is-notification-type', {
-            uuid: windowOptions.uuid,
-            name: windowOptions.name
-        });
+        const windowIsNotification = syncApiCall('window-is-notification-type', { uuid, name });
 
-        // Don't execute preload scripts and plugin modules in notifications
-        if (windowIsNotification) {
-            return;
-        }
-
-        let { preloadScripts } = convertOptionsToElectronSync(windowOptions);
-
-        evalPlugins(identity);
-
-        if (typeof preloadScripts === 'object' && preloadScripts.length) {
-            evalPreloadScripts(identity, preloadScripts);
+        if (!windowIsNotification) {
+            evalPlugins(uuid, name);
+            evalPreloadScripts(uuid, name);
         }
     });
 
     /**
-     * Requests plugin modules from the Core and evals them in the current window
+     * Request plugin modules from the Core and execute them in the current window
      */
-    function evalPlugins(identity) {
+    function evalPlugins(uuid, name) {
         const action = 'set-window-plugin-state';
         const plugins = syncApiCall('get-plugin-modules');
-        let logBase = `[plugin] [${identity.uuid}]-[${identity.name}]: `;
+        const log = (msg) => {
+            asyncApiCall('write-to-log', {
+                level: 'info',
+                message: `[plugins] [${uuid}]-[${name}]: ${msg}`
+            });
+        };
 
         plugins.forEach((plugin) => {
-            // _content - contains module code as a string to eval in this window
+            // _content: contains plugin module code as a string to eval in this window
             const { name, version, _content } = plugin;
 
             if (!_content) {
+                log(`Skipped execution of plugin module [${name} ${version}], ` +
+                    `because the content is not available`);
                 return;
             }
 
             try {
                 window.eval(_content); /* jshint ignore:line */
+                log(`Succeeded execution of plugin module [${name} ${version}]`);
                 asyncApiCall(action, { name, version, state: 'succeeded' });
-                syncApiCall('write-to-log', {
-                    level: 'info',
-                    message: logBase + `eval succeeded for ${name} ${version}`
-                });
             } catch (err) {
+                log(`Failed execution of plugin module [${name} ${version}]`);
                 asyncApiCall(action, { name, version, state: 'failed' });
-                syncApiCall('write-to-log', {
-                    level: 'info',
-                    message: logBase + `eval failed for ${name} ${version}`
-                });
             }
         });
 
@@ -626,34 +613,46 @@ limitations under the License.
     }
 
     /**
-     * Requests preload scripts contents from the Core and evals them in the current window
+     * Request preload scripts from the Core and execute them in the current window
      */
-    function evalPreloadScripts(identity, preloadOption) {
+    function evalPreloadScripts(uuid, name) {
         const action = 'set-window-preload-state';
-        let logBase = `[preload] [${identity.uuid}]-[${identity.name}]: `;
-        let preloadScripts;
+        const preloadScripts = syncApiCall('get-preload-scripts');
+        const requiredScriptsFailed = preloadScripts.some(e => !e._content && !e.optional);
+        const log = (msg) => {
+            asyncApiCall('write-to-log', {
+                level: 'info',
+                message: `[preloadScripts] [${uuid}]-[${name}]: ${msg}`
+            });
+        };
 
-        try {
-            preloadScripts = syncApiCall('get-selected-preload-scripts', preloadOption);
-        } catch (error) {
-            preloadScripts = [];
-            syncApiCall('write-to-log', { level: 'error', message: logBase + error });
-        }
+        if (requiredScriptsFailed) {
+            // Don't evaluate preload scripts when there
+            // is at least one load-failed that is required
+            log(`Aborted execution of preload scripts, ` +
+                `because at least one required preload script failed to load`);
 
-        preloadScripts.forEach((preloadScript) => {
-            const { url, content } = preloadScript;
+        } else {
+            preloadScripts.forEach((preloadScript) => {
+                // _content: contains preload script code as a string to eval in this window
+                const { url, _content } = preloadScript;
 
-            if (content) {
-                try {
-                    window.eval(content); /* jshint ignore:line */
-                    asyncApiCall(action, { url, state: 'succeeded' });
-                    syncApiCall('write-to-log', { level: 'info', message: logBase + `eval succeeded for ${url}` });
-                } catch (err) {
-                    asyncApiCall(action, { url, state: 'failed' });
-                    syncApiCall('write-to-log', { level: 'error', message: logBase + `eval failed for ${err}` });
+                if (!_content) {
+                    log(`Skipped execution of preload script for URL [${url}], ` +
+                        `because the content is not available`);
+                    return;
                 }
-            }
-        });
+
+                try {
+                    window.eval(_content); /* jshint ignore:line */
+                    log(`Succeeded execution of preload script for URL [${url}]`);
+                    asyncApiCall(action, { url, state: 'succeeded' });
+                } catch (error) {
+                    log(`Failed execution of preload script for URL [${url}]: ${error}`);
+                    asyncApiCall(action, { url, state: 'failed' });
+                }
+            });
+        }
 
         asyncApiCall(action, { allDone: true });
     }

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -618,7 +618,19 @@ limitations under the License.
     function evalPreloadScripts(uuid, name) {
         const action = 'set-window-preload-state';
         const preloadScripts = syncApiCall('get-preload-scripts');
-        const requiredScriptsFailed = preloadScripts.some(e => !e._content && !e.optional);
+
+        const requiredScriptsFailed = preloadScripts.some((e) => {
+            let isRequired = true;
+
+            if (typeof e.mandatory === 'boolean') {
+                isRequired = e.mandatory;
+            } else if (typeof e.optional === 'boolean') {
+                isRequired = !e.optional; // backwards compatibility
+            }
+
+            return !e._content && isRequired;
+        });
+
         const log = (msg) => {
             asyncApiCall('write-to-log', {
                 level: 'info',

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -96,11 +96,7 @@ export interface OpenFinWindow {
     id: number;
     name: string;
     plugins: PluginState[];
-    preloadScripts: {
-        optional?: boolean;
-        state: 'load-started'|'load-failed'|'load-succeeded'|'failed'|'succeeded';
-        url: string;
-    }[];
+    preloadScripts: PreloadScriptState[];
     uuid: string;
 }
 
@@ -301,4 +297,13 @@ export interface Plugin {
 
 export interface PluginState extends Plugin {
     state: 'load-failed'|'load-succeeded'|'failed'|'succeeded';
+}
+
+export interface PreloadScript {
+    optional?: boolean;
+    url: string;
+}
+
+export interface PreloadScriptState extends PreloadScript {
+    state: 'load-started'|'load-failed'|'load-succeeded'|'failed'|'succeeded';
 }

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -290,8 +290,8 @@ export interface Manifest {
 
 export interface Plugin {
     link?: string;
+    mandatory?: boolean;
     name: string;
-    optional?: boolean;
     version: string;
 }
 
@@ -300,7 +300,7 @@ export interface PluginState extends Plugin {
 }
 
 export interface PreloadScript {
-    optional?: boolean;
+    mandatory?: boolean;
     url: string;
 }
 


### PR DESCRIPTION
    ⚠️ NOT READY FOR A REVIEW YET

ℹ️ Since plugins moved from `optional` to `mandatory` option, we are adding the same change for preload scripts. _We will still support `optional` option for preload scripts though..._

👫 Coupled with [this javascript-adapter PR](https://github.com/openfin/javascript-adapter/pull/362)

➕ Tests: 
1. [new Window (preloadScripts) (multiple, missing optional)](https://testing-dashboard.openfin.co/#/app/tests/59b929a83d90dd51ca4f101c/edit)
2. [new Window (preloadScripts) (multiple, missing required)](https://testing-dashboard.openfin.co/#/app/tests/59ee0116af26a25be2ffc910/edit)
3. [new Window (preloadScripts) (multiple, missing default)](https://testing-dashboard.openfin.co/#/app/tests/59ee03d9af26a25be2ffc911/edit)

✅ Test results: [Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a1f21eb9a4b9e06a9723ab0), [Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a1f22369a4b9e06a9723ab1)