### PR TITLE
RUN-3883 single plugin retrieval

### DIFF
--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -703,6 +703,10 @@ exports.System = {
         return downloadScripts(identity, preloadScripts);
     },
 
+    getPluginModule: function(identity, plugin) {
+        return plugins.getModule(identity, plugin);
+    },
+
     getPluginModules: function(identity) {
         return plugins.getModules(identity);
     },

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -1279,6 +1279,12 @@ Window.setWindowPluginState = function(identity, payload) {
     // Single plugin state change
     if (!allDone) {
         plugins = plugins.filter(e => e.name === pluginName && e.version === version);
+
+        // If plugin not found / invalid plugin specified, then exit early
+        if (!plugins.length) {
+            return;
+        }
+
         plugins[0].state = state;
     }
 

--- a/src/browser/api_protocol/api_handlers/system.js
+++ b/src/browser/api_protocol/api_handlers/system.js
@@ -79,6 +79,7 @@ function SystemApiHandler() {
         'get-proxy-settings': getProxySettings,
         'get-remote-config': { apiFunc: getRemoteConfig, apiPath: '.getRemoteConfig' },
         'get-rvm-info': getRvmInfo,
+        'get-plugin-module': getPluginModule,
         'get-plugin-modules': getPluginModules,
         'get-preload-scripts': getPreloadScripts,
         'get-version': getVersion,
@@ -537,6 +538,18 @@ function SystemApiHandler() {
             .then((preloadScripts) => {
                 const dataAck = _.clone(successAck);
                 dataAck.data = preloadScripts;
+                ack(dataAck);
+            })
+            .catch(nack);
+    }
+
+    function getPluginModule(identity, message, ack, nack) {
+        const { payload: { plugin } } = message;
+
+        System.getPluginModule(identity, plugin)
+            .then((pluginModule) => {
+                const dataAck = _.clone(successAck);
+                dataAck.data = pluginModule;
                 ack(dataAck);
             })
             .catch(nack);

--- a/src/browser/plugins.ts
+++ b/src/browser/plugins.ts
@@ -41,14 +41,18 @@ const pluginPaths: Map<string, string> = new Map();
 export async function getModules(identity: Identity): Promise<PluginWithContent[]> {
     const { url, manifest } = getManifest(identity);
     const { plugins = [] } = manifest || {};
-    const promises = plugins.map((plugin: Plugin) => getModule(identity, url, plugin));
+    const promises = plugins.map((plugin: Plugin) => getModule(identity, plugin, url));
     return await Promise.all(promises);
 }
 
 /**
  * Gets a single plugin module
  */
-async function getModule(identity: Identity, sourceUrl: string, plugin: Plugin): Promise<PluginWithContent> {
+export async function getModule(identity: Identity, plugin: Plugin, sourceUrl?: string): Promise<PluginWithContent> {
+    if (!sourceUrl) {
+        sourceUrl = getManifest(identity).url;
+    }
+
     const id = `${plugin.name}: ${plugin.version}`;
     let pluginPath;
 


### PR DESCRIPTION
### Async Plugins
This is ***one of the few steps*** of async plugins implementation.
Small changes for easier code review & consumption.

**About**
This PR adds ability to retrieve one specific plugin at a time, on-demand and without evaluating it.

**Test results**
✅ [Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a95b6a66a994a57faa5c98a)
✅ [Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a95b7816a994a57faa5c98b)