### PR TITLE
RUN-3727 experimental application option

### DIFF
--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -236,11 +236,10 @@ module.exports = {
         newOptions.enableLargerThanScreen = true;
         newOptions['enable-plugins'] = true;
         newOptions.webPreferences = {
+            disableInitialReload: newOptions.experimental.disableInitialReload
             nodeIntegration: false,
             plugins: newOptions.plugins
         };
-
-        newOptions.webPreferences.disableInitialReload = newOptions.experimental.disableInitialReload;
 
         if (coreState.argo['disable-web-security'] || newOptions.webSecurity === false) {
             newOptions.webPreferences.webSecurity = false;

--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -236,7 +236,7 @@ module.exports = {
         newOptions.enableLargerThanScreen = true;
         newOptions['enable-plugins'] = true;
         newOptions.webPreferences = {
-            disableInitialReload: newOptions.experimental.disableInitialReload
+            disableInitialReload: newOptions.experimental.disableInitialReload,
             nodeIntegration: false,
             plugins: newOptions.plugins
         };

--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -240,10 +240,6 @@ module.exports = {
             plugins: newOptions.plugins
         };
 
-        // v2Api Fallback for incorrect spelling
-        let ex = newOptions.expiremental || { v2Api: false };
-        newOptions.experimental.v2Api = ex.v2Api || newOptions.experimental.v2Api;
-
         newOptions.webPreferences.disableInitialReload = newOptions.experimental.disableInitialReload;
 
         if (coreState.argo['disable-web-security'] || newOptions.webSecurity === false) {

--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -71,7 +71,8 @@ function five0BaseOptions() {
         'disableIabSecureLogging': false,
         'draggable': false,
         'exitOnClose': false,
-        'expiremental': {
+        'experimental': {
+            'disableInitialReload': false,
             'v2Api': false
         },
         'frame': true,
@@ -238,6 +239,12 @@ module.exports = {
             nodeIntegration: false,
             plugins: newOptions.plugins
         };
+
+        // v2Api Fallback for incorrect spelling
+        let ex = newOptions.expiremental || { v2Api: false };
+        newOptions.experimental.v2Api = ex.v2Api || false;
+
+        newOptions.webPreferences.disableInitialReload = newOptions.experimental.disableInitialReload;
 
         if (coreState.argo['disable-web-security'] || newOptions.webSecurity === false) {
             newOptions.webPreferences.webSecurity = false;

--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -242,7 +242,7 @@ module.exports = {
 
         // v2Api Fallback for incorrect spelling
         let ex = newOptions.expiremental || { v2Api: false };
-        newOptions.experimental.v2Api = ex.v2Api || false;
+        newOptions.experimental.v2Api = ex.v2Api || newOptions.experimental.v2Api;
 
         newOptions.webPreferences.disableInitialReload = newOptions.experimental.disableInitialReload;
 


### PR DESCRIPTION
experimental application option for shimming `--disable-init-reload` per app (process)

```
'experimental': {
  'disableInitialReload': false,
  'v2Api': false
},
```

Relates to https://github.com/openfin/runtime/pull/783

main.js already has the correct spelling
https://github.com/HadoukenIO/core/blob/develop/src/renderer/main.js#L48