### PR TITLE
RUN-3782 unsubscribe blocking events when renderer crashes

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -588,6 +588,14 @@ Window.create = function(id, opts) {
             emitToAppAndWin('crashed', {
                 reason: terminationStatus
             });
+
+            // When the renderer crashes, remove blocking event listeners.
+            // Removing 'close-requested' listeners will allow the crashed window to be closed manually easily.
+            const closeRequested = route.window('close-requested', uuid, name);
+            ofEvents.removeAllListeners(closeRequested);
+            // Removing 'show-requested' listeners will allow the crashed window to be shown so it can be closed.
+            const showRequested = route.window('show-requested', uuid, name);
+            ofEvents.removeAllListeners(showRequested);
         });
 
         browserWindow.on('responsive', () => {


### PR DESCRIPTION
**About**
When a renderer crashes, while being subscribed to its own `"close-requested"` and `"show-requested"` events, it will prevent the core from shutting down.
This PRs unsubscribes listeners for these events on renderer crashes

**New tests**:
• [Window.addEventListener (close-requested) (renderer crash)](https://testing-dashboard.openfin.co/#/app/tests/5a81dfb883591b524677a774/edit)
• [Window.addEventListener (show-requested) (renderer crash)](https://testing-dashboard.openfin.co/#/app/tests/5a81e1c883591b524677a775/edit)

**Test results**
&#10003; [Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a81e8856a994a57faa5c894)
&#10003; [Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a81e9076a994a57faa5c896)