### PR TITLE
Feature/RUN-3985 non blocking errors

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -91,6 +91,12 @@ module.exports = (grunt) => {
                     dest: 'staging/core/'
                 }]
             },
+            error: { //error dialog artifacts that need copying
+                files: [{
+                    src: ['src/error/*'],
+                    dest: 'staging/core/'
+                }]
+            },
             certificate: { //certificate dialog artifacts that need copying
                 files: [{
                     src: ['src/certificate/*'],

--- a/index.js
+++ b/index.js
@@ -72,7 +72,6 @@ let appIsReady = false;
 const deferredLaunches = [];
 const USER_DATA = app.getPath('userData');
 
-
 app.on('child-window-created', function(parentId, childId, childOptions) {
 
     if (!coreState.addChildToWin(parentId, childId)) {
@@ -163,6 +162,12 @@ includeFlashPlugin();
 
 // Opt in to launch crash reporter
 initializeCrashReporter(coreState.argo);
+
+if (coreState.argo['safe-errors']) {
+    process.on('uncaughtException', (err) => {
+        errors.createErrorUI(err);
+    });
+}
 
 // Has a local copy of an app config
 if (coreState.argo['local-startup-url']) {

--- a/src/browser/core_state.ts
+++ b/src/browser/core_state.ts
@@ -65,7 +65,7 @@ export const args = app.getCommandLineArguments(); // arguments as a string
 export const argv = app.getCommandLineArgv(); // arguments as an array
 export const argo = minimist(argv); // arguments as an object
 
-const apps: Shapes.App[] = [];
+let apps: Shapes.App[] = [];
 
 let startManifest = {};
 const manifests: Map <string, Shapes.Manifest> = new Map();
@@ -426,6 +426,10 @@ export function removeApp(id: number): void {
     // apps = apps.filter(app => app.id !== id);
 
     // return apps;
+}
+
+export function deleteApp(uuid: string): void {
+    apps = apps.filter(app => app.uuid !== uuid);
 }
 
 export function getWindowOptionsById(id: number): Shapes.WindowOptions|boolean {

--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -13,6 +13,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+import ofEvents from '../browser/of_events';
+import route from './route';
+import { app } from 'electron';
+import * as log from '../browser/log';
 /**
  * Interface of a converted JS error into a plain object
  */
@@ -31,4 +35,54 @@ export function errorToPOJO(error: Error): ErrorPlainObject {
         message: error.message,
         toString: error.toString
     };
+}
+
+export function createErrorUI(err: Error) {
+    // prevent issue with circular dependencies.
+    const Application = require('../browser/api/application').Application;
+    const coreState = require('../browser/core_state');
+
+    const appUuid = `error-app-${app.generateGUID()}`;
+
+    try {
+        const errorAppOptions = {
+            url: `file:///${__dirname}/../error/index.html`,
+            uuid: appUuid,
+            name: appUuid,
+            mainWindowOptions: {
+                defaultHeight: 250,
+                defaultWidth: 570,
+                defaultCentered: true,
+                saveWindowState: false,
+                showTaskbarIcon: false,
+                autoShow: true,
+                frame: true,
+                alwaysOnTop: true,
+                resizable: false,
+                contextMenu: false,
+                minimizable: false,
+                maximizable: false,
+                nonPersistent: true,
+                experimental: {
+                    'v2Api': true
+                },
+                customData: {
+                    error: errorToPOJO(err)
+                }
+            }
+        };
+
+        Application.create(errorAppOptions);
+
+        ofEvents.once(route.application('closed', appUuid), () => {
+            coreState.deleteApp(appUuid);
+        });
+
+        Application.run({ uuid: errorAppOptions.uuid });
+        log.writeToLog('info', err);
+
+    } catch (err) {
+        log.writeToLog('info', err);
+    }
+
 }

--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -56,7 +56,6 @@ export function createErrorUI(err: Error) {
                 saveWindowState: false,
                 showTaskbarIcon: false,
                 autoShow: true,
-                frame: true,
                 alwaysOnTop: true,
                 resizable: false,
                 contextMenu: false,
@@ -78,7 +77,7 @@ export function createErrorUI(err: Error) {
             coreState.deleteApp(appUuid);
         });
 
-        Application.run({ uuid: errorAppOptions.uuid });
+        Application.run({ uuid: appUuid });
         log.writeToLog('info', err);
 
     } catch (err) {

--- a/src/error/index.html
+++ b/src/error/index.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html>
+    <head>
+	    <meta charset="utf-8">
+	    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+	    <title>Warning</title>
+    </head>
+    <body>
+	    <div class="container">
+	        <h4>A JavaScript error occurred in the main process</h4>
+	        Uncaught Exception:
+	        <p id="error-body"></p>
+	    </div>
+	    <div class="container-btn">
+	        <button class="close-btn" onclick="closeWin()">OK</button>
+	    </div>
+	    <script>
+	        document.addEventListener('DOMContentLoaded', () => {
+	            getExceptionData();
+	        });
+
+	        async function closeWin() {
+	            try {
+		            const win = await fin.Window.getCurrent();
+		            return win.close();
+	            } catch (err) {
+		            console.log(err);
+	            }
+	        }
+
+	        async function getExceptionData() {
+	            const win = await fin.Window.getCurrent();
+	            const { customData } = await win.getOptions();
+	            const errBodySpan = document.querySelector('#error-body');
+
+	            errBodySpan.innerHTML = customData.error.message;
+	            document.body.addEventListener("copy", (event) => {
+		            fin.Clipboard.writeText({ data: customData.error.stack });
+	            });
+	        }
+	    </script>
+	    <style>
+	        body {
+	            margin: 0;
+	            overflow: hidden;
+	            font-size: medium;
+	        }
+	        h4 {
+	            color: darkblue;
+	        }
+	        .container {
+	            margin:8px;
+	            height: 140px
+	        }
+
+	        .container-btn {
+	            width: 100%;
+	            height: 60px;
+	            display: block;
+	            background-color: #F0F0F0;
+	            text-align: right;
+	        }
+
+	        .container-btn button {
+	            margin: 10px;
+	            width: 70px;
+	        }
+	        #error-body {
+	            height: 100px;
+	            white-space: pre-wrap;
+	            font-family: inherit;
+	            overflow: hidden;
+	        }
+	    </style>
+    </body>
+</html>

--- a/src/error/index.html
+++ b/src/error/index.html
@@ -49,7 +49,7 @@
 	            color: darkblue;
 	        }
 	        .container {
-	            margin:8px;
+	            margin:10px;
 	            height: 140px
 	        }
 	        .container-btn {

--- a/src/error/index.html
+++ b/src/error/index.html
@@ -52,7 +52,6 @@
 	            margin:8px;
 	            height: 140px
 	        }
-
 	        .container-btn {
 	            width: 100%;
 	            height: 60px;
@@ -60,7 +59,6 @@
 	            background-color: #F0F0F0;
 	            text-align: right;
 	        }
-
 	        .container-btn button {
 	            margin: 10px;
 	            width: 70px;

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -14,6 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 import * as assert from 'assert';
+import * as mockery from 'mockery';
+import {mockElectron, lastLogValue, lastVlogValue} from './electron';
+
+mockery.registerMock('electron', mockElectron);
+mockery.enable();
 import * as errors from '../src/common/errors';
 
 describe('Errors', () => {


### PR DESCRIPTION
* `--safe-errrors` flag to enable non-blocking errors
* User can `copy` the error stack into the clipboard
* Once User dismisses the error the app no longer appears on fin.System.getAllApplications calls
* Errors are always log
* Handles multiple errors at once.
* Non blocking

### Test results:
### No flags
[Win 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5ac6ba314ecc2a37d5a4840f)
[Win 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5ac6bb164ecc2a37d5a48412)

#### Using `--safe-errors`
[Win 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5ac6ba9d4ecc2a37d5a48410)
[Win10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5ac6bbe64ecc2a37d5a48414)