### PR TITLE
RUN-3620: fixed bug that tries to access unavailable application properties

### DIFF
--- a/src/browser/navigation_validation.ts
+++ b/src/browser/navigation_validation.ts
@@ -49,7 +49,7 @@ export function validateNavigationRules(uuid: string, url: string, parentUuid: s
     } else if (parentUuid) {
         electronApp.vlog(1, `validateNavigationRules app ${uuid} check parent ${parentUuid}`);
         const parentObject = coreState.appByUuid(parentUuid);
-        if (parentObject) {
+        if (parentObject && parentObject.isRunning) {
             const parentOpts = parentObject.appObj._options;
             isAllowed = validateNavigationRules(uuid, url, parentObject.parentUuid, parentOpts);
         } else {


### PR DESCRIPTION
validates the navigation rules only when parent app is still running

:white_check_mark: Test Results:
[Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a3929256f202a5432b79f68)
[Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a3929a26f202a5432b79f69)