### PR TITLE
RUN-3690 moved renderer crash reporter launch to runtime

### DIFF
--- a/index.js
+++ b/index.js
@@ -396,12 +396,19 @@ function includeFlashPlugin() {
 }
 
 function initializeCrashReporter(argo) {
-    if (!isInDiagnosticsMode(argo)) {
+    if (!needsCrashReporter(argo)) {
         return;
     }
 
     const configUrl = argo['startup-url'] || argo['config'];
     const diagnosticMode = argo['diagnostics'] || false;
+    const sandboxDisabled = argo['sandbox'] === false; // means '--no-sandbox' flag exists
+
+    if (diagnosticMode && !sandboxDisabled) {
+        log.writeToLog('info', `'--no-sandbox' flag has been automatically added, ` +
+            `because the application is running in diagnostics mode and has '--diagnostics' flag specified`);
+        app.commandLine.appendSwitch('no-sandbox');
+    }
 
     crashReporter.startOFCrashReporter({ diagnosticMode, configUrl });
 }
@@ -506,7 +513,7 @@ function initServer() {
 //please see the discussion on https://github.com/openfin/runtime-core/pull/194
 function launchApp(argo, startExternalAdapterServer) {
 
-    if (isInDiagnosticsMode(argo)) {
+    if (needsCrashReporter(argo)) {
         log.setToVerbose();
     }
 
@@ -666,6 +673,6 @@ function registerShortcuts() {
     app.on('browser-window-blur', unhookShortcuts);
 }
 
-function isInDiagnosticsMode(argo) {
+function needsCrashReporter(argo) {
     return !!(argo['diagnostics'] || argo['enable-crash-reporting']);
 }

--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -550,9 +550,7 @@ exports.System = {
         const reporterOptions = Object.assign({ configUrl }, options);
 
         log.setToVerbose();
-        crashReporter.startOFCrashReporter(reporterOptions);
-
-        return crashReporter.crashReporterState();
+        return crashReporter.startOFCrashReporter(reporterOptions);
     },
     terminateExternalProcess: function(processUuid, timeout = 3000, child = false) {
         let status = ProcessTracker.terminate(processUuid, timeout, child);

--- a/src/browser/api_protocol/api_handlers/system.js
+++ b/src/browser/api_protocol/api_handlers/system.js
@@ -144,7 +144,7 @@ function SystemApiHandler() {
     function startCrashReporter(identity, message, ack) {
         const dataAck = _.clone(successAck);
         const { payload } = message;
-        dataAck.data = System.startCrashReporter(identity, payload, false);
+        dataAck.data = System.startCrashReporter(identity, payload);
         ack(dataAck);
     }
 

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -21,27 +21,12 @@ limitations under the License.
 
     const openfinVersion = process.versions.openfin;
     const processVersions = JSON.parse(JSON.stringify(process.versions));
-
     let renderFrameId = global.routingId;
     let customData = global.getFrameData(renderFrameId);
     let glbl = global;
-
     const electron = require('electron');
-
-    if (global.shouldStartCrashReporter) {
-        try {
-            const crashReporter = electron.crashReporter;
-            crashReporter.startOFCrashReporter({ configUrl: global.configUrl });
-        } catch (e) {
-            console.warn(e);
-            console.warn('For the crash reporter to connect successfully, please ensure' +
-                ' "--no-sandbox" is present in the app\'s config');
-        }
-    }
-
     const webFrame = electron.webFrame.createForRenderFrame(renderFrameId);
     const ipc = electron.ipcRenderer;
-
     let childWindowRequestId = 0;
     let windowId;
     let webContentsId = 0;

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -43,17 +43,10 @@ try {
 let me = fs.readFileSync(path.join(__dirname, 'api-decorator.js'), 'utf8');
 me = me.slice(13);
 
-const shouldStartCrashReporter = !!(coreState.argo['diagnostics'] || coreState.argo['enable-crash-reporting']);
-const configUrl = coreState.argo['startup-url'] || coreState.argo['config'];
-
-let addCrashFlag = ` global.shouldStartCrashReporter = ${shouldStartCrashReporter}; `;
-addCrashFlag += ` global.configUrl = '${configUrl}'; `;
-const removeCrashFlag = ` delete global.shouldStartCrashReporter; delete global.configUrl; `;
-
 module.exports.api = (windowId) => {
     const mainWindowOptions = coreState.getMainWindowOptions(windowId);
     const enableV2Api = ((mainWindowOptions || {}).experimental || {}).v2Api;
     const v2AdapterShim = (!enableV2Api ? '' : jsAdapterV2);
 
-    return `${addCrashFlag} ${me} ; ${jsAdapter}; ${v2AdapterShim} ; fin.__internal_.ipc = null; ${removeCrashFlag}`;
+    return `${me} ; ${jsAdapter}; ${v2AdapterShim} ; fin.__internal_.ipc = null;`;
 };


### PR DESCRIPTION
This PR [and its sibling PR](https://github.com/openfin/runtime/pull/804) move the launch of the renderer's crash reporter from core's api-decorator to the runtime.

**Test results**: [Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a675e583f32861e82b77c63), [Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a675f0f3f32861e82b77c64)