### PR TITLE
RUN 3772 queue up console.* messages from the app and send them to the RVM

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -851,6 +851,7 @@ Window.create = function(id, opts) {
             const appConfigUrl = coreState.getConfigUrlByUuid(identity.uuid);
             if (!appConfigUrl) {
                 electronApp.vlog(2, `Error: could not get manifest url for app with uuid: ${identity.uuid}`);
+                return;
             }
 
             function checkPrependLeadingZero(num) {

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -839,6 +839,17 @@ Window.create = function(id, opts) {
     winObj.plugins = JSON.parse(JSON.stringify(plugins || []));
 
     const prepareConsoleMessageForRVM = (event, level, message, lineNo, sourceId) => {
+        const app = coreState.getAppByUuid(identity.uuid);
+        if (!app) {
+            electronApp.vlog(2, `Error: could not get app object for app with uuid: ${identity.uuid}`);
+            return;
+        }
+
+        // If enableAppLogging not set or false, skip sending to RVM
+        if (!app._options || !app._options.enableAppLogging) {
+            return;
+        }
+
         // Hack: since this function is getting called from the native side with
         // "webContents.on", there is weirdness where the "setTimeout(flushConsoleMessageQueue...)"
         // in addConsoleMessageToRVMMessageQueue would only get called the first time, and not subsequent times,
@@ -846,8 +857,6 @@ Window.create = function(id, opts) {
         // wrap this entire function in a "setTimeout" to put it in a different context. Eventually we should figure
         // out if there is a way around this by using event.preventDefault or something similar
         setTimeout(() => {
-            electronApp.vlog(1, `CONSOLE-MESSAGE`);
-
             const appConfigUrl = coreState.getConfigUrlByUuid(identity.uuid);
             if (!appConfigUrl) {
                 electronApp.vlog(2, `Error: could not get manifest url for app with uuid: ${identity.uuid}`);

--- a/src/browser/rvm/rvm_message_bus.ts
+++ b/src/browser/rvm/rvm_message_bus.ts
@@ -33,13 +33,6 @@ type relaunchOnCloseAction = 'relaunch-on-close';
 type getDesktopOwnerSettingsAction = 'get-desktop-owner-settings';
 type downloadRuntimeAction = 'runtime-download';
 
-export interface ConsoleMessage {
-    level: number;
-    message: string;
-    appConfigUrl: string;
-    timeStamp: string;
-}
-
 export interface ApplicationLog extends RvmMsgBase {
     topic: applicationTopic;
     action: applicationLogAction;
@@ -48,6 +41,13 @@ export interface ApplicationLog extends RvmMsgBase {
     payload: {
         messages: ConsoleMessage[];
     };
+}
+
+export interface ConsoleMessage {
+    level: number;
+    message: string;
+    appConfigUrl: string;
+    timeStamp: string;
 }
 
 export interface RegisterUser extends RvmMsgBase {

--- a/src/browser/rvm/rvm_message_bus.ts
+++ b/src/browser/rvm/rvm_message_bus.ts
@@ -26,11 +26,29 @@ export interface RvmMsgBase {
 
 // topic: application -----
 type applicationTopic = 'application';
+type applicationLogAction = 'application-log';
 type registerUserAction = 'register-user';
 type hideSplashscreenAction = 'hide-splashscreen';
 type relaunchOnCloseAction = 'relaunch-on-close';
 type getDesktopOwnerSettingsAction = 'get-desktop-owner-settings';
 type downloadRuntimeAction = 'runtime-download';
+
+export interface ConsoleMessage {
+    level: number;
+    message: string;
+    appConfigUrl: string;
+    timeStamp: string;
+}
+
+export interface ApplicationLog extends RvmMsgBase {
+    topic: applicationTopic;
+    action: applicationLogAction;
+    sourceUrl: string;
+    runtimeVersion: string;
+    payload: {
+        messages: ConsoleMessage[];
+    };
+}
 
 export interface RegisterUser extends RvmMsgBase {
     topic: applicationTopic;

--- a/src/browser/rvm/rvm_message_bus.ts
+++ b/src/browser/rvm/rvm_message_bus.ts
@@ -44,9 +44,9 @@ export interface ApplicationLog extends RvmMsgBase {
 }
 
 export interface ConsoleMessage {
+    appConfigUrl: string;
     level: number;
     message: string;
-    appConfigUrl: string;
     timeStamp: string;
 }
 

--- a/src/browser/rvm/utils.ts
+++ b/src/browser/rvm/utils.ts
@@ -7,6 +7,7 @@ Please contact OpenFin Inc. at sales@openfin.co to obtain a Commercial License.
 import { rvmMessageBus, ConsoleMessage } from '../rvm/rvm_message_bus';
 import { System } from '../api/system';
 import { setTimeout } from 'timers';
+
 /**
  * Interface for [sendToRVM] method
  */
@@ -22,7 +23,8 @@ interface SendToRVMOpts {
 let consoleMessageQueue: ConsoleMessage[] = [];
 let isFlushScheduled: boolean = false;
 
-function flushConsoleMessageQueue() {
+function flushConsoleMessageQueue(): void {
+    isFlushScheduled = false;
     if (consoleMessageQueue.length <= 0) {
         return;
     }
@@ -39,7 +41,6 @@ function flushConsoleMessageQueue() {
 
     consoleMessageQueue = [];
     sendToRVM(obj);
-    isFlushScheduled = false;
 }
 
 export function addConsoleMessageToRVMMessageQueue(message: ConsoleMessage): void {
@@ -47,9 +48,8 @@ export function addConsoleMessageToRVMMessageQueue(message: ConsoleMessage): voi
 
     // If no timer already set, set one to flush the queue in 10s
     if (!isFlushScheduled) {
-        setTimeout(flushConsoleMessageQueue, 10000);
-
         isFlushScheduled = true;
+        setTimeout(flushConsoleMessageQueue, 10000);
     }
 }
 

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -188,6 +188,7 @@ export interface WindowOptions {
     description?: string;
     disableIabSecureLogging?: boolean;
     draggable?: boolean;
+    enableAppLogging?: boolean;
     'enable-plugins'?: boolean;
     enableLargerThanScreen?: boolean;
     exitOnClose?: boolean;


### PR DESCRIPTION
[JIRA](https://appoji.jira.com/browse/RUN-3772)

As part of log management, we want to send console.log, console.info, console.error, etc. messages from the core to the RVM, and the RVM will write them to separate files (to avoid writing logs from every application to the same debug.log). Sending a message from the core to the RVM on every console log is too hard on the browser process (and sends a lot of messages to the RVM), so instead we store all the messages in a queue. Every time a message is pushed to an empty queue, we set a timer to flush it in 10s.

Tests:
[Win7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a7487ad3f32861e82b77d08)
[Win10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a74881c3f32861e82b77d09)
