### PR TITLE
RUN-3966 getSnapshot threw not function js error in V9

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -1355,7 +1355,7 @@ Window.getSnapshot = function(identity, callback = () => {}) {
     }
 
     browserWindow.capturePage(img => {
-        callback(undefined, img.toPng().toString('base64'));
+        callback(undefined, img.toPNG().toString('base64'));
     });
 };
 


### PR DESCRIPTION
This PR fixed a function name change error in getSnapshot. (V9)

Test Results:
[Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5accc5724ecc2a37d5a4843f)
[Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5accbecf4ecc2a37d5a4843d)