### PR TITLE
RUN-3821 - Services Event Namespace

### DIFF
--- a/src/browser/api/service.ts
+++ b/src/browser/api/service.ts
@@ -79,13 +79,13 @@ export module Service {
         // Currently assumes this is an application, add logic for external connection here when that becomes option
         ofEvents.once(route.application('closed', uuid), () => {
             serviceMap.delete(uuid);
-            ofEvents.emit(route.application('service-disconnected', uuid), {
+            ofEvents.emit(route.service('disconnected', uuid), {
                 uuid,
                 name
             });
         });
 
-        ofEvents.emit(route.system('service-connected'), serviceIdentity);
+        ofEvents.emit(route.service('connected', serviceIdentity.uuid), { topic: 'service', type: 'connected', ...serviceIdentity });
 
         // execute requests to connect for service that occured before service registration. Timeout ensures registration concludes first.
         setTimeout(() => {

--- a/src/browser/api_protocol/api_handlers/service_middleware.ts
+++ b/src/browser/api_protocol/api_handlers/service_middleware.ts
@@ -35,7 +35,7 @@ const remoteAckMap: Map<string, RemoteAck> = new Map();
 const pendingServiceConnections: Map<string, MessagePackage[]> = new Map();
 
 function getAckKey(id: number, identity: Identity): string {
-    return `${ id }-${ identity.uuid }`;
+    return `${ id }-${ identity.uuid }-${ identity.name }`;
 }
 
 function waitForServiceRegistration(uuid: string, msg: MessagePackage): void {


### PR DESCRIPTION
Added a services event namespace.   Had previously been leveraging application and system namespaces.  See javascript-adapter PR [here](https://github.com/openfin/javascript-adapter/pull/409)

Reworked tests included in tests below:

[Win7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5ab29e4a6a994a57faa5cae3)
[Win10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5ab29f7a6a994a57faa5cae4)