### PR TITLE
RUN-3848 added a flag for future async plugins loading

### DIFF
--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -40,9 +40,10 @@ limitations under the License.
     let windowId;
     let webContentsId = 0;
 
-    const initialOptions = glbl.__startOptions.options;
-    const entityInfo = glbl.__startOptions.entityInfo;
     const elIPCConfig = glbl.__startOptions.elIPCConfig;
+    const entityInfo = glbl.__startOptions.entityInfo;
+    const initialOptions = glbl.__startOptions.options;
+    const runtimeArguments = glbl.__startOptions.runtimeArguments;
     const socketServerState = glbl.__startOptions.socketServerState;
 
     let getOpenerSuccessCallbackCalled = () => {
@@ -444,7 +445,10 @@ limitations under the License.
         const { uuid, name } = initialOptions;
 
         if (!isNotificationType(name)) {
-            evalPlugins(uuid, name);
+            if (!runtimeArguments.includes('--async-plugins')) {
+                // Synchronous (old) implementation of plugin loading
+                evalPlugins(uuid, name);
+            }
             evalPreloadScripts(uuid, name);
         }
     });

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -434,7 +434,8 @@ limitations under the License.
             openerSuccessCBCalled: openerSuccessCBCalled,
             emitNoteProxyReady: emitNoteProxyReady,
             initialOptions,
-            entityInfo
+            entityInfo,
+            runtimeArguments
         }
     };
 

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -48,7 +48,14 @@ module.exports.api = (windowId) => {
     const mainWindowOptions = windowOptionSet.options || {};
     const enableV2Api = (mainWindowOptions.experimental || {}).v2Api;
     const v2AdapterShim = (!enableV2Api ? '' : jsAdapterV2);
-    const optionsString = JSON.stringify(windowOptionSet);
 
-    return `global.__startOptions = ${optionsString}; ${me} ; ${jsAdapter}; ${v2AdapterShim} ; fin.__internal_.ipc = null;`;
+    windowOptionSet.runtimeArguments = JSON.stringify(coreState.args);
+
+    return [
+        `global.__startOptions = ${JSON.stringify(windowOptionSet)}`,
+        me,
+        jsAdapter,
+        v2AdapterShim,
+        `fin.__internal_.ipc = null`
+    ].join(';');
 };


### PR DESCRIPTION
### Async Plugins
This is ***one of the few steps*** of async plugins implementation.
Small changes for easier code review & consumption.

**About**
Adding the new runtime argument `--async-plugins` behind which the rest of the new functionality will hide. Without this new flag, plugins will function the old synchronous way, like preload scripts.

**Test results**
✅ [Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a945e596a994a57faa5c97c)
✅ [Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a945f596a994a57faa5c97d)