### PR TITLE
RUN-3960 fixed issue with duplicated listener registration.

### DIFF
--- a/src/browser/api/interappbus.js
+++ b/src/browser/api/interappbus.js
@@ -181,7 +181,7 @@ function subscribe(identity, payload, listener) {
     ofBus.on(keys.toApp, listener);
 
     // for the subscribe listeners:
-    emitSubscriberAdded(identity, payload);
+    //emitSubscriberAdded(identity, payload);
 
     //return a function that will unhook the listeners
     var unsubItem = {
@@ -191,7 +191,7 @@ function subscribe(identity, payload, listener) {
             ofBus.removeListener(keys.toWin, listener);
             ofBus.removeListener(keys.toApp, listener);
 
-            emitSubscriberRemoved(identity, payload);
+            //emitSubscriberRemoved(identity, payload);
         }
     };
 


### PR DESCRIPTION
with current design, the adapter should do filtering and dispatching of the messages, so on core side, it could simply blast all the messages out to the adapter.

✅ Test Result:
[Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5ab349a46a994a57faa5caf3)
[Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5ab34a746a994a57faa5caf4)