### PR TITLE
Feature/RUN-3958 window.open with options

### DIFF
--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -463,8 +463,7 @@ limitations under the License.
         features = features.trim();
         let featuresObj = {};
         features.split(',').forEach(item => {
-            const splitItem = item.split('=');
-            const [name, value] = splitItem;
+            const [name, value] = item.split('=');
 
             switch (name) {
                 case 'height':

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -52,6 +52,7 @@ limitations under the License.
     // entity information accordingly
     const frameInfo = frames.find(e => e.frameRoutingId === renderFrameId);
     const entityInfo = frameInfo || glbl.__startOptions.entityInfo;
+    const decorateOpen = !runtimeArguments.includes('--native-window-open');
 
     let getOpenerSuccessCallbackCalled = () => {
         customData.openerSuccessCalled = customData.openerSuccessCalled || false;
@@ -327,7 +328,7 @@ limitations under the License.
     //extend open
     const originalOpen = global.open;
 
-    global.open = (...args) => {
+    function openChildWindow(...args) {
         const [url, requestedName, features = ''] = args; // jshint ignore:line
         const requestId = ++childWindowRequestId;
         const webContentsId = getWebContentsId();
@@ -346,7 +347,12 @@ limitations under the License.
             requestId, JSON.stringify(convertedOpts));
 
         return originalOpen(url, name, features);
-    };
+    }
+
+    //Only decorate global open if flag is not present.
+    if (decorateOpen) {
+        global.open = openChildWindow;
+    }
 
     function createChildWindow(options, cb) {
         let requestId = ++childWindowRequestId;

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -335,6 +335,7 @@ limitations under the License.
         const responseChannel = `${name}-created`;
 
         const options = Object.assign(featuresToOptionsObj(features), {
+            url,
             uuid: initialOptions.uuid,
             name: name,
             autoShow: true
@@ -470,7 +471,7 @@ limitations under the License.
                     featuresObj['defaultTop'] = +value;
                     break;
                 case 'left':
-                    featuresObj['defaultleft'] = +value;
+                    featuresObj['defaultLeft'] = +value;
                     break;
                 case 'centerscreen':
                     featuresObj['defaultCentered'] = featureToBool(value);

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -460,7 +460,7 @@ limitations under the License.
 
     //We need to do this as all values are text and convertToElectron does not handle type changes only name translation.
     function featuresToOptionsObj(features) {
-        features = features.trim();
+        features = features.split(' ').join('');
         let featuresObj = {};
         features.split(',').forEach(item => {
             const [name, value] = item.split('=');

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -337,13 +337,12 @@ limitations under the License.
         const options = Object.assign(featuresToOptionsObj(features), {
             uuid: initialOptions.uuid,
             name: name,
-            saveWindowState: false,
             autoShow: true
         });
 
         const convertedOpts = convertOptionsToElectronSync(options);
         ipc.send(renderFrameId, 'add-child-window-request', responseChannel, name, webContentsId,
-                 requestId, JSON.stringify(convertedOpts));
+            requestId, JSON.stringify(convertedOpts));
 
         return originalOpen(url, name, features);
     };

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -460,43 +460,35 @@ limitations under the License.
 
     //We need to do this as all values are text and convertToElectron does not handle type changes only name translation.
     function featuresToOptionsObj(features) {
-        features = features.split(' ').join('');
         let featuresObj = {};
-        features.split(',').forEach(item => {
+        features.split(' ').join('').split(',').map((item) => {
             const [name, value] = item.split('=');
-
             switch (name) {
+                /*jshint -W093 */
                 case 'height':
-                    featuresObj['defaultHeight'] = +value;
-                    break;
+                    return featuresObj['defaultHeight'] = +value;
                 case 'width':
-                    featuresObj['defaultWidth'] = +value;
-                    break;
+                    return featuresObj['defaultWidth'] = +value;
                 case 'top':
-                    featuresObj['defaultTop'] = +value;
-                    break;
+                    return featuresObj['defaultTop'] = +value;
                 case 'left':
-                    featuresObj['defaultLeft'] = +value;
-                    break;
+                    return featuresObj['defaultLeft'] = +value;
                 case 'centerscreen':
-                    featuresObj['defaultCentered'] = featureToBool(value);
-                    break;
+                    return featuresObj['defaultCentered'] = featureToBool(value);
                 case 'resizable':
-                    featuresObj[name] = featureToBool(value);
-                    break;
+                    return featuresObj[name] = featureToBool(value);
                 case 'chrome':
-                    featuresObj['frame'] = featureToBool(value);
-                    break;
+                    return featuresObj['frame'] = featureToBool(value);
                 case 'alwaysRaised':
-                    featuresObj['alwaysOnTop'] = featureToBool(value);
-                    break;
+                    return featuresObj['alwaysOnTop'] = featureToBool(value);
                 case 'minimizable':
-                    featuresObj[name] = featureToBool(value);
-                    break;
+                    return featuresObj[name] = featureToBool(value);
                 default:
-                    featuresObj[name] = value;
+                    return featuresObj[name] = value;
+                    /*jshint +W093 */
             }
         });
+
         return featuresObj;
     }
 


### PR DESCRIPTION
## Support for window.open with Features

### Features supported

We support a subset of [features as described by MDN](https://developer.mozilla.org/en-US/docs/Web/API/Window/open), features not supported are either not relevant to OpenFin windows or non standard. The list of features we support are:

* [height](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#height)
* [width](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#width)
* [top](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#top)
* [left](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#left)
* [centerscreen](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#centerscreen)
* [resizable](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#resizable)
* [chrome](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#chrome)
* [alwaysRaised](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#alwaysRaised)
* [minimizable](https://developer.mozilla.org/en-US/docs/Web/API/Window/open#minimizable)

### Window Names

We will try to use the Window name given to `window.open`, but if this uuid/name combo already exists we will generate a random name. This is suboptimal as the developer will get a different result without any prompt but we cannot produce an error as one of the use cases for this changeset is running code that is not OpenFin aware in the runtime and we cannot expect handling of failure at this stage.

### Flags

This behaviour will be on by default but can be turned off by a flag `--native-window-open`, similar to the [electron nativeWindowOpen option](https://github.com/electron/electron/blob/e73326a324b3e6998bad1517b98193be989b28ee/lib/renderer/window-setup.js#L117)

### Tests

[Win7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5ad73eee4ecc2a37d5a4848f)
[Win10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5ad73f4f4ecc2a37d5a48490)

I am writing new tests now.