### PR TITLE
RUN-3672 Resizing a window in a group

### DIFF
--- a/src/browser/bounds_changed_state_tracker.js
+++ b/src/browser/bounds_changed_state_tracker.js
@@ -87,8 +87,8 @@ function BoundsChangedStateTracker(uuid, name, browserWindow) {
         // set the changed flag only if it has not been set
         sizeChanged = sizeChanged || (widthDiff || heightDiff);
         if (sizeChanged) {
-            xDiff = xDiff && (Math.abs(boundsOne.width - boundsTwo.width) !== Math.abs(boundsOne.x - boundsTwo.x));
-            yDiff = yDiff && (Math.abs(boundsOne.height - boundsTwo.height) !== Math.abs(boundsOne.y - boundsTwo.y));
+            xDiff = xDiff && (boundsOne.x - boundsTwo.x !== (boundsOne.x + boundsOne.width) - (boundsTwo.x + boundsTwo.width));
+            yDiff = yDiff && (boundsOne.y - boundsTwo.y !== (boundsOne.y + boundsOne.height) - (boundsTwo.y + boundsTwo.height));
         }
         positionChanged = positionChanged || (xDiff || yDiff);
 
@@ -227,7 +227,7 @@ function BoundsChangedStateTracker(uuid, name, browserWindow) {
                         if (changeType === 0 || changeType === 2) {
                             x = toSafeInt(x + delta.x, x);
                             y = toSafeInt(y + delta.y, y);
-                        // If it is a change in the size of the window, only move windows that are beyond the side being changed
+                            // If it is a change in the size of the window, only move windows that are beyond the side being changed
                         } else if (changeType === 1) {
                             if (boundsCompare.width) {
                                 if (delta.x && ((x + width) < cachedBounds.x)) {

--- a/src/browser/bounds_changed_state_tracker.js
+++ b/src/browser/bounds_changed_state_tracker.js
@@ -222,7 +222,7 @@ function BoundsChangedStateTracker(uuid, name, browserWindow) {
                         return win.name !== name;
                     }).forEach((win) => {
                         let { x, y, width, height } = win.browserWindow.getBounds();
-                        
+
                         // If it is a change in position (working correctly) or a change in position and size (not yet implemented)
                         if (changeType === 0 || changeType === 2) {
                             x = toSafeInt(x + delta.x, x);
@@ -246,7 +246,6 @@ function BoundsChangedStateTracker(uuid, name, browserWindow) {
                                 }
                             }
                         }
-
 
                         if (isWin32) {
                             let hwnd = parseInt(win.browserWindow.nativeId, 16);

--- a/src/browser/bounds_changed_state_tracker.js
+++ b/src/browser/bounds_changed_state_tracker.js
@@ -222,12 +222,12 @@ function BoundsChangedStateTracker(uuid, name, browserWindow) {
                         return win.name !== name;
                     }).forEach((win) => {
                         let { x, y, width, height } = win.browserWindow.getBounds();
-                        // if the bounds change is a change in the size of the window:
-
-
-                        if (changeType === 0) {
+                        
+                        // If it is a change in position (working correctly) or a change in position and size (not yet implemented)
+                        if (changeType === 0 || changeType === 2) {
                             x = toSafeInt(x + delta.x, x);
                             y = toSafeInt(y + delta.y, y);
+                        // If it is a change in the size of the window, only move windows that are beyond the side being changed
                         } else if (changeType === 1) {
                             if (boundsCompare.width) {
                                 if (delta.x && ((x + width) < cachedBounds.x)) {
@@ -245,10 +245,7 @@ function BoundsChangedStateTracker(uuid, name, browserWindow) {
                                     y = toSafeInt(y + delta.y2, y);
                                 }
                             }
-                        } // else if (changeType === 2) {
-                        //     let interimX = cachedBounds.x + delta.width;
-                        //     let interimY = cachedBounds.y + delta.height;
-                        // }
+                        }
 
 
                         if (isWin32) {


### PR DESCRIPTION
Per [this JIRA](https://appoji.jira.com/browse/RUN-3672), all windows in a group were changing position based on the top-left corner (top side or left side) resizing.  I.e. if window 2 was to the right of window 1 and a user made window 1 larger by clicking&dragging the top-left corner, window 2 would still move to the left.  This PR makes it so that only windows that are on the correct side are moved by resizing.  

There are still issues here but I think they are beyond the scope of this ticket.  If the window is simultaneously moved and changed in size the other windows in the group will not move correctly.  However, this cannot be done by the user (requires a setBounds API call) so developers can easily make this a 2-step process (moveby, then resizeby).  Also, if there are multiple rows this can result in some wonky behavior - but I think it is impossible to make it work perfectly for all situations.  Also - I don't think this logic will be used for snap-and-dock - which will likely be used instead of window groups.   I created a [ticket](https://appoji.jira.com/browse/RUN-3783) to think about behavior we want in various situations. 

[Test runner test](https://testing-dashboard.openfin.co/#/app/tests/5a68f1f63f32861e82b77c6e/edit)

Tests:
[Win7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a6a068f3f32861e82b77c7b)
[Win10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a6a07613f32861e82b77c7c)