### PR TITLE
RUN-3756 - Send all IAB subscriptions to core to get success ack & emit to IAB.add(un)SubscribeListener

### DIFF
--- a/src/browser/api/interappbus.js
+++ b/src/browser/api/interappbus.js
@@ -135,7 +135,7 @@ function dispatchToSubscriptions(topic, identity, destUuid, destName, payload, s
 }
 
 function emitSubscriberAdded(identity, payload) {
-    const senderUuid = payload.sourceUuid || '*';
+    const senderUuid = payload.sourceUuid || ANY_UUID;
 
     const eventingPayload = {
         senderUuid: senderUuid,
@@ -143,13 +143,13 @@ function emitSubscriberAdded(identity, payload) {
         uuid: identity.uuid,
         name: identity.name,
         topic: payload.topic,
-        directMsg: payload.sourceWindowName !== '*' ? payload.sourceWindowName : false
+        directMsg: payload.sourceWindowName !== ANY_NAME ? payload.sourceWindowName : false
     };
     busEventing.emit(ofEvents.subscriber.ADDED, eventingPayload);
 }
 
 function emitSubscriberRemoved(identity, payload) {
-    const senderUuid = payload.sourceUuid || '*';
+    const senderUuid = payload.sourceUuid || ANY_UUID;
 
     const eventingPayload = {
         senderUuid: senderUuid,
@@ -157,7 +157,7 @@ function emitSubscriberRemoved(identity, payload) {
         uuid: identity.uuid,
         name: identity.name,
         topic: payload.topic,
-        directMsg: payload.sourceWindowName !== '*' ? payload.sourceWindowName : false
+        directMsg: payload.sourceWindowName !== ANY_NAME ? payload.sourceWindowName : false
     };
     busEventing.emit(ofEvents.subscriber.REMOVED, eventingPayload);
 }

--- a/src/browser/api/interappbus.js
+++ b/src/browser/api/interappbus.js
@@ -191,7 +191,7 @@ function subscribe(identity, payload, listener) {
             ofBus.removeListener(keys.toWin, listener);
             ofBus.removeListener(keys.toApp, listener);
 
-            busEventing.emit(ofEvents.subscriber.REMOVED, eventingPayload);
+            emitSubscriberRemoved(identity, payload);
         }
     };
 
@@ -201,11 +201,11 @@ function subscribe(identity, payload, listener) {
 function unsubscribe(identity, cbId, senderUuid, ...rest) {
 
 
-    setTimeout(()=>{
-        throw new Error("tom wins"), 5
-    });
+    setTimeout(() => {
+        throw new Error('tom wins');
+    }, 5);
 
-    
+
     let {
         uuid,
         name

--- a/src/browser/api/interappbus.js
+++ b/src/browser/api/interappbus.js
@@ -199,7 +199,6 @@ function subscribe(identity, payload, listener) {
 }
 
 function unsubscribe(identity, cbId, senderUuid, ...rest) {
-
     let {
         uuid,
         name
@@ -224,7 +223,6 @@ function unsubscribe(identity, cbId, senderUuid, ...rest) {
     ofBus.removeListener(keys.toApp, callback);
 
     delete callbacks['' + cbId];
-
 
     busEventing.emit(ofEvents.subscriber.REMOVED, {
         senderUuid: senderUuid,

--- a/src/browser/api/interappbus.js
+++ b/src/browser/api/interappbus.js
@@ -200,12 +200,6 @@ function subscribe(identity, payload, listener) {
 
 function unsubscribe(identity, cbId, senderUuid, ...rest) {
 
-
-    setTimeout(() => {
-        throw new Error('tom wins');
-    }, 5);
-
-
     let {
         uuid,
         name

--- a/src/browser/api/interappbus.js
+++ b/src/browser/api/interappbus.js
@@ -135,9 +135,9 @@ function dispatchToSubscriptions(topic, identity, destUuid, destName, payload, s
 }
 
 function emitSubscriberAdded(identity, payload) {
-    let senderUuid = payload.sourceUuid || '*';
+    const senderUuid = payload.sourceUuid || '*';
 
-    let eventingPayload = {
+    const eventingPayload = {
         senderUuid: senderUuid,
         senderName: senderUuid,
         uuid: identity.uuid,
@@ -149,9 +149,9 @@ function emitSubscriberAdded(identity, payload) {
 }
 
 function emitSubscriberRemoved(identity, payload) {
-    let senderUuid = payload.sourceUuid || '*';
+    const senderUuid = payload.sourceUuid || '*';
 
-    let eventingPayload = {
+    const eventingPayload = {
         senderUuid: senderUuid,
         senderName: senderUuid,
         uuid: identity.uuid,

--- a/src/browser/api/interappbus.js
+++ b/src/browser/api/interappbus.js
@@ -175,11 +175,37 @@ function subscribe(identity, payload, listener) {
             busEventing.emit(ofEvents.subscriber.REMOVED, eventingPayload);
         }
     };
-    subscriptionManager.registerSubscription(unsubItem.unsubscribe, identity, payload);
 
     return unsubItem;
 }
 
+function emitSubscriberAdded(identity, payload) {
+    let senderUuid = payload.sourceUuid || '*';
+
+    let eventingPayload = {
+        senderUuid: senderUuid,
+        senderName: senderUuid,
+        uuid: identity.uuid,
+        name: identity.name,
+        topic: payload.topic,
+        directMsg: payload.sourceWindowName !== '*' ? payload.sourceWindowName : false
+    };
+    busEventing.emit(ofEvents.subscriber.ADDED, eventingPayload);
+}
+
+function emitSubscriberRemoved(identity, payload) {
+    let senderUuid = payload.sourceUuid || '*';
+
+    let eventingPayload = {
+        senderUuid: senderUuid,
+        senderName: senderUuid,
+        uuid: identity.uuid,
+        name: identity.name,
+        topic: payload.topic,
+        directMsg: payload.sourceWindowName !== '*' ? payload.sourceWindowName : false
+    };
+    busEventing.emit(ofEvents.subscriber.REMOVED, eventingPayload);
+}
 
 function unsubscribe(identity, cbId, senderUuid, ...rest) {
     let {
@@ -215,7 +241,6 @@ function unsubscribe(identity, cbId, senderUuid, ...rest) {
         topic: topic
     });
 }
-
 
 function subscriberAdded(identity, listener) {
     let {
@@ -362,7 +387,9 @@ module.exports.InterApplicationBus = {
     publish,
     send,
     subscribe,
+    emitSubscriberAdded,
     unsubscribe,
+    emitSubscriberRemoved,
     subscriberAdded,
     removeSubscriberAdded,
     subscriberRemoved,


### PR DESCRIPTION
[Javascript-Adapter PR](https://github.com/openfin/javascript-adapter/pull/379)

Per [RUN-3756](https://appoji.jira.com/browse/RUN-3756), was not getting any success callbacks on a 2nd IAB subscription to a given UUID (including wildcard) and topic. When fixing that, saw [this issue (RUN-3761)](https://appoji.jira.com/browse/RUN-3761) where we are also not getting the 2nd subscribe listener from IAB.addSubscribeListener so this fixes that as well since the fix for it would be a better fix than what I had for RUN-3756.  With this PR, we are letting the core handle multiple subscriptions to the same UUID & topic from a given subscriber, which allows the core to emit to any subscribe/unsubscribe listeners out there. 

[Win7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a5e61cdbd581266877d66cc)
[Win10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a5e6bf0bd581266877d66d3)

Update:
 testrunner tests: 
[subscribe - 2nd callback](https://testing-dashboard.openfin.co/#/app/tests/5a592646bd581266877d66b0/edit)
[unsubscribe - 1st callback of 2](https://testing-dashboard.openfin.co/#/app/tests/5a592648bd581266877d66b1/edit)
[addSubscribeListener - 1st/2nd subscription (get both)](https://testing-dashboard.openfin.co/#/app/tests/5a5e5c3abd581266877d66ca/edit)
[addUnsubscribeListener - 1st/2nd subscription (get both)](https://testing-dashboard.openfin.co/#/app/tests/5a5e5dcabd581266877d66cb/edit)