### PR TITLE
RUN-3748 deeplinking parameters not passed

### DIFF
--- a/index.js
+++ b/index.js
@@ -534,7 +534,8 @@ function launchApp(argo, startExternalAdapterServer) {
         // this ensures that external connections that start the runtime can do so without a main window
         let successfulInitialLaunch = true;
 
-        if (startupAppOptions && (!isRunning || ofManifestUrl !== configUrl)) {
+        // comparing ofManifestUrl and configUrl shouldn't consider query strings. Otherwise, it will break deep linking
+        if (startupAppOptions && (!isRunning || ofManifestUrl.split('?')[0] !== configUrl.split('?')[0])) {
             //making sure that if a window is present we set the window name === to the uuid as per 5.0
             startupAppOptions.name = uuid;
             successfulInitialLaunch = initFirstApp(configObject, configUrl, licenseKey);

--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -557,7 +557,9 @@ function run(identity, mainWindowOpts, userAppConfigArgs) {
             // only resend if we've sent once before(meaning 1 window has shown)
             Application.emitHideSplashScreen(identity);
         }
-        Application.emitRunRequested(identity, userAppConfigArgs);
+        // need to call convert function to get updated args
+        mainWindowOpts.userAppConfigArgs = convertOpts.parseQueryString(userAppConfigArgs);
+        Application.emitRunRequested(identity, mainWindowOpts.userAppConfigArgs);
         return;
     }
 
@@ -846,13 +848,7 @@ Application.emitRunRequested = function(identity, userAppConfigArgs) {
     };
 
     if (userAppConfigArgs) {
-        let queryParams = userAppConfigArgs.split('&');
-        let args = {};
-        queryParams.forEach(function(param) {
-            let [key, value] = param.split('=');
-            args[key] = value;
-        });
-        data.userAppConfigArgs = args;
+        data.userAppConfigArgs = userAppConfigArgs;
     }
     if (uuid) {
         ofEvents.emit(route.application('run-requested', uuid), data);

--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -20,6 +20,7 @@ limitations under the License.
 // built-in modules
 let path = require('path');
 let electron = require('electron');
+let queryString = require('querystring');
 let BrowserWindow = electron.BrowserWindow;
 let electronApp = electron.app;
 let dialog = electron.dialog;
@@ -558,7 +559,7 @@ function run(identity, mainWindowOpts, userAppConfigArgs) {
             Application.emitHideSplashScreen(identity);
         }
         // need to call convert function to get updated args
-        mainWindowOpts.userAppConfigArgs = convertOpts.parseQueryString(userAppConfigArgs);
+        mainWindowOpts.userAppConfigArgs = queryString.parse(userAppConfigArgs);
         Application.emitRunRequested(identity, mainWindowOpts.userAppConfigArgs);
         return;
     }

--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -838,14 +838,24 @@ Application.emitHideSplashScreen = function(identity) {
 };
 
 Application.emitRunRequested = function(identity, userAppConfigArgs) {
-    var uuid = identity && identity.uuid;
-    if (uuid) {
-        ofEvents.emit(route.application('run-requested', uuid), {
-            topic: 'application',
-            type: 'run-requested',
-            uuid,
-            userAppConfigArgs
+    const uuid = identity && identity.uuid;
+    let data = {
+        topic: 'application',
+        type: 'run-requested',
+        uuid
+    };
+
+    if (userAppConfigArgs) {
+        let queryParams = userAppConfigArgs.split('&');
+        let args = {};
+        queryParams.forEach(function(param) {
+            let [key, value] = param.split('=');
+            args[key] = value;
         });
+        data.userAppConfigArgs = args;
+    }
+    if (uuid) {
+        ofEvents.emit(route.application('run-requested', uuid), data);
     }
 };
 

--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -841,17 +841,13 @@ Application.emitHideSplashScreen = function(identity) {
 
 Application.emitRunRequested = function(identity, userAppConfigArgs) {
     const uuid = identity && identity.uuid;
-    let data = {
-        topic: 'application',
-        type: 'run-requested',
-        uuid
-    };
-
-    if (userAppConfigArgs) {
-        data.userAppConfigArgs = userAppConfigArgs;
-    }
     if (uuid) {
-        ofEvents.emit(route.application('run-requested', uuid), data);
+        ofEvents.emit(route.application('run-requested', uuid), {
+            topic: 'application',
+            type: 'run-requested',
+            uuid,
+            userAppConfigArgs
+        });
     }
 };
 

--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -558,9 +558,8 @@ function run(identity, mainWindowOpts, userAppConfigArgs) {
             // only resend if we've sent once before(meaning 1 window has shown)
             Application.emitHideSplashScreen(identity);
         }
-        // need to call convert function to get updated args
-        mainWindowOpts.userAppConfigArgs = queryString.parse(userAppConfigArgs);
-        Application.emitRunRequested(identity, mainWindowOpts.userAppConfigArgs);
+
+        Application.emitRunRequested(identity, queryString.parse(userAppConfigArgs));
         return;
     }
 

--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -20,6 +20,7 @@ limitations under the License.
 // built-in modules
 let fs = require('fs');
 let path = require('path');
+let queryString = require('querystring');
 
 // npm modules
 let _ = require('underscore');
@@ -242,7 +243,7 @@ module.exports = {
         }
 
         if (coreState.argo['user-app-config-args']) {
-            newOptions.userAppConfigArgs = this.parseQueryString(coreState.argo['user-app-config-args']);
+            newOptions.userAppConfigArgs = queryString.parse(coreState.argo['user-app-config-args']);
         }
 
         if (options.message !== undefined) {
@@ -341,16 +342,6 @@ module.exports = {
                 configUrl
             });
         }, errorCallback);
-    },
-
-    parseQueryString: function(queryString) {
-        let queryParams = queryString.split('&');
-        let args = {};
-        queryParams.forEach(function(param) {
-            let [key, value] = param.split('=');
-            args[decodeURIComponent(key)] = decodeURIComponent(value);
-        });
-        return args;
     }
 };
 

--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -242,7 +242,7 @@ module.exports = {
         }
 
         if (coreState.argo['user-app-config-args']) {
-            newOptions.userAppConfigArgs = coreState.argo['user-app-config-args'];
+            newOptions.userAppConfigArgs = this.parseQueryString(coreState.argo['user-app-config-args']);
         }
 
         if (options.message !== undefined) {
@@ -341,8 +341,17 @@ module.exports = {
                 configUrl
             });
         }, errorCallback);
