### PR TITLE
Revert back to an older version of the p2p package untill bugs are fixed.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "homepage": "https://github.com/openfin/openfin",
   "optionalDependencies": {
     "openfin-sign": "git+ssh://git@github.com:openfin/openfin-sign.git#caee55ecbe6f81e6ed9630790781fe4d1835cb03",
-    "runtime-p2p": "git+ssh://git@github.com:openfin/runtime-p2p.git#7426ace77dbe87b73a54181b46be0938c15d81ba"
+    "runtime-p2p": "git+ssh://git@github.com:openfin/runtime-p2p.git#ca7400b3e71fa73875a063bf22acd0531f1cc295"
   },
   "devDependencies": {
     "@types/minimist": "^1.2.0",


### PR DESCRIPTION
Newer version of runtime-p2p has a few issues, would not affect any feature in .27 but will need fixing for .28.

Test results:
[Win7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a3d56f36f202a5432b79f87)
[Win10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a3d577f6f202a5432b79f88)