### PR TITLE
RUN-3829 fix getVersion for node-less

### DIFF
--- a/src/renderer/node-less.js
+++ b/src/renderer/node-less.js
@@ -35,6 +35,7 @@ const susbcribeForTeardown = (routingId, handlers = []) => {
 // OpenFin: these values are used in lib/common/api/crash-reporter.js
 process.versions = process.versions || {};
 process.versions.combinedId = electron.remote.app.getCombinedId();
+process.versions.openfin = electron.remote.app.getRuntimeVersion();
 process.versions.mainFrameRoutingId = electron.ipcRenderer.getFrameRoutingID();
 process.versions.cachePath = electron.remote.app.getPath('userData');
 


### PR DESCRIPTION
[W10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a85fd536a994a57faa5c900)
[W7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a85fc686a994a57faa5c8f[f)

[Runtime](https://github.com/openfin/runtime/pull/838)