-    }
+    },
 
+    parseQueryString: function(queryString) {
+        let queryParams = queryString.split('&');
+        let args = {};
+        queryParams.forEach(function(param) {
+            let [key, value] = param.split('=');
+            args[decodeURIComponent(key)] = decodeURIComponent(value);
+        });
+        return args;
+    }
 };
 
 function normalizePreload(preload) {

--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -241,6 +241,10 @@ module.exports = {
             newOptions.webPreferences.webSecurity = false;
         }
 
+        if (coreState.argo['user-app-config-args']) {
+            newOptions.userAppConfigArgs = coreState.argo['user-app-config-args'];
+        }
+
         if (options.message !== undefined) {
             newOptions.message = options.message;
         }

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -432,7 +432,18 @@ limitations under the License.
         if (getOpenerSuccessCallbackCalled() || window.opener === null || initialOptions.rawWindowOpen) {
             deferByTick(() => {
                 pendingMainCallbacks.forEach((callback) => {
-                    callback();
+                    const userAppConfigArgs = initialOptions.userAppConfigArgs;
+                    if (userAppConfigArgs) { // handle deep linking callback
+                        const queryParams = userAppConfigArgs.split('&');
+                        let args = {};
+                        queryParams.forEach(function(param) {
+                            let [key, value] = param.split('=');
+                            args[key] = value;
+                        });
+                        callback(args);
+                    } else {
+                        callback();
+                    }
                 });
             });
         }

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -434,13 +434,7 @@ limitations under the License.
                 pendingMainCallbacks.forEach((callback) => {
                     const userAppConfigArgs = initialOptions.userAppConfigArgs;
                     if (userAppConfigArgs) { // handle deep linking callback
-                        const queryParams = userAppConfigArgs.split('&');
-                        let args = {};
-                        queryParams.forEach(function(param) {
-                            let [key, value] = param.split('=');
-                            args[key] = value;
-                        });
-                        callback(args);
+                        callback(userAppConfigArgs);
                     } else {
                         callback();
                     }


### PR DESCRIPTION
This PR is fixing below two issues:

1. When launched for the first time, the application is not receiving the deep linking parameters.

2. Second launch and beyond, which triggers the run-requested method, do receive the arguments. However, they are only received as one string in the event.userAppConfigArgs key. The design docs states it should be able to use event.userAppConfigArgs.parameterName.

Test results: [Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a6f73e33f32861e82b77cb4) [Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a6f74c33f32861e82b77cb5)

Currently there are no auto tests specifically for deep linking. It requires a manual test.