### PR TITLE
RUN-3901: Feature/nodeless opener success callback called

### DIFF
--- a/src/renderer/node-less.js
+++ b/src/renderer/node-less.js
@@ -45,7 +45,6 @@ process.versions.cachePath = electron.remote.app.getPath('userData');
 const mainWindowId = electron.remote.getCurrentWindow(process.versions.mainFrameRoutingId).id;
 const apiDecoratorAsString = electron.remote.require('./src/renderer/main').api(mainWindowId);
 
-let perFrameData = {};
 // let chromiumWindowAlertEnabled = electron.remote.app.getCommandLineArguments().includes('--enable-chromium-window-alert');
 
 const hookWebFrame = (webFrame, renderFrameId) => {
@@ -98,10 +97,7 @@ const registerAPI = (w, routingId, isMainFrame) => {
         // Mock as a Node/Electron environment
         // ===================================
         // let global = w;
-        w.getFrameData = (routingId) => {
-            perFrameData[routingId] = perFrameData[routingId] || {};
-            return perFrameData[routingId];
-        };
+        w.getFrameData = process.getFrameData;
 
         w.require = require;
         // w.debugMessages.push('w.require = require;');

--- a/src/renderer/node-less.js
+++ b/src/renderer/node-less.js
@@ -48,7 +48,6 @@ const apiDecoratorAsString = electron.remote.require('./src/renderer/main').api(
 // let chromiumWindowAlertEnabled = electron.remote.app.getCommandLineArguments().includes('--enable-chromium-window-alert');
 
 const hookWebFrame = (webFrame, renderFrameId) => {
-    console.log('hookWebFrame');
     electron.ipcRenderer.on(`ELECTRON_INTERNAL_RENDERER_WEB_FRAME_METHOD-${renderFrameId}`, (event, method, args) => {
         webFrame[method](...args);
     });


### PR DESCRIPTION
Tests:

[W10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a9daba76a994a57faa5c9dc)
[W7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5a9daad66a994a57faa5c9db)

[Runtime](https://github.com/openfin/runtime/pull/864)