### PR TITLE
RUN-3880 move the sync ready events from renderer to browser process

### DIFF
--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -642,6 +642,14 @@ exports.System = {
     raiseEvent: function(eventName, eventArgs) {
         return ofEvents.emit(eventName, eventArgs);
     },
+    // eventsIter is an Array or other iterable object (such as a Map or Set)
+    // whose elements are [key, value] pairs when iterated over
+    raiseManyEvents: function(eventsIter) {
+
+        for (let [eventName, args] of eventsIter) {
+            ofEvents.emit(eventName, args);
+        }
+    },
     downloadAsset: function(identity, asset, cb) {
         const srcUrl = coreState.getConfigUrlByUuid(identity.uuid);
         const downloadId = asset.downloadId;

--- a/src/browser/api_protocol/api_handlers/system.js
+++ b/src/browser/api_protocol/api_handlers/system.js
@@ -90,6 +90,7 @@ function SystemApiHandler() {
         'open-url-with-browser': openUrlWithBrowser,
         'process-snapshot': processSnapshot,
         'raise-event': raiseEvent,
+        'raise-many-events': raiseManyEvents,
         'read-registry-value': { apiFunc: readRegistryValue, apiPath: '.readRegistryValue', apiPolicyDelegate: ReadRegistryValuePolicyDelegate },
         'release-external-process': { apiFunc: releaseExternalProcess, apiPath: '.releaseExternalProcess' },
         'resolve-uuid': resolveUuid,
@@ -182,6 +183,10 @@ function SystemApiHandler() {
 
         System.raiseEvent(evt, eventArgs);
         ack(successAck);
+    }
+
+    function raiseManyEvents(identity, message) {
+        return System.raiseManyEvents(message.payload);
     }
 
     function convertOptions(identity, message, ack) {

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -215,21 +215,24 @@ limitations under the License.
         const { uuid, name, parent, entityType } = entityInfo;
         const winIdentity = { uuid, name };
         const parentFrameName = parent.name || name;
+        const eventMap = new Map();
 
-        raiseEventSync(`window/initialized/${uuid}-${name}`, winIdentity);
+        eventMap.set(`window/initialized/${uuid}-${name}`, winIdentity);
 
         // main window
         if (uuid === name) {
-            raiseEventSync(`application/initialized/${uuid}`);
+            eventMap.set(`application/initialized/${uuid}`);
         }
 
-        raiseEventSync(`window/dom-content-loaded/${uuid}-${name}`, winIdentity);
-        raiseEventSync(`window/connected/${uuid}-${name}`, winIdentity);
-        raiseEventSync(`window/frame-connected/${uuid}-${parentFrameName}`, {
+        eventMap.set(`window/dom-content-loaded/${uuid}-${name}`, winIdentity);
+        eventMap.set(`window/connected/${uuid}-${name}`, winIdentity);
+        eventMap.set(`window/frame-connected/${uuid}-${parentFrameName}`, {
             frameName: name,
             entityType
         });
-        raiseEventSync(`frame/connected/${uuid}-${name}`, winIdentity);
+        eventMap.set(`frame/connected/${uuid}-${name}`, winIdentity);
+
+        asyncApiCall('raise-many-events', [...eventMap]);
     }
 
     function deferByTick(callback) {


### PR DESCRIPTION
From `api-decorator` we were sending out a series of ready/initialization events using sync calls (though they happened from within an async load event). This change preserves the order and moves the entire set of calls to a single api call that fans out browser side to raise each event. 

Tests well
[Win 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5aa7421c6a994a57faa5ca64)
[Win 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5aa742df6a994a57faa5ca65)

