### PR TITLE
RUN-3563 RUN-3564 RUN-3565 RUN-3536 preload scripts refactor/cleanup/fix

### DIFF
--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -46,7 +46,6 @@ import { validateNavigationRules } from '../navigation_validation';
 import * as log from '../log';
 import SubscriptionManager from '../subscription_manager';
 import route from '../../common/route';
-import { getIdentifier, deletePreloadScriptState } from '../preload_scripts';
 
 const subscriptionManager = new SubscriptionManager();
 const TRAY_ICON_KEY = 'tray-icon-events';
@@ -440,7 +439,9 @@ Application.run = function(identity, configUrl = '', userAppConfigArgs = undefin
     } else {
         // Flow through preload script logic (eg. re-download of failed preload scripts)
         // only if app is not already running.
-        System.downloadPreloadScripts(windowIdentity, mainWindowOpts.preloadScripts, proceed);
+        System.downloadPreloadScripts(windowIdentity, mainWindowOpts.preloadScripts)
+            .then(proceed)
+            .catch(proceed);
     }
 };
 
@@ -819,15 +820,6 @@ Application.emitRunRequested = function(identity, userAppConfigArgs) {
             userAppConfigArgs
         });
     }
-};
-
-Application.reloadPreloadScripts = function(identity, preloadScripts, callback) {
-    (preloadScripts || []).map(preload => {
-        electronApp.vlog(1, `clear preload script ${getIdentifier(preload)}`);
-        deletePreloadScriptState(getIdentifier(preload));
-    });
-    System.downloadPreloadScripts(identity, preloadScripts, callback);
-
 };
 
 Application.wait = function() {

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -47,7 +47,6 @@ let WindowGroups = require('../window_groups.js');
 import { validateNavigation, navigationValidator } from '../navigation_validation';
 import { toSafeInt } from '../../common/safe_int';
 import route from '../../common/route';
-import { getPreloadScriptState, getIdentifier } from '../preload_scripts';
 import { FrameInfo } from './frame';
 import { System } from './system';
 // constants
@@ -811,12 +810,7 @@ Window.create = function(id, opts) {
     winObj.plugins = JSON.parse(JSON.stringify(plugins || []));
 
     // Set preload scripts' final loading states
-    winObj.preloadScripts = (_options.preloadScripts || _options.preload || []).map(preload => {
-        return {
-            url: getIdentifier(preload),
-            state: getPreloadScriptState(getIdentifier(preload))
-        };
-    });
+    winObj.preloadScripts = (_options.preloadScripts || []);
     winObj.framePreloadScripts = {}; // frame ID => [{url, state}]
 
     if (!coreState.getWinObjById(id)) {
@@ -1198,9 +1192,9 @@ Window.setWindowPreloadState = function(identity, payload) {
             if (!frameState) {
                 frameState = openfinWindow.framePreloadScripts[name] = [];
             }
-            preloadScripts = frameState.find(e => e.url === getIdentifier(payload));
+            preloadScripts = frameState.find(e => e.url === url);
             if (!preloadScripts) {
-                frameState.push(preloadScripts = { url: getIdentifier(payload) });
+                frameState.push(preloadScripts = { url });
             }
             preloadScripts = [preloadScripts];
         } else {
@@ -1209,7 +1203,7 @@ Window.setWindowPreloadState = function(identity, payload) {
         if (preloadScripts) {
             preloadScripts[0].state = state;
         } else {
-            log.writeToLog('info', `setWindowPreloadState missing preloadState ${uuid} ${name} ${getIdentifier(payload)} `);
+            log.writeToLog('info', `setWindowPreloadState missing preloadState ${uuid} ${name} ${url} `);
         }
     }
 

--- a/src/browser/api_protocol/api_handlers/application.js
+++ b/src/browser/api_protocol/api_handlers/application.js
@@ -77,7 +77,6 @@ module.exports.applicationApiMap = {
     'register-custom-data': registerCustomData,
     'register-external-window': registerExternalWindow,
     'relaunch-on-close': relaunchOnClose,
-    'redownload-preload-scripts': downloadPreloadScripts, // download-preload-scripts already used
     'remove-tray-icon': removeTrayIcon,
     'restart-application': restartApplication,
     'run-application': runApplication,
@@ -442,20 +441,4 @@ function relaunchOnClose(identity, message, ack, nack) {
     Application.scheduleRestart(appIdentity, () => {
         ack(successAck);
     }, nack);
-}
-
-function downloadPreloadScripts(identity, message, ack, nack) {
-    const appIdentity = apiProtocolBase.getTargetApplicationIdentity(message.payload);
-    const { payload } = message;
-    // not pass name in Identity here to prevent preload script events from firing
-    Application.reloadPreloadScripts({ uuid: appIdentity.uuid }, payload.scripts, err => {
-        electronApp.vlog(1, `reloadPreloadScripts ${JSON.stringify(err)}`);
-        if (Array.isArray(err)) {
-            const dataAck = _.clone(successAck);
-            dataAck.data = err;
-            ack(dataAck);
-        } else {
-            nack(err);
-        }
-    });
 }

--- a/src/browser/api_protocol/api_handlers/system.js
+++ b/src/browser/api_protocol/api_handlers/system.js
@@ -53,6 +53,7 @@ function SystemApiHandler() {
         'convert-options': convertOptions,
         'delete-cache-request': deleteCacheRequest, // apiPath: '.deleteCacheOnRestart' -> deprecated
         'download-asset': { apiFunc: downloadAsset, apiPath: '.downloadAsset' },
+        'download-preload-scripts': downloadPreloadScripts,
         'download-runtime': { apiFunc: downloadRuntime, apiPath: '.downloadRuntime' },
         'exit-desktop': { apiFunc: exitDesktop, apiPath: '.exitDesktop' },
         'generate-guid': generateGuid,
@@ -78,7 +79,7 @@ function SystemApiHandler() {
         'get-remote-config': { apiFunc: getRemoteConfig, apiPath: '.getRemoteConfig' },
         'get-rvm-info': getRvmInfo,
         'get-plugin-modules': getPluginModules,
-        'get-selected-preload-scripts': getSelectedPreloadScripts,
+        'get-preload-scripts': getPreloadScripts,
         'get-version': getVersion,
         'get-websocket-state': getWebSocketState,
         'launch-external-process': { apiFunc: launchExternalProcess, apiPath: '.launchExternalProcess' },
@@ -99,8 +100,7 @@ function SystemApiHandler() {
         'terminate-external-process': { apiFunc: terminateExternalProcess, apiPath: '.terminateExternalProcess' },
         'update-proxy': updateProxy,
         'view-log': { apiFunc: viewLog, apiPath: '.getLog' },
-        'write-to-log': writeToLog,
-        'download-preload-scripts': downloadPreloadScripts //internal function
+        'write-to-log': writeToLog
     };
 
     apiProtocolBase.registerActionMap(SystemApiHandlerMap, 'System');
@@ -152,21 +152,6 @@ function SystemApiHandler() {
         const dataAck = _.clone(successAck);
         dataAck.data = System.getCrashReporterState();
         ack(dataAck);
-    }
-
-    function downloadPreloadScripts(identity, message, ack, nack) {
-        const { payload } = message;
-        const { uuid, name, scripts } = payload;
-        const windowIdentity = { uuid, name };
-
-        System.downloadPreloadScripts(windowIdentity, scripts, err => {
-            if (!err) {
-                const dataAck = _.clone(successAck);
-                ack(dataAck);
-            } else {
-                nack(err);
-            }
-        });
     }
 
     function getAppAssetInfo(identity, message, ack, nack) {
@@ -508,6 +493,18 @@ function SystemApiHandler() {
         });
     }
 
+    function downloadPreloadScripts(identity, message, ack, nack) {
+        const { scripts } = message.payload;
+
+        System.downloadPreloadScripts(identity, scripts)
+            .then((downloadResults) => {
+                const dataAck = _.clone(successAck);
+                dataAck.data = downloadResults;
+                ack(dataAck);
+            })
+            .catch(nack);
+    }
+
     function downloadRuntime(identity, message, ack, nack) {
         const { payload } = message;
         const dataAck = _.clone(successAck);
@@ -540,13 +537,11 @@ function SystemApiHandler() {
         });
     }
 
-    function getSelectedPreloadScripts(identity, message, ack, nack) {
-        const { payload } = message;
-
-        System.getSelectedPreloadScripts(payload)
-            .then(scriptSet => {
+    function getPreloadScripts(identity, message, ack, nack) {
+        System.getPreloadScripts(identity)
+            .then((preloadScripts) => {
                 const dataAck = _.clone(successAck);
-                dataAck.data = scriptSet;
+                dataAck.data = preloadScripts;
                 ack(dataAck);
             })
             .catch(nack);

--- a/src/browser/cached_resource_fetcher.ts
+++ b/src/browser/cached_resource_fetcher.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import {app, net} from 'electron'; // Electron app
-import {stat, mkdir, writeFileSync, createWriteStream} from 'fs';
+import {stat, mkdir, createWriteStream} from 'fs';
 import {join, parse} from 'path';
 import {parse as parseUrl} from 'url';
 import {createHash} from 'crypto';

--- a/src/browser/preload_scripts.ts
+++ b/src/browser/preload_scripts.ts
@@ -14,223 +14,106 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// built-in modules
-import * as fs from 'fs';
-
-// local modules
-import { System } from './api/system.js';
+const Window = require('./api/window.js').Window;
 import { cachedFetch } from './cached_resource_fetcher';
-import * as log from './log';
-import { Identity } from '../shapes';
-import ofEvents from './of_events';
-import route from '../common/route';
-import { Timer } from '../common/timer';
+import { convertToElectron } from './convert_options';
+import { Identity, PreloadScript } from '../shapes';
+import { readFile } from 'fs';
+import { writeToLog } from './log';
 
-
-// some local type definitions
-type PreloadOption = PreloadInstance[];
-type PreloadInstance = PreloadScript;
-interface PreloadScript {
-    url: string; // URI actually: http:// or file://
-    optional?: boolean; // not used herein but used by api_decorator at script execution time
-}
-interface PreloadFetched extends PreloadScript {
-    scriptPath: string; // location on disc of cached fetch
-}
-type FetchResolver = (value?: PreloadInstance | PreloadFetched | FetchResponse) => void;
-type Resolver = (value?: any) => void;
-type Rejector = (reason?: Error) => void;
-
-// Preload scripts' states are stored here. Example:
-// 'http://path.com/to/script': 'load-succeeded'
-const preloadStates = new Map();
-
-const REGEX_FILE_SCHEME = /^file:\/\//i;
-
-interface FetchResponse {
-    identity: Identity;
-    preloadScript?: PreloadInstance;
-    scriptPath: string;
+interface PreloadScriptWithContent extends PreloadScript {
+    _content: string;
 }
 
-type LoadResponses = boolean[];
+interface DownloadResult {
+    url: string;
+    success: boolean;
+    error?: string;
+}
 
-/** Returns a `Promise` once all preload scripts have been fetched and loaded or have failed to fetch or load.
+/**
+ * A map of local paths to preload scripts that
+ * have already been downloaded (per app).
  *
- * @param {object} identity
- * @param {PreloadInstance[]} preloadOption
- * @param {function} [proceed] - If supplied, both `catch` and `then` are called on it.
- *
- * If you don't supply `proceed`, call both `catch` and `then` on your own to proceed as appropriate.
- *
- * Notes:
- * 1. There is only one `catch`able error, bad preload option type, which has already been logged for you.
- * 2. The promise otherwise always resolves; fetch/load failures are not errors.
- * 3. Successfully loaded scripts are cached via `System.setPreloadScript`,
- * to be eval'd later by api_decorator as windows spin up.
- * 4. No resolve values are available to `then`; to access loaded scripts,
- * call `System.getPreloadScript` or `System.getSelectedPreloadScripts`.
+ * Examples:
+ * 'appUuid preloadScriptURL' -> 'path\to\preload\script.js'
+ * 'appUuid preloadScriptURL' -> '' (empty path means load failed)
  */
+const pathMap: Map<string, string> = new Map();
 
-export function fetchAndLoadPreloadScripts(
-    identity: Identity,
-    preloadOption: PreloadOption,
-    proceed?: () => void
-): Promise<LoadResponses> {
-    const timer = new Timer();
-    let result: Promise<LoadResponses>;
+const getKey = (uuid: string, url: string): string => `${uuid} ${url}`;
 
-    const loadedScripts: Promise<any>[] = preloadOption.map((preload: PreloadInstance) => {
-        const { url } = preload;
-
-        logPreload('info', identity, 'fetch started', url);
-        updatePreloadState(identity, preload, 'load-started');
-
-        // todo: following if clause slated for removal (RUN-3227, blocked by RUN-3162), i.e., return always
-        // todo: removed check for memory cache here,  need to remove memory cache entirely
-        return fetchToCache(identity, preload).then(loadFromCache);
+export async function downloadScripts(identity: Identity, preloadScripts: PreloadScript[] = []): Promise<DownloadResult[]> {
+    const promises = preloadScripts.map((preloadScript) => {
+        return downloadScript(identity, preloadScript);
     });
-
-    // wait for them all to resolve
-    result = Promise.all(loadedScripts);
-
-    result.catch((error: Error | string) => {
-        logPreload('error', identity, 'error', '', error);
-        return error;
-    }).then((values: LoadResponses) => {
-        const compact = values.filter(b => b);
-        logPreload('info', identity, 'summary: fetch/load',  `${compact.length} of ${values.length} scripts`, timer);
-        return values;
-    });
-
-    if (proceed) {
-        result.catch(proceed).then(proceed);
-    }
-
-    return result;
+    return await Promise.all(promises);
 }
 
-// resolves to type `PreloadFetched` on success
-// resolves to `undefined` when fetch fails to cache the asset
-function fetchToCache(identity: Identity, preloadScript: PreloadScript): Promise<FetchResponse> {
-    const timer = new Timer();
-    const { url } = preloadScript;
+function downloadScript(identity: Identity, preloadScript: PreloadScript): Promise<DownloadResult> {
+    return new Promise((resolve) => {
+        const { uuid, name } = identity;
+        const { url } = preloadScript;
+        const pathMapKey = getKey(uuid, url);
+        const log = (msg: string) => {
+            writeToLog('info', `[preloadScripts] [${uuid}]-[${name}]: ${msg}`);
+        };
 
-    return new Promise((resolve: FetchResolver, reject: Rejector) => {
-        cachedFetch(identity.uuid, url, (fetchError: Error, scriptPath: string) => {
-            if (!fetchError) {
-                logPreload('info', identity, 'fetch succeeded', url, timer);
-                resolve({identity, preloadScript, scriptPath});
+        log(`Started downloading preload script from URL [${url}]`);
+
+        cachedFetch(uuid, url, (error, scriptPath) => {
+            const result: DownloadResult = { url, success: !error };
+
+            if (error) {
+                pathMap.set(pathMapKey, '');
+                log(`Failed downloading preload script from URL [${url}]: ${error}`);
+                result.error = error.toString();
             } else {
-                logPreload(preloadScript.optional ? 'warning' : 'error', identity, 'fetch failed', url, fetchError);
-                updatePreloadState(identity, preloadScript, 'load-failed');
-                resolve();
+                pathMap.set(pathMapKey, scriptPath);
+                log(`Succeeded downloading preload script from URL [${url}]`);
             }
+
+            resolve(result);
         });
     });
 }
 
-// resolves to type `PreloadLoaded` on success
-// resolves to `undefined` when above fetch failed or when successfully fetched asset fails to load from Chromium cache
-function loadFromCache(opts: FetchResponse): Promise<boolean> {
-    return new Promise((resolve: Resolver, reject: Rejector) => {
-        if (!opts || !opts.scriptPath) {
-            resolve(false); // got fetchError above OR no error but no scriptPath either; in any case don't attempt to load
-        } else {
-            const preload = opts.preloadScript;
-            const { identity, scriptPath } = opts;
-            const id = getIdentifier(preload);
+export async function loadScripts(identity: Identity): Promise<PreloadScriptWithContent[]|any> {
+    const options = Window.getOptions(identity);
+    const { preloadScripts } = convertToElectron(options);
+    const promises = preloadScripts.map((preloadScript: PreloadScript) => loadScript(identity, preloadScript));
+    return await Promise.all(promises);
+}
 
-            fs.readFile(scriptPath, 'utf8', (readError: Error, scriptText: string) => {
-                // todo: remove following workaround when RUN-3162 issue fixed
-                //BEGIN WORKAROUND (RUN-3162 fetchError null on 404)
-                if (!readError && /^(Cannot GET |<\?xml)/.test(scriptText)) {
-                    // got a 404 but response was cached as a
-                    logPreload(isOptional(preload) ? 'warning' : 'error', identity, 'load failed', id, 404);
-                    updatePreloadState(identity, preload, 'load-failed');
-                    resolve(false);
-                    return;
-                }
-                //END WORKAROUND
+function loadScript(identity: Identity, preloadScript: PreloadScript): Promise<PreloadScriptWithContent> {
+    return new Promise((resolve) => {
+        const { uuid, name } = identity;
+        const { url } = preloadScript;
+        const pathMapKey = getKey(uuid, url);
+        const scriptPath = pathMap.get(pathMapKey);
+        const log = (msg: string) => {
+            writeToLog('info', `[preloadScripts] [${uuid}]-[${name}]: ${msg}`);
+        };
 
-                if (!readError) {
-                    logPreload('info', identity, 'load succeeded', id);
-                    updatePreloadState(identity, preload, 'load-succeeded');
-                    System.setPreloadScript(getIdentifier(preload), scriptText);
-                } else {
-                    logPreload(isOptional(preload) ? 'warning' : 'error', identity, 'load failed', id, readError);
-                    updatePreloadState(identity, preload, 'load-failed');
-                }
+        log(`Started loading preload script for URL [${url}]`);
+        Window.setWindowPreloadState(identity, {...preloadScript, state: 'load-started'});
 
-                resolve(!readError);
-            });
+        if (!scriptPath) {
+            log(`Failed loading preload script for URL [${url}]: preload script wasn't downloaded`);
+            Window.setWindowPreloadState(identity, {...preloadScript, state: 'load-failed'});
+            return resolve({...preloadScript, _content: ''});
         }
+
+        readFile(scriptPath, 'utf8', (readError: Error, data: string) => {
+            if (readError) {
+                log(`Failed loading preload script for URL [${url}] from path [${scriptPath}]: ${readError}`);
+                Window.setWindowPreloadState(identity, {...preloadScript, state: 'load-failed'});
+                resolve({...preloadScript, _content: ''});
+            } else {
+                log(`Succeeded loading preload script for URL [${url}] from path [${scriptPath}]`);
+                Window.setWindowPreloadState(identity, {...preloadScript, state: 'load-succeeded'});
+                resolve({...preloadScript, _content: data});
+            }
+        });
     });
-}
-
-function logPreload(
-    level: string,
-    identity: Identity,
-    state: string,
-    id: string,
-    timerOrError?: Timer | Error | string | number
-): void {
-    if (id) {
-        state += ` for ${id}`;
-    }
-
-    if (timerOrError instanceof Timer) {
-        state += timerOrError.toString(' in #.### secs.');
-    } else if (timerOrError) {
-        state += `: ${JSON.stringify(timerOrError)}`;
-    }
-
-    log.writeToLog(level, `[PRELOAD] [${identity.uuid}]-[${identity.name}] ${state}`);
-}
-
-function updatePreloadState(
-    identity: Identity,
-    preload: PreloadInstance,
-    state?: string
-): void {
-    const id = getIdentifier(preload);
-    const {uuid, name} = identity;
-    if (name) {
-        const eventRoute = route.window('preload-scripts-state-changing', uuid, name);
-        const preloadScripts = [Object.assign({}, preload, {state})];
-
-        preloadStates.set(id, state);
-        ofEvents.emit(eventRoute, {name, uuid, preloadScripts});
-    }
-}
-
-function isPreloadOption(preloadOption: PreloadOption): preloadOption is PreloadOption {
-    return (
-        preloadOption &&
-        Array.isArray(preloadOption) &&
-        preloadOption.every(isPreloadInstance)
-    );
-}
-
-// type guard: a Preload object
-function isPreloadInstance(preload: PreloadInstance): preload is PreloadInstance {
-    return (
-        typeof preload === 'object' && typeof getIdentifier(preload) === 'string'
-    );
-}
-
-export function getPreloadScriptState(identifier: string): string {
-    return preloadStates.get(identifier);
-}
-
-export function getIdentifier(preload: any) {
-    return preload.url ? preload.url : `${preload.name}-${preload.version}`;
-}
-
-export function deletePreloadScriptState(identifier: string): void {
-    preloadStates.delete(identifier);
-}
-
-function isOptional(preload: any) {
-    return preload.optional;
 }

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -96,11 +96,7 @@ export interface OpenFinWindow {
     id: number;
     name: string;
     plugins: PluginState[];
-    preloadScripts: {
-        optional?: boolean;
-        state: 'load-started'|'load-failed'|'load-succeeded'|'failed'|'succeeded';
-        url: string;
-    }[];
+    preloadScripts: PreloadScriptState[];
     uuid: string;
     mainFrameRoutingId: number;
 }
@@ -304,4 +300,13 @@ export interface Plugin {
 
 export interface PluginState extends Plugin {
     state: 'load-failed'|'load-succeeded'|'failed'|'succeeded';
+}
+
+export interface PreloadScript {
+    optional?: boolean;
+    url: string;
+}
+
+export interface PreloadScriptState extends PreloadScript {
+    state: 'load-started'|'load-failed'|'load-succeeded'|'failed'|'succeeded';
 }


### PR DESCRIPTION
⚠️ Sorry about one massive change in a single PR. When I was removing in-memory caching, there was so much to change and later fix, that I just ended up fully refactoring. Splitting this into multiple phases would be hard and time consuming.
On a positive side, I believe that this change, although massive, removes **a lot** of complexity (51%) around preload scripts and will be pleasure to work with for possible future bugs and edge cases.
Forgive me for my _big changes_ sins

ℹ️ This PR:
1. removes in-memory caching for preload scripts
2. refactors and cleans up preload scripts logic
3. fixes correct event order for "preload-scripts-state-changing" when window.reloads
4. handles re-downloading preload scripts with Wenjun's PR

➕ New test: [Preload scripts: window.reload (preload-scripts-state-changing)](https://testing-dashboard.openfin.co/#/app/tests/5a046ed91573627ee43842bb/edit)

✅ Test results:
• [Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a2072199a4b9e06a9723abc)
• [Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a2072579a4b9e06a9723abd)