### PR TITLE
RUN-3837 Added no asar search paths to js-adapter, exposed grunt task as as npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ openfin --config app.json --launch
 
 * Replace the OpenFin core with a built Hadouken core
 ```bash
-grunt deploy --target=C:\Users\[username]\AppData\Local\OpenFin\runtime\[replace this with a version]\OpenFin\resources
+npm run deploy -- --target=C:\Users\[username]\AppData\Local\OpenFin\runtime\[replace this with a version]\OpenFin\resources
 ```
 
 * Now you can re-launch the OpenFin runtime with the modified Hadouken core.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "pretest": "grunt babel && grunt ts",
     "test": "grunt test",
-    "postinstall": "grunt"
+    "postinstall": "grunt",
+    "deploy": "grunt deploy",
+    "build": "grunt"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "The core app of the OpenFin Runtime 8",
   "main": "index.js",
   "scripts": {
-    "pretest": "grunt babel && grunt ts",
-    "test": "grunt test",
-    "postinstall": "grunt",
+    "build": "grunt",
     "deploy": "grunt deploy",
-    "build": "grunt"
+    "postinstall": "grunt",
+    "pretest": "grunt babel && grunt ts",
+    "test": "grunt test"
   },
   "repository": {
     "type": "git",

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -19,25 +19,30 @@ let fs = require('fs');
 let path = require('path');
 const coreState = require('../browser/core_state.js');
 
+function readAdapterFromSearchPaths(searchPaths, packageFile) {
+    let adapter = '';
+    for (let adapterPath of searchPaths) {
+        try {
+            adapter = fs.readFileSync(path.join(process.resourcesPath, adapterPath, packageFile), 'utf8');
+            break;
+        } catch (error) {
+            continue;
+        }
+    }
+    return adapter;
+}
+
 // check resources/adapter/openfin-desktop.js then
 // resources/adapter.asar/openfin-desktop.js
 // for ease of developement
-let jsAdapter = '';
 const searchPaths = ['adapter', 'adapter.asar'];
-for (let adapterPath of searchPaths) {
-    try {
-        jsAdapter = fs.readFileSync(path.join(process.resourcesPath, adapterPath, 'openfin-desktop.js'), 'utf8');
-        break;
-    } catch (error) {
-        continue;
-    }
-}
+const jsAdapter = readAdapterFromSearchPaths(searchPaths, 'openfin-desktop.js');
 
-let jsAdapterV2 = '';
-try {
-    const jsAdapterV2Path = path.join(process.resourcesPath, 'js-adapter.asar', 'js-adapter.js');
-    jsAdapterV2 = fs.readFileSync(jsAdapterV2Path, 'utf8');
-} catch (error) {}
+// check resources/js-adapter/js-adapter.js then
+// resources/js-adapter.asar/openfin-desktop.js
+// for ease of developement
+const searchPathsV2Api = ['js-adapter', 'js-adapter.asar'];
+const jsAdapterV2 = readAdapterFromSearchPaths(searchPathsV2Api, 'js-adapter.js');
 
 // Remove strict (Prevents, as of now, poorly understood memory lifetime scoping issues with remote module)
 let me = fs.readFileSync(path.join(__dirname, 'api-decorator.js'), 'utf8');


### PR DESCRIPTION
v2 adapter now is acquired the same way the v1 adapter is acquired.

Additionally exposed deploy and build tasks as npm scripts so they can be launched without a global grunt install. 

Test results:
[Win 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a95d8d76a994a57faa5c992)
[Win 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a95d9c36a994a57faa5c993)