### PR TITLE
RUN-3444 replaces 'optional' option with 'mandatory' for preload scripts

### DIFF
--- a/src/browser/rvm/rvm_message_bus.ts
+++ b/src/browser/rvm/rvm_message_bus.ts
@@ -363,14 +363,13 @@ export class RVMMessageBus extends EventEmitter  {
      */
     public getPluginInfo(manifestUrl: string, opts: Plugin): Promise<PluginQueryResponse> {
         return new Promise((resolve) => {
-            const {name, version, optional} = opts;
+            const {name, version} = opts;
 
             const rvmMsg: PluginQuery = {
                 topic: 'application',
                 action: 'query-plugin',
                 name,
                 version,
-                optional,
                 sourceUrl: manifestUrl
             };
 

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -619,7 +619,19 @@ limitations under the License.
     function evalPreloadScripts(uuid, name) {
         const action = 'set-window-preload-state';
         const preloadScripts = syncApiCall('get-preload-scripts');
-        const requiredScriptsFailed = preloadScripts.some(e => !e._content && !e.optional);
+
+        const requiredScriptsFailed = preloadScripts.some((e) => {
+            let isRequired = true;
+
+            if (typeof e.mandatory === 'boolean') {
+                isRequired = e.mandatory;
+            } else if (typeof e.optional === 'boolean') {
+                isRequired = !e.optional; // backwards compatibility
+            }
+
+            return !e._content && isRequired;
+        });
+
         const log = (msg) => {
             asyncApiCall('write-to-log', {
                 level: 'info',

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -293,8 +293,8 @@ export interface Manifest {
 
 export interface Plugin {
     link?: string;
+    mandatory?: boolean;
     name: string;
-    optional?: boolean;
     version: string;
 }
 
@@ -303,7 +303,7 @@ export interface PluginState extends Plugin {
 }
 
 export interface PreloadScript {
-    optional?: boolean;
+    mandatory?: boolean;
     url: string;
 }
 


### PR DESCRIPTION
ℹ️ Since plugins moved from `optional` to `mandatory` option, we are adding the same change for preload scripts. _We will still support `optional` option for preload scripts though..._

👫 Coupled with [this javascript-adapter PR](https://github.com/openfin/javascript-adapter/pull/362)

➕ Tests: 
1. [new Window (preloadScripts) (multiple, missing optional)](https://testing-dashboard.openfin.co/#/app/tests/59b929a83d90dd51ca4f101c/edit)
2. [new Window (preloadScripts) (multiple, missing required)](https://testing-dashboard.openfin.co/#/app/tests/59ee0116af26a25be2ffc910/edit)
3. [new Window (preloadScripts) (multiple, missing default)](https://testing-dashboard.openfin.co/#/app/tests/59ee03d9af26a25be2ffc911/edit)

✅ Test results: [Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a1f21eb9a4b9e06a9723ab0), [Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a1f22369a4b9e06a9723ab1)