### PR TITLE
RUN-3812 - Services Core - add name to Ack key

### DIFF
--- a/src/browser/api_protocol/api_handlers/service_middleware.ts
+++ b/src/browser/api_protocol/api_handlers/service_middleware.ts
@@ -35,7 +35,7 @@ const remoteAckMap: Map<string, RemoteAck> = new Map();
 const pendingServiceConnections: Map<string, MessagePackage[]> = new Map();
 
 function getAckKey(id: number, identity: Identity): string {
-    return `${ id }-${ identity.uuid }`;
+    return `${ id }-${ identity.uuid }-${ identity.name }`;
 }
 
 function waitForServiceRegistration(uuid: string, msg: MessagePackage): void {


### PR DESCRIPTION
Bug fix to add name to ack key so that child windows don't overwrite each other's messages (OK for name to be undefined)