### PR TITLE
RUN-2393 dispatch "close" event after window was closed.

### DIFF
--- a/src/browser/api/notifications/subscriptions.ts
+++ b/src/browser/api/notifications/subscriptions.ts
@@ -541,9 +541,6 @@ function routeRequest(id: any, msg: NotificationMessage, ack: any) {
 
         case NoteAction.close:
             requestNoteClose(msg);
-
-            // TODO this should actually happen after the close happens
-            dispatchEvent('close', msg);
             break;
 
         case NoteAction.click:
@@ -700,7 +697,7 @@ function closeNotification(req: NotificationMessage): void {
 
     Window.animate(id, animateOpts, {}, () => {
         Window.close(id);
-
+        dispatchEvent('close', req);
         // TODO removeFromExternalMaps(id);
     }, (e: any) => { writeToLog('info', e); });
 }


### PR DESCRIPTION
close event was dispatched before notification was closed, thus missing click events, fixed the bug by dispatching close event after notification window was closed.

:white_check_mark: Test Result:
[Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a329bef6f202a5432b79f46)
[Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a329c6b6f202a5432b79f47)