### PR TITLE
RUN-3588 add support for registerUser API

### DIFF
--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -386,7 +386,7 @@ Application.registerUser = function(identity, userName, appName, callback, error
     }
 
     let licenseKey = app.licenseKey;
-    let configUrl = app._configUrl || app.configUrl;
+    let configUrl = coreState.getConfigUrlByUuid(uuid);
 
     if (!licenseKey) {
         errorCallback(new Error(`application with uuid ${uuid} has no licenseKey specified`));
@@ -413,7 +413,7 @@ Application.registerUser = function(identity, userName, appName, callback, error
         sendToRVM({
                 topic: 'application',
                 action: 'register-user',
-                sourceUrl: app._configUrl,
+                sourceUrl: configUrl,
                 runtimeVersion: System.getVersion(),
                 payload: {
                     userName: userName,

--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -57,6 +57,7 @@ let rvmBus;
 let MonitorInfo;
 var Application = {};
 let fetchingIcon = {};
+let registeredUsersByApp = {};
 
 // var OfEvents = [
 //     'closed',
@@ -371,28 +372,55 @@ Application.pingChildWindow = function() {
     console.warn('Deprecated');
 };
 Application.registerCustomData = function(identity, data, callback, errorCallback) {
-    let app = Application.wrap(identity.uuid);
+    console.warn('Deprecated');
+    errorCallback(new Error('This function has been deprecated - please use Application.registerUser instead.'));
+};
+
+Application.registerUser = function(identity, userName, appName, callback, errorCallback) {
+    let uuid = identity.uuid;
+    let app = coreState.getAppByUuid(uuid) || coreState.getExternalAppObjByUuid(uuid);
 
     if (!app) {
-        errorCallback(new Error(`application with uuid ${identity.uuid} does not exist`));
+        errorCallback(new Error(`application with uuid ${uuid} does not exist`));
+        return;
+    }
+
+    let licenseKey = app.licenseKey;
+    let configUrl = app._configUrl || app.configUrl;
+
+    if (!licenseKey) {
+        errorCallback(new Error(`application with uuid ${uuid} has no licenseKey specified`));
+    } else if (!configUrl) {
+        errorCallback(new Error(`application with uuid ${uuid} has no _configUrl specified`));
     } else if (!rvmBus) {
         errorCallback(new Error('cannot connect to the RVM'));
-    } else if (!data || !data.userId || !data.organization) {
-        errorCallback(new Error('\'userId\' and \'organization\' fields are required to send custom data'));
+    } else if (!userName) {
+        errorCallback(new Error('\'userId\' field is required to register user'));
+    } else if (!appName) {
+        errorCallback(new Error('\'appName\' field is required to register user'));
+    } else if (userName.length > 128) {
+        errorCallback(new Error('\'userName\' is too long; must be <= 128 characters'));
+    } else if (appName.length > 32) {
+        errorCallback(new Error('\'appName\' is too long; must be <= 32 characters'));
+    } else if (uuid in registeredUsersByApp && registeredUsersByApp[uuid].has(userName)) {
+        errorCallback(new Error(`userName ${userName} is already registered for appName ${appName} with app uuid ${uuid}`));
     } else {
-        let success = rvmBus.publish({
-            topic: 'application',
-            action: 'register-custom-data',
-            sourceUrl: app._configUrl,
-            runtimeVersion: System.getVersion(),
-            data
-        });
-
-        if (success) {
-            callback();
-        } else {
-            errorCallback(new Error('there was an issue sending a message to the RVM'));
+        if (!(uuid in registeredUsersByApp)) {
+            registeredUsersByApp[uuid] = new Set();
         }
+        registeredUsersByApp[uuid].add(userName);
+
+        sendToRVM({
+                topic: 'application',
+                action: 'register-user',
+                sourceUrl: app._configUrl,
+                runtimeVersion: System.getVersion(),
+                payload: {
+                    userName: userName,
+                    appName: appName
+                }
+            }).then(callback, errorCallback)
+            .catch(errorCallback);
     }
 };
 
@@ -602,6 +630,10 @@ function run(identity, mainWindowOpts, userAppConfigArgs) {
     ofEvents.once(route.window('closed', uuid, uuid), () => {
         delete fetchingIcon[uuid];
         removeTrayIcon(app);
+
+        if (uuid in registeredUsersByApp) {
+            delete registeredUsersByApp[uuid];
+        }
 
         ofEvents.emit(route.application('closed', uuid), { topic: 'application', type: 'closed', uuid });
 

--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -371,22 +371,17 @@ Application.isRunning = function(identity) {
 Application.pingChildWindow = function() {
     console.warn('Deprecated');
 };
-Application.registerCustomData = function(identity, data, callback, errorCallback) {
-    console.warn('Deprecated');
-    errorCallback(new Error('This function has been deprecated - please use Application.registerUser instead.'));
-};
-
 Application.registerUser = function(identity, userName, appName, callback, errorCallback) {
-    let uuid = identity.uuid;
-    let app = coreState.getAppByUuid(uuid) || coreState.getExternalAppObjByUuid(uuid);
+    const uuid = identity.uuid;
+    const app = coreState.getAppByUuid(uuid) || coreState.getExternalAppObjByUuid(uuid);
 
     if (!app) {
         errorCallback(new Error(`application with uuid ${uuid} does not exist`));
         return;
     }
 
-    let licenseKey = app.licenseKey;
-    let configUrl = coreState.getConfigUrlByUuid(uuid);
+    const licenseKey = app.licenseKey;
+    const configUrl = coreState.getConfigUrlByUuid(uuid);
 
     if (!licenseKey) {
         errorCallback(new Error(`application with uuid ${uuid} has no licenseKey specified`));

--- a/src/browser/api_protocol/api_handlers/application.js
+++ b/src/browser/api_protocol/api_handlers/application.js
@@ -75,6 +75,7 @@ module.exports.applicationApiMap = {
     'notify-on-content-loaded': notifyOnContentLoaded,
     'ping-child-window': pingChildWindow,
     'register-custom-data': registerCustomData,
+    'register-user': registerUser,
     'register-external-window': registerExternalWindow,
     'relaunch-on-close': relaunchOnClose,
     'redownload-preload-scripts': downloadPreloadScripts, // download-preload-scripts already used
@@ -432,6 +433,15 @@ function registerCustomData(identity, message, ack, nack) {
     const appIdentity = apiProtocolBase.getTargetApplicationIdentity(payload);
 
     Application.registerCustomData(appIdentity, payload.data, () => {
+        ack(successAck);
+    }, nack);
+}
+
+function registerUser(identity, message, ack, nack) {
+    const payload = message.payload;
+    const appIdentity = apiProtocolBase.getTargetApplicationIdentity(payload);
+
+    Application.registerUser(appIdentity, payload.userName, payload.appName, () => {
         ack(successAck);
     }, nack);
 }

--- a/src/browser/api_protocol/api_handlers/application.js
+++ b/src/browser/api_protocol/api_handlers/application.js
@@ -74,9 +74,8 @@ module.exports.applicationApiMap = {
     'notify-on-app-connected': notifyOnAppConnected,
     'notify-on-content-loaded': notifyOnContentLoaded,
     'ping-child-window': pingChildWindow,
-    'register-custom-data': registerCustomData,
-    'register-user': registerUser,
     'register-external-window': registerExternalWindow,
+    'register-user': registerUser,
     'relaunch-on-close': relaunchOnClose,
     'redownload-preload-scripts': downloadPreloadScripts, // download-preload-scripts already used
     'remove-tray-icon': removeTrayIcon,
@@ -426,15 +425,6 @@ function externalWindowAction(identity, message, ack) {
 
     ack(successAck);
     /* jshint bitwise: true */
-}
-
-function registerCustomData(identity, message, ack, nack) {
-    const payload = message.payload;
-    const appIdentity = apiProtocolBase.getTargetApplicationIdentity(payload);
-
-    Application.registerCustomData(appIdentity, payload.data, () => {
-        ack(successAck);
-    }, nack);
 }
 
 function registerUser(identity, message, ack, nack) {

--- a/src/browser/rvm/rvm_message_bus.ts
+++ b/src/browser/rvm/rvm_message_bus.ts
@@ -26,18 +26,21 @@ export interface RvmMsgBase {
 
 // topic: application -----
 type applicationTopic = 'application';
-type registerCustomDataAction = 'register-custom-data';
+type registerUserAction = 'register-user';
 type hideSplashscreenAction = 'hide-splashscreen';
 type relaunchOnCloseAction = 'relaunch-on-close';
 type getDesktopOwnerSettingsAction = 'get-desktop-owner-settings';
 type downloadRuntimeAction = 'runtime-download';
 
-export interface RegisterCustomData extends RvmMsgBase {
+export interface RegisterUser extends RvmMsgBase {
     topic: applicationTopic;
-    action: registerCustomDataAction;
+    action: registerUserAction;
     sourceUrl: string;
     runtimeVersion: string;
-    data: any;
+    payload: {
+        userName: string;
+        appName: string;
+    };
 }
 
 export interface HideSplashscreen extends RvmMsgBase {


### PR DESCRIPTION
https://appoji.jira.com/browse/RUN-3588

This PR is for the new "registerUser" API that will replace the currently unused registerCustomData (see: https://github.com/openfin/Internal-Wiki/wiki/Custom-License-Registration)

Tests:
[W10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a25cfba299179466481952a)
[W7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a25cf3e2991794664819529)
[New Test](https://testing-dashboard.openfin.co/#/app/tests/5a25ce482991794664819528/edit) (I have more tests that need to be made public once the new RVM goes stable)

Related javascript-adapter PR: https://github.com/openfin/javascript-adapter/pull/365
