### PR TITLE
RUN-4020 fixed Frame.getCurrent for iframes

### DIFF
--- a/src/browser/core_state.ts
+++ b/src/browser/core_state.ts
@@ -71,7 +71,7 @@ let startManifest = {};
 const manifests: Map <string, Shapes.Manifest> = new Map();
 
 // TODO: This needs to go go away, pending socket server refactor.
-let socketServerState = {};
+let socketServerState: PortInfo|{} = {};
 
 const manifestProxySettings: Shapes.ProxySettings = {
     proxyAddress: '',
@@ -551,7 +551,7 @@ export function setSocketServerState(state: PortInfo) {
 }
 
 //TODO: This needs to go go away, pending socket server refactor.
-export function getSocketServerState() {
+export function getSocketServerState(): PortInfo|{} {
     return socketServerState;
 }
 
@@ -719,19 +719,21 @@ export function getRoutingInfoByUuidFrame(uuid: string, frame: string) {
     }
 }
 
-export function getWindowInitialOptionSet(windowId: number): any {
-    const options = <any>getWindowOptionsById(windowId);
+export function getWindowInitialOptionSet(windowId: number): Shapes.WindowInitialOptionSet {
+    const ofWin = <Shapes.OpenFinWindow>getWinObjById(windowId);
+    const options = ofWin._options;
     const { uuid, name } = options;
     const entityInfo = getEntityInfo({ uuid, name });
     const elIPCConfig = {
         channels: electronIPC.channels
     };
-    const socketServerState = getSocketServerState();
+    const socketServerState = <PortInfo>getSocketServerState();
 
     return {
         options,
         entityInfo,
         elIPCConfig,
-        socketServerState
+        socketServerState,
+        frames: Array.from(ofWin.frames.values())
     };
 }

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -40,11 +40,18 @@ limitations under the License.
     let windowId;
     let webContentsId = 0;
 
-    const elIPCConfig = glbl.__startOptions.elIPCConfig;
-    const entityInfo = glbl.__startOptions.entityInfo;
-    const initialOptions = glbl.__startOptions.options;
-    const runtimeArguments = glbl.__startOptions.runtimeArguments;
-    const socketServerState = glbl.__startOptions.socketServerState;
+    const {
+        elIPCConfig,
+        options: initialOptions,
+        runtimeArguments,
+        socketServerState,
+        frames
+    } = glbl.__startOptions;
+
+    // The following will check whether it is an iframe and update
+    // entity information accordingly
+    const frameInfo = frames.find(e => e.frameRoutingId === renderFrameId);
+    const entityInfo = frameInfo || glbl.__startOptions.entityInfo;
 
     let getOpenerSuccessCallbackCalled = () => {
         customData.openerSuccessCalled = customData.openerSuccessCalled || false;

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import { PortInfo } from './browser/port_discovery';
+
 export interface Identity {
     uuid: string;
     name?: string;
@@ -336,4 +338,19 @@ export interface EventPayload {
     topic: string;
     uuid: string;
     name?: string;
+}
+
+export interface ElectronIpcChannels {
+    CORE_MESSAGE: string;
+    WINDOW_MESSAGE: string;
+}
+
+export interface WindowInitialOptionSet {
+    options: WindowOptions;
+    entityInfo: FrameInfo;
+    socketServerState: PortInfo;
+    frames: ChildFrameInfo[];
+    elIPCConfig: {
+        channels: ElectronIpcChannels
+    };
 }


### PR DESCRIPTION
ℹ️ This PR fixed regression with `Frame.getCurrent` for iframes

⛓ Chained with [this javascript-adapter PR](https://github.com/openfin/javascript-adapter/pull/419)

➕ New automated tests:
1. [Iframe: frame.getInfo](https://testing-dashboard.openfin.co/#/app/tests/5ad5feaa4ecc2a37d5a48471/edit)
2. [Iframe: frame.getInfo T2](https://testing-dashboard.openfin.co/#/app/tests/5ad600894ecc2a37d5a48472/edit)
3. [Iframe: Frame.getCurrent](https://testing-dashboard.openfin.co/#/app/tests/5ad5fe8f4ecc2a37d5a48470/edit)
4. [Iframe: Frame.getCurrent T2](https://testing-dashboard.openfin.co/#/app/tests/5ad603054ecc2a37d5a48473/edit)

✅ [Window 7 test results](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5ad60e1a4ecc2a37d5a48476)
✅ [Window 10 test results](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5ad60e9a4ecc2a37d5a48477)