### PR TITLE
RUN-3974 Object Destroyed error on on pre-main close.

### DIFF
--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -578,16 +578,28 @@ function run(identity, mainWindowOpts, userAppConfigArgs) {
 
     // fire the connected once the main window's dom is ready
     app.mainWindow.webContents.once('dom-ready', () => {
-        const pid = app.mainWindow.webContents.processId;
+        //edge case where the window might be destroyed by the time we get here.
+        if (!app.mainWindow.isDestroyed()) {
+            const pid = app.mainWindow.webContents.processId;
 
-        if (pid) {
-            app._processInfo = new ProcessInfo(pid);
+            if (pid) {
+                app._processInfo = new ProcessInfo(pid);
 
-            // Must call once to start measuring CPU usage
-            app._processInfo.getCpuUsage();
+                // Must call once to start measuring CPU usage
+                app._processInfo.getCpuUsage();
+            }
+
+            ofEvents.emit(route.application('connected', uuid), { topic: 'application', type: 'connected', uuid });
+        } else {
+            //Window was closed before constructor
+            let constructorCallbackMessage = {
+                success: false,
+                data: {
+                    message: 'Window closed before web context initiatiated'
+                }
+            };
+            ofEvents.emit(route.window('fire-constructor-callback', uuid, uuid), constructorCallbackMessage);
         }
-
-        ofEvents.emit(route.application('connected', uuid), { topic: 'application', type: 'connected', uuid });
     });
 
     // function finish() {

--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -592,7 +592,7 @@ function run(identity, mainWindowOpts, userAppConfigArgs) {
             ofEvents.emit(route.application('connected', uuid), { topic: 'application', type: 'connected', uuid });
         } else {
             //Window was closed before constructor
-            let constructorCallbackMessage = {
+            const constructorCallbackMessage = {
                 success: false,
                 data: {
                     message: 'Window closed before web context initiatiated'


### PR DESCRIPTION
Fixed issue where if you closed a window before fin.desktop.main would throw an Object Destroyed error.

Tests: 
[Win10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5ac3e4854ecc2a37d5a483de)
[Win7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5ac3e3c54ecc2a37d5a483dd)