### PR TITLE
RUN-3895 remove optional dependencies from npm-shrinkwrap to fix build

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3860,8 +3860,8 @@
     },
     "openfin-sign": {
       "version": "1.0.0",
-      "from": "git+ssh://git@github.com/openfin/openfin-sign.git#v1.0.0",
-      "resolved": "git+ssh://git@github.com/openfin/openfin-sign.git#8a43b6cf28148c099a25663143263e42b5ef9b41",
+      "from": "openfin/openfin-sign#v1.0.0",
+      "resolved": "git://github.com/openfin/openfin-sign.git#8a43b6cf28148c099a25663143263e42b5ef9b41",
       "dev": true
     },
     "options": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4226,12 +4226,6 @@
         }
       }
     },
-    "runtime-p2p": {
-      "version": "0.0.1",
-      "from": "runtime-p2p@git+ssh://git@github.com/openfin/runtime-p2p.git#7426ace77dbe87b73a54181b46be0938c15d81ba",
-      "resolved": "git+ssh://git@github.com/openfin/runtime-p2p.git#7426ace77dbe87b73a54181b46be0938c15d81ba",
-      "optional": true
-    },
     "rx": {
       "version": "4.1.0",
       "from": "rx@https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "load-grunt-tasks": "^3.3.0",
     "mocha": "^3.0.2",
     "mockery": "^2.0.0",
-    "openfin-sign": "git+ssh://git@github.com:openfin/openfin-sign.git#v1.0.0",
+    "openfin-sign": "openfin/openfin-sign.git#v1.0.0",
     "rewire": "^2.5.2",
     "should": "^11.1.0",
     "should-sinon": "^0.0.5",


### PR DESCRIPTION
Removed runtime-p2p from npm-shrinkwrap.json since optionalDependencies don't seem to play well with shrinkwrapping.

Also changed openfin-sign to use the GitHub URL syntax over ssh.