### PR TITLE
RUN-3988 Multi-Runtime Join Group_1

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -497,7 +497,6 @@ Window.create = function(id, opts) {
         browserWindow._options = _options;
 
         // set taskbar icon
-        // DOES THIS MESS UP OTHER EXTERNAL WINDOWS?
         if (!browserWindow.isExternalWindow()) {
             setTaskbar(browserWindow);
         }
@@ -1072,15 +1071,9 @@ Window.close = function(identity, force, callback = () => {}) {
 
     let defaultAction = () => {
         if (!browserWindow.isDestroyed()) {
-            const ofWindow = Window.wrap(identity.uuid, identity.name);
-            ofWindow.forceClose = true;
-
-            if (beforeWindowClose) {
-                beforeWindowClose().then(browserWindow.close);
-            } else {
-                browserWindow.close();
-            }
-
+            let openfinWindow = Window.wrap(identity.uuid, identity.name);
+            openfinWindow.forceClose = true;
+            browserWindow.close();
         }
     };
 
@@ -1408,10 +1401,6 @@ Window.isShowing = function(identity) {
     let browserWindow = getElectronBrowserWindow(identity);
 
     return !!(browserWindow && browserWindow.isVisible());
-};
-
-Window.setBeforeWindowClose = (fn) => {
-    beforeWindowClose = fn;
 };
 
 const meshJoinGroupEvents = (identity, grouping) => {

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -497,7 +497,7 @@ Window.create = function(id, opts) {
         browserWindow._options = _options;
 
         // set taskbar icon
-        if (!browserWindow.isExternalWindow()) {
+        if (!opts.meshJoinGroup) {
             setTaskbar(browserWindow);
         }
 

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -499,8 +499,6 @@ Window.create = function(id, opts) {
         // set taskbar icon
         if (!opts.meshJoinGroup) {
             setTaskbar(browserWindow);
-        } else {
-            _options.meshJoinGroup = true;
         }
 
         // apply options to browserWindow
@@ -1977,10 +1975,6 @@ function createWindowTearDown(identity, id) {
                         name: child.name,
                         uuid: child.uuid
                     };
-
-                    if (child._options.meshJoinGroup && child.browserWindow.isExternalWindow()) {
-                        browserWindow.setExternalWindowNativeId('0x0');
-                    }
 
                     Window.close(childIdentity, true, () => {
                         closedChildren++;

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -1412,73 +1412,105 @@ Window.isShowing = function(identity) {
 };
 
 const meshJoinGroupEvents = (identity, grouping) => {
-    const beginSubscription = {
-        uuid: grouping.uuid,
-        name: grouping.name,
-        listenType: 'on',
-        className: 'window',
-        eventName: 'begin-user-bounds-changed'
-    };
 
-    addRemoteSubscription(beginSubscription);
+    const initEvent = (event, other) => {
+        const subscription = {
+            uuid: grouping.uuid,
+            name: grouping.name,
+            listenType: 'on',
+            className: 'window',
+            eventName: event
+        }
+        addRemoteSubscription(subscription);
 
-    const endSubscription = {
-        uuid: grouping.uuid,
-        name: grouping.name,
-        listenType: 'on',
-        className: 'window',
-        eventName: 'end-user-bounds-changed'
-    };
+        const oldEvent = route.window(event, grouping.uuid, grouping.name);
+        const newEvent = route.externalWindow(other, identity.uuid, grouping.name);
 
-    addRemoteSubscription(endSubscription);
-    const changingSubscription = {
-        uuid: grouping.uuid,
-        name: grouping.name,
-        listenType: 'on',
-        className: 'window',
-        eventName: 'bounds-changing'
-    };
+        ofEvents.on(oldEvent, payload => {
+            const newPayload = Object.assign({}, payload);
+            newPayload.uuid = identity.uuid;
+            ofEvents.emit(newEvent, newPayload);
+        });
+    }
 
-    addRemoteSubscription(changingSubscription);
+    initEvent('begin-user-bounds-changed', 'begin-user-bounds-change');
+    initEvent('end-user-bounds-changed', 'end-user-bounds-change');
+    initEvent('bounds-changing', 'moving');
+    initEvent('bounds-changed', 'bounds-changed');
 
-    const changedSubscription = {
-        uuid: grouping.uuid,
-        name: grouping.name,
-        listenType: 'on',
-        className: 'window',
-        eventName: 'bounds-changed'
-    };
 
-    addRemoteSubscription(changedSubscription);
+    // do focus
 
-    const oldBegin = route.window('begin-user-bounds-changed', grouping.uuid, grouping.name);
-    const newBegin = route.externalWindow('begin-user-bounds-change', identity.uuid, grouping.name);
-    const oldEnd = route.window('end-user-bounds-changed', grouping.uuid, grouping.name);
-    const newEnd = route.externalWindow('end-user-bounds-change', identity.uuid, grouping.name);
-    const oldChanging = route.window('bounds-changing', grouping.uuid, grouping.name);
-    const newChanging = route.externalWindow('moving', identity.uuid, grouping.name);
-    const oldChanged = route.window('bounds-changed', grouping.uuid, grouping.name);
-    const newChanged = route.externalWindow('bounds-changed', identity.uuid, grouping.name);
-    ofEvents.on(oldBegin, payload => {
-        const newPayload = Object.assign({}, payload);
-        newPayload.uuid = identity.uuid;
-        ofEvents.emit(newBegin, newPayload);
-    });
-    ofEvents.on(oldEnd, payload => {
-        const newPayload = Object.assign({}, payload);
-        newPayload.uuid = identity.uuid;
-        ofEvents.emit(newEnd, newPayload);
-    });
-    ofEvents.on(oldChanging, payload => {
-        const newPayload = Object.assign({}, payload);
-        newPayload.uuid = identity.uuid;
-        ofEvents.emit(newChanging, newPayload);
-    });
-    ofEvents.on(oldChanged, payload => {
-        const newPayload = Object.assign({}, payload);
-        newPayload.uuid = identity.uuid;
-        ofEvents.emit(newChanged, newPayload);
-    });
+    // remove child by id (corestate) on close of parent
+
+
+    // const beginSubscription = {
+    //     uuid: grouping.uuid,
+    //     name: grouping.name,
+    //     listenType: 'on',
+    //     className: 'window',
+    //     eventName: 'begin-user-bounds-changed'
+    // };
+
+    // addRemoteSubscription(beginSubscription);
+
+    // const endSubscription = {
+    //     uuid: grouping.uuid,
+    //     name: grouping.name,
+    //     listenType: 'on',
+    //     className: 'window',
+    //     eventName: 'end-user-bounds-changed'
+    // };
+
+    // addRemoteSubscription(endSubscription);
+    // const changingSubscription = {
+    //     uuid: grouping.uuid,
+    //     name: grouping.name,
+    //     listenType: 'on',
+    //     className: 'window',
+    //     eventName: 'bounds-changing'
+    // };
+
+    // addRemoteSubscription(changingSubscription);
+
+    // const changedSubscription = {
+    //     uuid: grouping.uuid,
+    //     name: grouping.name,
+    //     listenType: 'on',
+    //     className: 'window',
+    //     eventName: 'bounds-changed'
+    // };
+
+    // addRemoteSubscription(changedSubscription);
+
+    // const oldBegin = route.window('begin-user-bounds-changed', grouping.uuid, grouping.name);
+    // const newBegin = route.externalWindow('begin-user-bounds-change', identity.uuid, grouping.name);
+    // const oldEnd = route.window('end-user-bounds-changed', grouping.uuid, grouping.name);
+    // const newEnd = route.externalWindow('end-user-bounds-change', identity.uuid, grouping.name);
+    // const oldChanging = route.window('bounds-changing', grouping.uuid, grouping.name);
+    // const newChanging = route.externalWindow('moving', identity.uuid, grouping.name);
+    // const oldChanged = route.window('bounds-changed', grouping.uuid, grouping.name);
+    // const newChanged = route.externalWindow('bounds-changed', identity.uuid, grouping.name);
+    // ofEvents.on(oldBegin, payload => {
+    //     const newPayload = Object.assign({}, payload);
+    //     newPayload.uuid = identity.uuid;
+    //     ofEvents.emit(newBegin, newPayload);
+    // });
+    // ofEvents.on(oldEnd, payload => {
+    //     const newPayload = Object.assign({}, payload);
+    //     newPayload.uuid = identity.uuid;
+    //     ofEvents.emit(newEnd, newPayload);
+    // });
+    // ofEvents.on(oldChanging, payload => {
+    //     const newPayload = Object.assign({}, payload);
+    //     newPayload.uuid = identity.uuid;
+    //     ofEvents.emit(newChanging, newPayload);
+    // });
+    // ofEvents.on(oldChanged, payload => {
+    //     const newPayload = Object.assign({}, payload);
+    //     newPayload.uuid = identity.uuid;
+    //     ofEvents.emit(newChanged, newPayload);
+    // });
 };
 
 Window.joinGroup = function(identity, grouping, locals) {

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -1420,7 +1420,7 @@ const meshJoinGroupEvents = (identity, grouping) => {
 
     Object.keys(eventMap).forEach(key => {
         const event = key;
-        const bwEvent = eventMap[key]
+        const bwEvent = eventMap[key];
 
         const subscription = {
             uuid: grouping.uuid,
@@ -1438,7 +1438,7 @@ const meshJoinGroupEvents = (identity, grouping) => {
             newPayload.uuid = identity.uuid;
             ofEvents.emit(newEvent, newPayload);
         });
-        
+
         unsubscriptions.push(addRemoteSubscription(subscription));
     });
 
@@ -1447,7 +1447,7 @@ const meshJoinGroupEvents = (identity, grouping) => {
         const childClose = route.externalWindow('close', grouping.uuid, grouping.name);
         ofEvents.on(externalClose, () => unsubs.forEach(unsub => unsub()));
         ofEvents.on(childClose, () => unsubs.forEach(unsub => unsub()));
-    })
+    });
 };
 
 Window.joinGroup = function(identity, grouping, locals) {

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -499,6 +499,8 @@ Window.create = function(id, opts) {
         // set taskbar icon
         if (!opts.meshJoinGroup) {
             setTaskbar(browserWindow);
+        } else {
+            _options.meshJoinGroup = true;
         }
 
         // apply options to browserWindow
@@ -1975,6 +1977,10 @@ function createWindowTearDown(identity, id) {
                         name: child.name,
                         uuid: child.uuid
                     };
+
+                    if (child._options.meshJoinGroup && child.browserWindow.isExternalWindow()) {
+                        browserWindow.setExternalWindowNativeId('0x0');
+                    }
 
                     Window.close(childIdentity, true, () => {
                         closedChildren++;

--- a/src/browser/api_protocol/api_handlers/mesh_middleware.ts
+++ b/src/browser/api_protocol/api_handlers/mesh_middleware.ts
@@ -157,7 +157,8 @@ const handleExternalWindow = async (identity: Identity, toGroup: Identity) => {
         const childWindowOptions = {
             uuid: identity.uuid,
             name,
-            hwnd: hwnd.data
+            hwnd: hwnd.data,
+            meshJoinGroup: true
         };
         const parent = coreState.getWindowByUuidName(identity.uuid, identity.name);
         const parentId = parent && parent.browserWindow && parent.browserWindow.id;

--- a/src/browser/api_protocol/api_handlers/mesh_middleware.ts
+++ b/src/browser/api_protocol/api_handlers/mesh_middleware.ts
@@ -182,8 +182,9 @@ async function meshJoinWindowGroupMiddleware(msg: MessagePackage, next: (locals?
     const action = data && data.action;
     const isJoinWindowGroupAction = action === 'join-window-group';
     const isValidIdentity = typeof (identity) === 'object';
+    const optInFlag = coreState.argo['mesh-join-group'];
 
-    if (!isJoinWindowGroupAction || !isValidIdentity) {
+    if (!isJoinWindowGroupAction || !isValidIdentity || !optInFlag) {
         next();
         return;
     }
@@ -285,4 +286,4 @@ function registerMiddleware (requestHandler: RequestHandler<MessagePackage>): vo
     requestHandler.addPreProcessor(aggregateFromExternalRuntime);
 }
 
-export { registerMiddleware, isLocalUuid };
+export { registerMiddleware };

--- a/src/browser/api_protocol/api_handlers/mesh_middleware.ts
+++ b/src/browser/api_protocol/api_handlers/mesh_middleware.ts
@@ -134,7 +134,7 @@ function sendMessageMiddleware(msg: MessagePackage, next: () => void) {
     }
 }
 
-const handleExternalWindow = async (identity: Identity, toGroup: Identity): Promise<string|void> => {
+const handleExternalWindow = async (identity: Identity, toGroup: Identity): Promise<string|void|Error> => {
     const { uuid, name } = toGroup;
     if (coreState.getWindowByUuidName(identity.uuid, name)) {
         // External window already created and registered

--- a/src/browser/api_protocol/api_handlers/mesh_middleware.ts
+++ b/src/browser/api_protocol/api_handlers/mesh_middleware.ts
@@ -134,7 +134,7 @@ function sendMessageMiddleware(msg: MessagePackage, next: () => void) {
     }
 }
 
-const handleExternalWindow = async (identity: Identity, toGroup: Identity) => {
+const handleExternalWindow = async (identity: Identity, toGroup: Identity): Promise<string|void> => {
     const { uuid, name } = toGroup;
     if (coreState.getWindowByUuidName(identity.uuid, name)) {
         // External window already created and registered
@@ -170,14 +170,14 @@ const handleExternalWindow = async (identity: Identity, toGroup: Identity) => {
         }
         Window.create(childId, childWindowOptions);
 
-        return hwnd;
+        return hwnd.data;
     } catch (e) {
         log.writeToLog('info', e);
         return e;
     }
 };
 
-async function meshJoinWindowGroupMiddleware(msg: MessagePackage, next: (locals?: object) => void) {
+async function meshJoinWindowGroupMiddleware(msg: MessagePackage, next: (locals?: object) => void): Promise<void> {
     const { identity, data, ack, nack } = msg;
     const payload = data && data.payload;
     const action = data && data.action;

--- a/src/browser/api_protocol/api_handlers/middleware_entity_existence.ts
+++ b/src/browser/api_protocol/api_handlers/middleware_entity_existence.ts
@@ -23,6 +23,7 @@ import { windowApiMap } from './window.js';
 const apisToIgnore = new Set([
     // Application
     'create-application',
+    'join-window-group',
     'create-child-window',
     'is-application-running',
     //TODO: we do not check run for .NET, the adapter will create an application then run it without waiting for the ack.

--- a/src/browser/api_protocol/api_handlers/middleware_entity_existence.ts
+++ b/src/browser/api_protocol/api_handlers/middleware_entity_existence.ts
@@ -23,9 +23,9 @@ import { windowApiMap } from './window.js';
 const apisToIgnore = new Set([
     // Application
     'create-application',
-    'join-window-group',
     'create-child-window',
     'is-application-running',
+    'join-window-group',
     //TODO: we do not check run for .NET, the adapter will create an application then run it without waiting for the ack.
     'run-application',
     // Window

--- a/src/browser/api_protocol/api_handlers/window.js
+++ b/src/browser/api_protocol/api_handlers/window.js
@@ -36,7 +36,6 @@ module.exports.windowApiMap = {
     'focus-window': focusWindow,
     'get-current-window-options': getCurrentWindowOptions,
     'get-all-frames': getAllFrames,
-    'get-hwnd': getHwnd,
     'get-window-bounds': getWindowBounds,
     'get-window-group': getWindowGroup,
     'get-window-info': getWindowInfo,
@@ -332,12 +331,6 @@ function hideWindow(identity, message, ack) {
 
     Window.hide(windowIdentity);
     ack(successAck);
-}
-
-function getHwnd(identity, message, ack) {
-    const { payload } = message;
-    const windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-    return Window.getHwnd(windowIdentity);
 }
 
 function getAllFrames(identity, message) {

--- a/src/browser/api_protocol/api_handlers/window.js
+++ b/src/browser/api_protocol/api_handlers/window.js
@@ -309,7 +309,7 @@ function joinWindowGroup(identity, message, ack) {
     const windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
     const groupingIdentity = apiProtocolBase.getGroupingWindowIdentity(payload);
     const { locals } = message;
-    if (locals && locals.hwnd || locals.groupingHwnd) {
+    if (locals && (locals.hwnd || locals.groupingHwnd)) {
         locals.requester = identity;
     }
     Window.joinGroup(windowIdentity, groupingIdentity, locals);

--- a/src/browser/api_protocol/api_handlers/window.js
+++ b/src/browser/api_protocol/api_handlers/window.js
@@ -309,7 +309,7 @@ function joinWindowGroup(identity, message, ack) {
         windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload),
         groupingIdentity = apiProtocolBase.getGroupingWindowIdentity(payload);
 
-    Window.joinGroup(windowIdentity, groupingIdentity);
+    Window.joinGroup(windowIdentity, groupingIdentity, payload.hwnd);
     ack(successAck);
 }
 

--- a/src/browser/api_protocol/api_handlers/window.js
+++ b/src/browser/api_protocol/api_handlers/window.js
@@ -36,6 +36,7 @@ module.exports.windowApiMap = {
     'focus-window': focusWindow,
     'get-current-window-options': getCurrentWindowOptions,
     'get-all-frames': getAllFrames,
+    'get-hwnd': getHwnd,
     'get-window-bounds': getWindowBounds,
     'get-window-group': getWindowGroup,
     'get-window-info': getWindowInfo,
@@ -305,11 +306,14 @@ function leaveWindowGroup(identity, message, ack) {
 }
 
 function joinWindowGroup(identity, message, ack) {
-    var payload = message.payload,
-        windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload),
-        groupingIdentity = apiProtocolBase.getGroupingWindowIdentity(payload);
-
-    Window.joinGroup(windowIdentity, groupingIdentity, payload.hwnd);
+    const payload = message.payload;
+    const windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+    const groupingIdentity = apiProtocolBase.getGroupingWindowIdentity(payload);
+    const { locals } = message;
+    if (locals && locals.hwnd || locals.groupingHwnd) {
+        locals.requester = identity;
+    }
+    Window.joinGroup(windowIdentity, groupingIdentity, locals);
     ack(successAck);
 }
 
@@ -330,6 +334,11 @@ function hideWindow(identity, message, ack) {
     ack(successAck);
 }
 
+function getHwnd(identity, message, ack) {
+    const { payload } = message;
+    const windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+    return Window.getHwnd(windowIdentity);
+}
 
 function getAllFrames(identity, message) {
     const { payload } = message;

--- a/src/browser/bounds_changed_state_tracker.js
+++ b/src/browser/bounds_changed_state_tracker.js
@@ -16,6 +16,7 @@ limitations under the License.
 /*
     src/browser/bounds_changed_state_tracker.js
  */
+import * as log from './log'
 
 let windowTransaction = require('electron').windowTransaction;
 
@@ -306,6 +307,7 @@ function BoundsChangedStateTracker(uuid, name, browserWindow) {
                     }
 
                     WindowGroups.getGroup(groupUuid).filter((win) => {
+                        log.writeToLog(1, `***** win name/uuid, name ${win.uuid} ${win.name} -  ${name}`, true);
                         win.browserWindow.bringToFront();
                         return win.name !== name;
                     }).forEach((win) => {

--- a/src/browser/bounds_changed_state_tracker.js
+++ b/src/browser/bounds_changed_state_tracker.js
@@ -456,7 +456,6 @@ function BoundsChangedStateTracker(uuid, name, browserWindow) {
 
                     if (groupLeader.type === 'api') {
                         handleBoundsChange(false, true);
-                        //TBD:  if external window, ignore next bounds changed
                     }
                 } else {
                     if (!animations.getAnimationHandler().hasWindow(browserWindow.id) && !isUserBoundsChangeActive()) {

--- a/src/browser/bounds_changed_state_tracker.js
+++ b/src/browser/bounds_changed_state_tracker.js
@@ -16,8 +16,6 @@ limitations under the License.
 /*
     src/browser/bounds_changed_state_tracker.js
  */
-import * as log from './log'
-
 let windowTransaction = require('electron').windowTransaction;
 
 let _ = require('underscore');
@@ -307,7 +305,6 @@ function BoundsChangedStateTracker(uuid, name, browserWindow) {
                     }
 
                     WindowGroups.getGroup(groupUuid).filter((win) => {
-                        log.writeToLog(1, `***** win name/uuid, name ${win.uuid} ${win.name} -  ${name}`, true);
                         win.browserWindow.bringToFront();
                         return win.name !== name;
                     }).forEach((win) => {

--- a/src/browser/bounds_changed_state_tracker.js
+++ b/src/browser/bounds_changed_state_tracker.js
@@ -456,6 +456,7 @@ function BoundsChangedStateTracker(uuid, name, browserWindow) {
 
                     if (groupLeader.type === 'api') {
                         handleBoundsChange(false, true);
+                        //TBD:  if external window, ignore next bounds changed
                     }
                 } else {
                     if (!animations.getAnimationHandler().hasWindow(browserWindow.id) && !isUserBoundsChangeActive()) {

--- a/src/browser/external_window_event_adapter.js
+++ b/src/browser/external_window_event_adapter.js
@@ -22,9 +22,6 @@ electronApp.on('ready', () => {
 });
 import route from '../common/route';
 
-
-import * as log from './log'
-
 class ExternalWindowEventAdapter {
     constructor(browserWindow) {
         let options = browserWindow && browserWindow._options;
@@ -123,7 +120,6 @@ class ExternalWindowEventAdapter {
         });
 
         ofEvents.on(route.externalWindow('moving', uuid, name), () => {
-            log.writeToLog(1, `**** in moving - lbd ${disabledFrameState.leftButtonDown}`, true);
             if (disabledFrameState.leftButtonDown) {
                 let bounds = browserWindow.getBounds();
                 let mousePosition = MonitorInfo.getMousePosition();
@@ -141,8 +137,6 @@ class ExternalWindowEventAdapter {
                 if (xCursorDelta !== 0 || yCursorDelta !== 0) {
                     bounds.x = (cursorCurr.x - disabledFrameState.cursorStart.x) + disabledFrameState.boundsStart.x;
                     bounds.y = (cursorCurr.y - disabledFrameState.cursorStart.y) + disabledFrameState.boundsStart.y;
-
-                    log.writeToLog(1, `**** in moving ${JSON.stringify(bounds, undefined, 4)}`, true);
 
                     browserWindow.emit('disabled-frame-bounds-changing', {}, bounds, disabledFrameState.changeType);
 

--- a/src/browser/external_window_event_adapter.js
+++ b/src/browser/external_window_event_adapter.js
@@ -38,7 +38,9 @@ class ExternalWindowEventAdapter {
         let cachedState = null;
 
         ofEvents.on(route.externalWindow('focus', uuid, name), () => {
-            browserWindow.emit('focus');
+            if (!browserWindow.isDestroyed()) {
+                browserWindow.emit('focus');
+            }
         });
 
         ofEvents.on(route.externalWindow('blur', uuid, name), () => {
@@ -148,9 +150,11 @@ class ExternalWindowEventAdapter {
         });
 
         ofEvents.on(route.externalWindow('close', uuid, name), () => {
-            browserWindow.emit('close');
-            browserWindow.close();
-            browserWindow.emit('closed');
+            if (!browserWindow.isDestroyed()) {
+                browserWindow.emit('close');
+                browserWindow.close();
+                browserWindow.emit('closed');
+            }
         });
     }
 }

--- a/src/browser/external_window_event_adapter.js
+++ b/src/browser/external_window_event_adapter.js
@@ -22,6 +22,9 @@ electronApp.on('ready', () => {
 });
 import route from '../common/route';
 
+
+import * as log from './log'
+
 class ExternalWindowEventAdapter {
     constructor(browserWindow) {
         let options = browserWindow && browserWindow._options;
@@ -120,6 +123,7 @@ class ExternalWindowEventAdapter {
         });
 
         ofEvents.on(route.externalWindow('moving', uuid, name), () => {
+            log.writeToLog(1, `**** in moving - lbd ${disabledFrameState.leftButtonDown}`, true);
             if (disabledFrameState.leftButtonDown) {
                 let bounds = browserWindow.getBounds();
                 let mousePosition = MonitorInfo.getMousePosition();
@@ -137,6 +141,8 @@ class ExternalWindowEventAdapter {
                 if (xCursorDelta !== 0 || yCursorDelta !== 0) {
                     bounds.x = (cursorCurr.x - disabledFrameState.cursorStart.x) + disabledFrameState.boundsStart.x;
                     bounds.y = (cursorCurr.y - disabledFrameState.cursorStart.y) + disabledFrameState.boundsStart.y;
+
+                    log.writeToLog(1, `**** in moving ${JSON.stringify(bounds, undefined, 4)}`, true);
 
                     browserWindow.emit('disabled-frame-bounds-changing', {}, bounds, disabledFrameState.changeType);
 

--- a/src/browser/remote_subscriptions.ts
+++ b/src/browser/remote_subscriptions.ts
@@ -47,7 +47,7 @@ const pendingRemoteSubscriptions: Map<number, RemoteSubscription> = new Map();
 /**
  * Shape of remote subscription props
  */
-interface RemoteSubscriptionProps extends Identity {
+export interface RemoteSubscriptionProps extends Identity {
     className: 'application'|'window'|'system'; // names of the class event emitters, used for subscriptions
     eventName: string; // name of the type of the event to subscribe to
     listenType: 'on'|'once'; // used to set up subscription type

--- a/src/browser/remote_subscriptions.ts
+++ b/src/browser/remote_subscriptions.ts
@@ -95,9 +95,11 @@ export function addRemoteSubscription(subscriptionProps: RemoteSubscriptionProps
         connectionManager.resolveIdentity({
             uuid: subscription.uuid
 
-        }).then((id) => {
+        // }).then((id) => {
+        }).then(async (id) => {
             // Found app/window in a remote runtime, subscribing
-            applyRemoteSubscription(subscription, id.runtime);
+            // applyRemoteSubscription(subscription, id.runtime);
+            await applyRemoteSubscription(subscription, id.runtime);
 
         }).catch(() => {
             // App/window not found. We are assuming it will come up sometime in the future.
@@ -138,9 +140,6 @@ async function applyRemoteSubscription(subscription: RemoteSubscription, runtime
         cleanUpSubscription(subscription, runtimeKey);
     };
 
-    // Subscribe to an event on a remote runtime
-    classEventEmitter[listenType](eventName, listener);
-
     // Store a cleanup function for the added listener in
     // un-subscription map, so that later we can remove extra subscriptions
     if (!Array.isArray(unSubscriptions.get(runtimeKey))) {
@@ -149,6 +148,10 @@ async function applyRemoteSubscription(subscription: RemoteSubscription, runtime
     unSubscriptions.get(runtimeKey).push(() => {
         classEventEmitter.removeListener(eventName, listener);
     });
+
+    // Subscribe to an event on a remote runtime
+    // classEventEmitter[listenType](eventName, listener);
+    await classEventEmitter[listenType](eventName, listener);
 }
 
 /**

--- a/src/browser/remote_subscriptions.ts
+++ b/src/browser/remote_subscriptions.ts
@@ -47,7 +47,7 @@ const pendingRemoteSubscriptions: Map<number, RemoteSubscription> = new Map();
 /**
  * Shape of remote subscription props
  */
-export interface RemoteSubscriptionProps extends Identity {
+interface RemoteSubscriptionProps extends Identity {
     className: 'application'|'window'|'system'; // names of the class event emitters, used for subscriptions
     eventName: string; // name of the type of the event to subscribe to
     listenType: 'on'|'once'; // used to set up subscription type
@@ -95,11 +95,9 @@ export function addRemoteSubscription(subscriptionProps: RemoteSubscriptionProps
         connectionManager.resolveIdentity({
             uuid: subscription.uuid
 
-        // }).then((id) => {
-        }).then(async (id) => {
+        }).then((id) => {
             // Found app/window in a remote runtime, subscribing
-            // applyRemoteSubscription(subscription, id.runtime);
-            await applyRemoteSubscription(subscription, id.runtime);
+            applyRemoteSubscription(subscription, id.runtime);
 
         }).catch(() => {
             // App/window not found. We are assuming it will come up sometime in the future.
@@ -150,8 +148,7 @@ async function applyRemoteSubscription(subscription: RemoteSubscription, runtime
     });
 
     // Subscribe to an event on a remote runtime
-    // classEventEmitter[listenType](eventName, listener);
-    await classEventEmitter[listenType](eventName, listener);
+    classEventEmitter[listenType](eventName, listener);
 }
 
 /**

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -55,6 +55,7 @@ declare module 'electron' {
     export class BrowserWindow {
         constructor(props: any);
 
+        id: number;
         _options: {
             minWidth: number;
             minHeight: number;

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -77,6 +77,7 @@ declare module 'electron' {
         emit(routeString: string, ...args: any[]): void;
         getBounds(): Rectangle;
         setWindowPlacement(bounds: Rectangle): void;
+        close(): void;
     }
 
     export class ipcMain {


### PR DESCRIPTION
Currently the runtime where the request is made is the one handling the join group.  The middleware checks to see if either of the windows in another runtime, if so - it gets the nativeId from the other runtime, creates an external window (identity that makes the join group api call is the parent window), and subscribes to the necessary events, then uses the created external window to handle group movements.  

@wenjunche or whoever else knows external windows - please see line 500 in window.js.  I am skipping the setTaskbar fn for the external windows created here since it was erroring out (errors on l.1823 - `browserWindow.setIcon(icon);`, brings down runtime).  Not sure why it was freezing up the app, icon argument looked OK.

There is still a lot to do but this PR works to joingroup when called from an OF app:
- Currently cannot handle joinGroup calls from external applications (can't test w/ js-adapter...)
- close window / ungroup unhandled
- needs more testing with various runtime options (3 runtimes that matter each call: called from, window 1, window 2)

Tests: 
[Win7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5ace55104ecc2a37d5a48452)
[Win10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5ace55804ecc2a37d5a48453)