### PR TITLE
RUN-3452 check if globalShortcut was destroyed

### DIFF
--- a/index.js
+++ b/index.js
@@ -657,7 +657,9 @@ function registerShortcuts() {
     });
 
     const unhookShortcuts = (event, browserWindow) => {
-        globalShortcut.unregisterAll();
+        if (!globalShortcut.isDestroyed()) {
+            globalShortcut.unregisterAll();
+        }
     };
 
     app.on('browser-window-closed', unhookShortcuts);


### PR DESCRIPTION

check if globalShortcut was destroyed before calling unregisterAll

✅ Test Result:
[Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a3bef896f202a5432b79f82)

[Runtime PR](https://github.com/openfin/runtime/pull/780)