### PR TITLE
Run 3831 multi runtime close

### DIFF
--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -659,7 +659,9 @@ function run(identity, mainWindowOpts, userAppConfigArgs) {
                 console.error(err);
                 console.error(err.stack);
             } finally {
-                electronApp.exit(0);
+                if (!coreState.getRemoteCloseActionInProgress()) {
+                    electronApp.exit(0);
+                }
             }
         }
     });

--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -446,9 +446,11 @@ Application.revokeWindowAccess = function() {
 // userAppConfigArgs must be set to 'undefined' because
 // regular parameters cannot come after default parameters.
 Application.run = function(identity, configUrl = '', userAppConfigArgs = undefined) {
+    log.writeToLog(1, '$$$run1', true);
     if (!identity) {
         return;
     }
+
 
     const app = createAppObj(identity.uuid, null, configUrl);
     const mainWindowOpts = convertOpts.convertToElectron(app._options);
@@ -469,6 +471,7 @@ Application.run = function(identity, configUrl = '', userAppConfigArgs = undefin
 };
 
 function run(identity, mainWindowOpts, userAppConfigArgs) {
+    log.writeToLog(1, '$$$run2', true);
     const uuid = identity.uuid;
     const app = Application.wrap(uuid);
     const appState = coreState.appByUuid(uuid);

--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -450,7 +450,6 @@ Application.run = function(identity, configUrl = '', userAppConfigArgs = undefin
         return;
     }
 
-
     const app = createAppObj(identity.uuid, null, configUrl);
     const mainWindowOpts = convertOpts.convertToElectron(app._options);
 

--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -446,7 +446,6 @@ Application.revokeWindowAccess = function() {
 // userAppConfigArgs must be set to 'undefined' because
 // regular parameters cannot come after default parameters.
 Application.run = function(identity, configUrl = '', userAppConfigArgs = undefined) {
-    log.writeToLog(1, '$$$run1', true);
     if (!identity) {
         return;
     }
@@ -471,7 +470,6 @@ Application.run = function(identity, configUrl = '', userAppConfigArgs = undefin
 };
 
 function run(identity, mainWindowOpts, userAppConfigArgs) {
-    log.writeToLog(1, '$$$run2', true);
     const uuid = identity.uuid;
     const app = Application.wrap(uuid);
     const appState = coreState.appByUuid(uuid);
@@ -662,7 +660,7 @@ function run(identity, mainWindowOpts, userAppConfigArgs) {
                 console.error(err);
                 console.error(err.stack);
             } finally {
-                if (!coreState.getRemoteCloseActionInProgress()) {
+                if (!coreState.remoteCloseActionInProgress()) {
                     electronApp.exit(0);
                 }
             }

--- a/src/browser/api_protocol/api_handlers/middleware_entity_existence.ts
+++ b/src/browser/api_protocol/api_handlers/middleware_entity_existence.ts
@@ -36,7 +36,7 @@ const apisToIgnore = new Set([
  * Verifies that API is called on applications and windows that exist,
  * otherwise a proper error callback is executed.
  */
-function verifyEntityExistence(msg: MessagePackage, next: () => void): void {
+function verifyEntityExistence(msg: MessagePackage, next: () => void): Promise<any> | void {
     const { data, nack } = msg;
     const payload = data && data.payload;
     const uuid = payload && payload.uuid;

--- a/src/browser/api_protocol/transport_strategy/ack.ts
+++ b/src/browser/api_protocol/transport_strategy/ack.ts
@@ -50,9 +50,17 @@ export class NackPayload {
     }
 }
 
-export type AckFunc = (payload: AckPayload | NackPayload) => void;
+export type AckFunc = (payload: AckNackArgs) => Promise<any>;
+// export type AckFunc = (payload: AckNackArgs) => Promise<(payload: AckNackArgs) => Promise<void>>;
+/*
+'Promise<(payload: AckNackArgs) => Promise<void>>'
+'(payload: AckNackArgs): Promise<void>'
+*/
+// export type NackFunc = (error: string | Error) => Promise<void>;
+export type NackFunc = (error: string | Error) => Promise<any>;
 
-export type NackFunc = (error: string | Error) => void;
+// export type AckFunc = Promise<(payload: AckNackArgs) => Promise<void>>
+export type AckNackArgs =  AckPayload | NackPayload | string | Error;
 
 export interface RemoteAck {
     ack: AckFunc;

--- a/src/browser/api_protocol/transport_strategy/ack.ts
+++ b/src/browser/api_protocol/transport_strategy/ack.ts
@@ -51,15 +51,7 @@ export class NackPayload {
 }
 
 export type AckFunc = (payload: AckNackArgs) => Promise<any>;
-// export type AckFunc = (payload: AckNackArgs) => Promise<(payload: AckNackArgs) => Promise<void>>;
-/*
-'Promise<(payload: AckNackArgs) => Promise<void>>'
-'(payload: AckNackArgs): Promise<void>'
-*/
-// export type NackFunc = (error: string | Error) => Promise<void>;
 export type NackFunc = (error: string | Error) => Promise<any>;
-
-// export type AckFunc = Promise<(payload: AckNackArgs) => Promise<void>>
 export type AckNackArgs =  AckPayload | NackPayload | string | Error;
 
 export interface RemoteAck {

--- a/src/browser/api_protocol/transport_strategy/api_transport_base.ts
+++ b/src/browser/api_protocol/transport_strategy/api_transport_base.ts
@@ -59,9 +59,9 @@ export abstract class ApiTransportBase<T> {
 
     protected abstract ackDecoratorSync(e: any, messageId: number): AckFunc;
 
-    protected nackDecorator(ackFunction: AckFunc): (err: Error | string) => void {
+    protected nackDecorator(ackFunction: AckFunc): NackFunc {
         return (err: Error | string) => {
-            ackFunction(new NackPayload(err));
+            return ackFunction(new NackPayload(err));
         };
     }
 

--- a/src/browser/api_protocol/transport_strategy/elipc_strategy.ts
+++ b/src/browser/api_protocol/transport_strategy/elipc_strategy.ts
@@ -51,8 +51,6 @@ export class ElipcStrategy extends ApiTransportBase<MessagePackage> {
                         Promise.resolve()
                             .then(() => endpoint.apiFunc(identity, data, ack, nack))
                             .then(result => {
-                                log.writeToLog(1, 'made the call', true);
-                                log.writeToLog(1, JSON.stringify(data), true);
                                 // older action calls will invoke ack internally, newer ones will return a value
                                 if (result !== undefined) {
                                     ack(new AckPayload(result));

--- a/src/browser/api_protocol/transport_strategy/elipc_strategy.ts
+++ b/src/browser/api_protocol/transport_strategy/elipc_strategy.ts
@@ -51,6 +51,8 @@ export class ElipcStrategy extends ApiTransportBase<MessagePackage> {
                         Promise.resolve()
                             .then(() => endpoint.apiFunc(identity, data, ack, nack))
                             .then(result => {
+                                log.writeToLog(1, 'made the call', true);
+                                log.writeToLog(1, JSON.stringify(data), true);
                                 // older action calls will invoke ack internally, newer ones will return a value
                                 if (result !== undefined) {
                                     ack(new AckPayload(result));
@@ -161,6 +163,10 @@ export class ElipcStrategy extends ApiTransportBase<MessagePackage> {
                 } catch (err) {
                     reject(err);
                 }
+
+                log.writeToLog(1, 'ackman', true);
+                log.writeToLog(1, JSON.stringify(ackObj), true);
+
 
                 if (!e.sender.isDestroyed()) {
                     e.returnValue = JSON.stringify(ackObj);

--- a/src/browser/api_protocol/transport_strategy/elipc_strategy.ts
+++ b/src/browser/api_protocol/transport_strategy/elipc_strategy.ts
@@ -161,11 +161,7 @@ export class ElipcStrategy extends ApiTransportBase<MessagePackage> {
                 } catch (err) {
                     reject(err);
                 }
-
-                log.writeToLog(1, 'ackman', true);
-                log.writeToLog(1, JSON.stringify(ackObj), true);
-
-
+                
                 if (!e.sender.isDestroyed()) {
                     e.returnValue = JSON.stringify(ackObj);
                     resolve();

--- a/src/browser/api_protocol/transport_strategy/elipc_strategy.ts
+++ b/src/browser/api_protocol/transport_strategy/elipc_strategy.ts
@@ -151,19 +151,22 @@ export class ElipcStrategy extends ApiTransportBase<MessagePackage> {
         const ackObj = new AckMessage();
         ackObj.correlationId = messageId;
 
-        return (payload: any): void => {
-            ackObj.payload = payload;
+        return (payload: any) => {
+            return new Promise((resolve, reject) => {
+                ackObj.payload = payload;
 
-            try {
-                // Log all messages when -v=1
-                system.debugLog(1, `sent sync in-runtime <= ${JSON.stringify(ackObj)}`);
-            } catch (err) {
-                /* tslint:disable: no-empty */
-            }
+                try {
+                    // Log all messages when -v=1
+                    system.debugLog(1, `sent sync in-runtime <= ${JSON.stringify(ackObj)}`);
+                } catch (err) {
+                    reject(err);
+                }
 
-            if (!e.sender.isDestroyed()) {
-                e.returnValue = JSON.stringify(ackObj);
-            }
+                if (!e.sender.isDestroyed()) {
+                    e.returnValue = JSON.stringify(ackObj);
+                    resolve();
+                }
+            });
         };
     }
 
@@ -171,21 +174,23 @@ export class ElipcStrategy extends ApiTransportBase<MessagePackage> {
         const ackObj = new AckMessage();
         ackObj.correlationId = messageId;
 
-        return (payload: any): void => {
-            ackObj.payload = payload;
+        return (payload: any) => {
+            return new Promise((resolve, reject) => {
+                ackObj.payload = payload;
 
-            try {
-                // Log all messages when -v=1
-                /* tslint:disable: max-line-length */
-                system.debugLog(1, `sent in-runtime <= ${e.frameRoutingId} ${JSON.stringify(ackObj)}`);
-            } catch (err) {
-                /* tslint:disable: no-empty */
-            }
+                try {
+                    // Log all messages when -v=1
+                    /* tslint:disable: max-line-length */
+                    system.debugLog(1, `sent in-runtime <= ${e.frameRoutingId} ${JSON.stringify(ackObj)}`);
+                } catch (err) {
+                    reject(err);
+                }
 
-            if (!e.sender.isDestroyed()) {
-                e.sender.sendToFrame(e.frameRoutingId, electronIpc.channels.CORE_MESSAGE, JSON.stringify(ackObj));
-            }
+                if (!e.sender.isDestroyed()) {
+                    e.sender.sendToFrame(e.frameRoutingId, electronIpc.channels.CORE_MESSAGE, JSON.stringify(ackObj));
+                    resolve();
+                }
+            });
         };
-
     }
 }

--- a/src/browser/api_protocol/transport_strategy/ws_strategy.ts
+++ b/src/browser/api_protocol/transport_strategy/ws_strategy.ts
@@ -59,7 +59,9 @@ export class WebSocketStrategy extends ApiTransportBase<MessagePackage> {
     }
 
     private responseHandler = (action: string, ack: AckFunc, nack: NackFunc): RemoteAck => {
-        const isNonCloseAction = !(action === 'close-window' || action === 'close-application');
+        const closeActions = ['close-window', 'close-application', 'terminate-application'];
+
+        const isNonCloseAction = !(closeActions.indexOf(action) === -1);
 
         if (isNonCloseAction) {
             return {ack, nack};

--- a/src/browser/api_protocol/transport_strategy/ws_strategy.ts
+++ b/src/browser/api_protocol/transport_strategy/ws_strategy.ts
@@ -20,7 +20,7 @@ import { Endpoint, ActionMap } from '../shapes';
 import route from '../../../common/route';
 import * as log from '../../log';
 import * as coreState from '../../core_state';
-import { app } from 'electron'; //electronApp = electron.app;
+import { app } from 'electron';
 declare var require: any;
 
 import { ExternalApplication } from '../../api/external_application';
@@ -72,7 +72,7 @@ export class WebSocketStrategy extends ApiTransportBase<MessagePackage> {
             };
         }
     }
-//Promise<(payload: AckNackArgs) => Promise<void>>
+
     private addPotentialShutdownCall = (fn: (AckFunc | NackFunc) , ctx: object = null): AckFunc => {
         const origFn = fn;
 
@@ -91,17 +91,6 @@ export class WebSocketStrategy extends ApiTransportBase<MessagePackage> {
                     reject();
                 });
             });
-
-            // try {
-            //     origFn.call(ctx, payload);
-            //     if (coreState.shouldCloseRuntime([])) {
-            //         app.exit(0);
-            //     }
-            // } catch (err) {
-            //     log.writeToLog(1, err, true);
-            // } finally {
-            //     coreState.setRemoteCloseActionInProgress(false);
-            // }
         };
     }
 

--- a/src/browser/core_state.ts
+++ b/src/browser/core_state.ts
@@ -519,6 +519,16 @@ function anyAppRestarting(): boolean {
     return !!apps.find(app => app.isRestarting);
 }
 
+let isRemoteCloseActionInProress = false;
+
+export function getRemoteCloseActionInProgress() {
+    return isRemoteCloseActionInProress;
+}
+
+export function setRemoteCloseActionInProgress(isInProgress: boolean) {
+    isRemoteCloseActionInProress = !!isInProgress;
+}
+
 export function shouldCloseRuntime(ignoreArray: string[]|undefined): boolean {
     const ignoredApps = ignoreArray || [];
 

--- a/src/browser/core_state.ts
+++ b/src/browser/core_state.ts
@@ -521,7 +521,7 @@ function anyAppRestarting(): boolean {
 
 let isRemoteCloseActionInProress = false;
 
-export function getRemoteCloseActionInProgress() {
+export function remoteCloseActionInProgress() {
     return isRemoteCloseActionInProress;
 }
 

--- a/src/browser/transports/socket_server.js
+++ b/src/browser/transports/socket_server.js
@@ -55,9 +55,9 @@ let Server = function() {
         });
     };
 
-    me.send = function(id, message) {
+    me.send = function(id, message, cb = () => {}) {
         if (activeConnections[id]) {
-            activeConnections[id].send(message);
+            activeConnections[id].send(message, {}, cb);
         }
     };
 

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -32,6 +32,7 @@ declare module 'electron' {
         export function on(event: string, callback: () => void): void;
         export function setMinLogLevel(level: number): void;
         export function vlog(level: number, message: any): any;
+        export function exit(code: number): any;
 
         export function readRegistryValue(root: string, key: string, value: string): any;
 


### PR DESCRIPTION
This change ensures that we respect the websocket write before tearing down the browser process in cases where the external connection (adapter or multi-runtime) action. Further action here is required to be fully comfortable with the shutdown sequence, it is captured [here](https://appoji.jira.com/browse/RUN-3962)

[tests well](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5ab5087d6a994a57faa5cb11)

[this](https://testing-dashboard.openfin.co/#/app/tests/5ab54a0d6a994a57faa5cb14/edit) is the additional test that will pass when the versions are resolved

