### PR TITLE
RUN-3839 Removed the usage of the browser side API to generate GUIDs, replaced it with the render side getGUID API

### DIFF
--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -109,10 +109,6 @@ limitations under the License.
         return socketServerState;
     }
 
-    function generateGuidSync() {
-        return syncApiCall('generate-guid');
-    }
-
     function convertOptionsToElectronSync(options) {
         return syncApiCall('convert-options', options);
     }
@@ -321,7 +317,7 @@ limitations under the License.
         let requestId = ++childWindowRequestId;
         // initialize what's needed to create a child window via window.open
         let url = ((options || {}).url || undefined);
-        let uniqueKey = generateGuidSync();
+        let uniqueKey = fin.desktop.getUuid();
         let frameName = `openfin-child-window-${uniqueKey}`; //((options || {}).frameName || undefined);
         let features = ((options || {}).features || undefined);
         let webContentsId = getWebContentsId();
@@ -416,7 +412,7 @@ limitations under the License.
                     onContentReady(window, cb);
                 }
             },
-            getUuid: generateGuidSync,
+            getUuid: process.getGUID,
             getVersion: () => {
                 return openfinVersion;
             }


### PR DESCRIPTION
Consumed by the adapters new and old. 

### Tests:
[Win 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a9713016a994a57faa5c99a)
[Win 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a97154f6a994a57faa5c99b)