### PR TITLE
RUN-4008: Send parent config url to RVM on app started event

### DIFF
--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -500,6 +500,13 @@ function run(identity, mainWindowOpts, userAppConfigArgs) {
 
         coreState.setLicenseKey({ uuid }, licenseKey);
 
+        const parentUuid = appState.parentUuid || null;
+
+        let parentConfigUrl = null;
+        if (parentUuid) {
+            parentConfigUrl = coreState.getConfigUrlByUuid(parentUuid);
+        }
+
         return {
             licenseKey,
             uuid,
@@ -507,7 +514,8 @@ function run(identity, mainWindowOpts, userAppConfigArgs) {
                 type: 'js'
             },
             parentApp: {
-                uuid: appState.parentUuid || null
+                uuid: parentUuid,
+                configUrl: parentConfigUrl
             }
         };
     };

--- a/src/browser/api_protocol/api_handlers/authorization.js
+++ b/src/browser/api_protocol/api_handlers/authorization.js
@@ -141,7 +141,8 @@ function onRequestAuthorization(id, data) {
                     client: externalApplicationOptions.client,
                     uuid,
                     parentApp: {
-                        uuid: null
+                        uuid: null,
+                        configUrl: null
                     }
                 }
             }, externalApplicationOptions.configUrl);


### PR DESCRIPTION
[JIRA](https://appoji.jira.com/browse/RUN-4008)

We want to send the parent app's config url to the RVM on the app-started event, since it will be helpful for us to tie together different records when looking at licensing data.

Tests:
[W7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5acbcc434ecc2a37d5a48439)
[W10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5acbcdac4ecc2a37d5a4843a)

I investigated the test failures and they appear to be flaky tests, unrelated to my changes. I reran each failure individually and observed the following:

* Window.navigateBack passes when I reran it with my asar
* Window.getSnapshot, Window.getSnapshot T2, and Notification.close all fail on regular canary, without my asar

Not sure if those are known issues or not

