### PR TITLE
RUN-3866: sync issue with cachedFetch

### DIFF
--- a/src/browser/cached_resource_fetcher.ts
+++ b/src/browser/cached_resource_fetcher.ts
@@ -103,6 +103,7 @@ function makeDirectory(location: string) {
     return new Promise((resolve, reject) => {
         mkdir(location, (err: null | Error) => {
             if (err) {
+                app.vlog(1, `cachedFetch makeDirectory error, check EEXIST ${err.message}`);
                 // EEXIST not an error
                 pathExists(location).then(value => value ? resolve() : reject(err))
                     .catch(() => {
@@ -116,8 +117,6 @@ function makeDirectory(location: string) {
     });
 }
 
-let makingCacheDir = false;
-let makingAppDir = false;
 
 async function prepDownloadLocation(appCacheDir: string) {
     const appCacheDirExists = await pathExists(appCacheDir);
@@ -129,16 +128,13 @@ async function prepDownloadLocation(appCacheDir: string) {
     const rootCachePath = getRootCachePath();
     const cacheRootPathExists = await pathExists(rootCachePath);
 
-    if (!cacheRootPathExists && !makingCacheDir) {
-        makingCacheDir = true;
+    if (!cacheRootPathExists) {
         await makeDirectory(rootCachePath);
-        makingCacheDir = false;
     }
 
-    if (!makingAppDir) {
-        makingAppDir = true;
+    const cacheAppPathExists = await pathExists(appCacheDir);
+    if (!cacheAppPathExists) {
         await makeDirectory(appCacheDir);
-        makingAppDir = false;
     }
 
     return;


### PR DESCRIPTION
The issue is with global makingCacheDir and makingAppDir.  If one request sets it to true, another request may come in before makeDirectory returns.  

makeDirectory checks for EEXIST already, so removing makingCacheDir and makingAppDir.

To test check for EEXIST, just add same URL as preload scripts multiple times.

[W10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a945c926a994a57faa5c97b)
[W7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a945baf6a994a57faa5c97a)

[New Test](https://testing-dashboard.openfin.co/#/app/tests/5a9593ff6a994a57faa5c985/edit)