### PR TITLE
RUN-3662 Fixed issue where auth events on resource fetcher were not handled.

### DIFF
--- a/src/browser/cached_resource_fetcher.ts
+++ b/src/browser/cached_resource_fetcher.ts
@@ -214,6 +214,12 @@ function download(fileUrl: string, filePath: string): Promise<any> {
             });
         });
 
+        request.once('login', (authInfo: any, callback: Function) => {
+            //Simply provide empty credentials to raise the authentication error.
+            //https://github.com/rdepena/electron/blob/master/docs/api/client-request.md#event-login
+            callback();
+        });
+
         request.once('error', (err: Error) => {
             reject(err);
         });


### PR DESCRIPTION
login events raised by the net module were not being handled, this led to hanging promises.

By invoking the empty callback we force a request error to be raised, this is exactly what we want.

### Tests:
[Win7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a25cfdb299179466481952b)
[Win10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a25d03b299179466481952c)