### PR TITLE
RUN-3819 killed running false

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -594,6 +594,16 @@ Window.create = function(id, opts) {
             // Removing 'show-requested' listeners will allow the crashed window to be shown so it can be closed.
             const showRequested = route.window('show-requested', uuid, name);
             ofEvents.removeAllListeners(showRequested);
+
+            const closeMessage = `Window ${uuid}/${name} crashed and was force closed`;
+            const closeFailMessage = `Window ${uuid}/${name} crashed and was not able to be cleaned up`;
+
+            try {
+                Window.close({ uuid, name }, true, () => log.writeToLog('info', closeMessage));
+            } catch (e) {
+                log.writeToLog('info', closeFailMessage);
+                log.writeToLog('info', e);
+            }
         });
 
         browserWindow.on('responsive', () => {

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -567,9 +567,8 @@ Window.create = function(id, opts) {
             }
         });
 
+        const isMainWindow = (uuid === name);
         const emitToAppAndWin = (type, payload) => {
-            let isMainWindow = (uuid === name);
-
             // Window crashed: inform Window "namespace"
             ofEvents.emit(route.window(type, uuid, name), Object.assign({ topic: 'window', type, uuid, name }, payload));
 
@@ -591,11 +590,14 @@ Window.create = function(id, opts) {
             // Removing 'close-requested' listeners will allow the crashed window to be closed manually easily.
             const closeRequested = route.window('close-requested', uuid, name);
             ofEvents.removeAllListeners(closeRequested);
+
             // Removing 'show-requested' listeners will allow the crashed window to be shown so it can be closed.
             const showRequested = route.window('show-requested', uuid, name);
             ofEvents.removeAllListeners(showRequested);
 
-            coreState.setAppRunningState(uuid, false);
+            if (isMainWindow) {
+                coreState.setAppRunningState(uuid, false);
+            }
         });
 
         browserWindow.on('responsive', () => {

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -595,15 +595,7 @@ Window.create = function(id, opts) {
             const showRequested = route.window('show-requested', uuid, name);
             ofEvents.removeAllListeners(showRequested);
 
-            const closeMessage = `Window ${uuid}/${name} crashed and was force closed`;
-            const closeFailMessage = `Window ${uuid}/${name} crashed and was not able to be cleaned up`;
-
-            try {
-                Window.close({ uuid, name }, true, () => log.writeToLog('info', closeMessage));
-            } catch (e) {
-                log.writeToLog('info', closeFailMessage);
-                log.writeToLog('info', e);
-            }
+            coreState.setAppRunningState(uuid, false);
         });
 
         browserWindow.on('responsive', () => {


### PR DESCRIPTION
When an application crashes (main window, so not x-orig child) set the running state of the app as false

[tests well](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5aa2b3496a994a57faa5ca4f)
[test added](https://testing-dashboard.openfin.co/#/app/tests/5aa180f26a994a57faa5ca38/)