### PR TITLE
RUN-3898 - Services for external applications

### DIFF
--- a/src/browser/api/service.ts
+++ b/src/browser/api/service.ts
@@ -53,22 +53,20 @@ export module Service {
         if (!serviceIdentity || serviceMap.get(serviceIdentity.uuid)) {
             return false;
         }
-        const { uuid, isExternal } = serviceIdentity;
-
         serviceIdentity.serviceName = serviceName;
+        const { uuid, isExternal, ...eventPayload } = serviceIdentity;
+
         serviceMap.set(uuid, serviceIdentity);
 
         // When service exits, remove from serviceMap
         const eventString = isExternal ? route.externalApplication('closed', uuid) : route.application('closed', uuid);
         ofEvents.once(eventString, () => {
             serviceMap.delete(uuid);
-            ofEvents.emit(route.service('disconnected', uuid), {
-                uuid,
-                name
-            });
+            ofEvents.emit(route.service('disconnected', uuid), eventPayload);
         });
 
-        ofEvents.emit(route.service('connected', uuid), { topic: 'service', type: 'connected', ...serviceIdentity });
+
+        ofEvents.emit(route.service('connected', uuid), eventPayload);
 
         // execute requests to connect for service that occured before service registration. Timeout ensures registration concludes first.
         setTimeout(() => {

--- a/src/browser/api/service.ts
+++ b/src/browser/api/service.ts
@@ -27,7 +27,7 @@ export module Service {
         const eventString = route.service(type, targetIdentity.uuid);
         ofEvents.on(eventString, listener);
 
-        return (): void => {
+        return () => {
             ofEvents.removeListener(eventString, listener);
         };
     }

--- a/src/browser/api_protocol/api_handlers/event_listener.js
+++ b/src/browser/api_protocol/api_handlers/event_listener.js
@@ -160,15 +160,14 @@ function EventListenerApiHandler() {
         'service': {
             name: 'service',
             subscribe: function(identity, type, payload, cb) {
-                const { uuid } = payload;
-                const serviceIdentity = apiProtocolBase.getTargetApplicationIdentity(payload);
-                const targetUuid = serviceIdentity.uuid;
-                const islocalApp = !!coreState.getWindowByUuidName(targetUuid, targetUuid);
-                const localUnsub = Service.addEventListener(serviceIdentity, type, cb);
+                const targetIdentity = apiProtocolBase.getTargetApplicationIdentity(payload);
+                const { uuid } = targetIdentity;
+                const islocalUuid = coreState.isLocalUuid(uuid);
+                const localUnsub = Service.addEventListener(targetIdentity, type, cb);
                 let remoteUnSub;
-                const isExternalClient = ExternalApplication.isRuntimeClient(identity.uuid);
+                const isExternalRuntime = ExternalApplication.isRuntimeClient(identity.uuid);
 
-                if (!islocalApp && !isExternalClient) {
+                if (!islocalUuid && !isExternalRuntime) {
                     const subscription = {
                         uuid,
                         listenType: 'on',

--- a/src/browser/api_protocol/api_handlers/mesh_middleware.ts
+++ b/src/browser/api_protocol/api_handlers/mesh_middleware.ts
@@ -20,8 +20,6 @@ import { default as connectionManager } from '../../connection_manager';
 import ofEvents from '../../of_events';
 import { isLocalUuid } from '../../core_state';
 
-const coreState = require('../../core_state');
-
 const SUBSCRIBE_ACTION = 'subscribe';
 const PUBLISH_ACTION = 'publish-message';
 const SEND_MESSAGE_ACTION = 'send-message';

--- a/src/browser/api_protocol/api_handlers/mesh_middleware.ts
+++ b/src/browser/api_protocol/api_handlers/mesh_middleware.ts
@@ -18,6 +18,7 @@ import { MessagePackage } from '../transport_strategy/api_transport_base';
 import * as log from '../../log';
 import { default as connectionManager } from '../../connection_manager';
 import ofEvents from '../../of_events';
+import { isLocalUuid } from '../../core_state';
 
 const coreState = require('../../core_state');
 
@@ -49,13 +50,6 @@ const subscriberTriggeredEvents: any = {
     'subscribe': true,
     'unsubscribe': true
 };
-
-function isLocalUuid(uuid: string): Boolean {
-    const externalConn = coreState.getExternalAppObjByUuid(uuid);
-    const app = coreState.getAppObjByUuid(uuid);
-
-    return externalConn || app ? true : false;
-}
 
 //on a InterAppBus subscribe/unsubscribe send a subscriber-added/subscriber-removed event.
 function subscriberEventMiddleware(msg: MessagePackage, next: () => void) {

--- a/src/browser/api_protocol/api_handlers/service.ts
+++ b/src/browser/api_protocol/api_handlers/service.ts
@@ -39,7 +39,8 @@ export class ServiceApiHandler {
 
         const serviceIdentity = Service.registerService(identity, serviceName);
         const dataAck = Object.assign({}, successAck, { data: serviceIdentity });
-        serviceIdentity ? ack(dataAck) : nack('Only one service may be registered per application/connection.');
+        const nackString = 'Register Failed: Please note that only one service may be registered per application.';
+        serviceIdentity ? ack(dataAck) : nack(nackString);
     }
 
 }

--- a/src/browser/api_protocol/api_handlers/service_middleware.ts
+++ b/src/browser/api_protocol/api_handlers/service_middleware.ts
@@ -60,7 +60,7 @@ function setTargetIdentity(identity: Identity, payload: any): TargetIdentity {
     if (payload.connectAction) {
         // If initial connection to a service, identity may exist but not be registered;
         const serviceIdentity = Service.getServiceByUuid(uuid);
-        const targetIdentity = serviceIdentity && getExternalOrOfWindowIdentity(payload);
+        const targetIdentity = serviceIdentity && getExternalOrOfWindowIdentity(serviceIdentity);
         return { targetIdentity, serviceIdentity };
     }
     // Sender could be service or client, want service Identity sent in payload either way

--- a/src/browser/core_state.ts
+++ b/src/browser/core_state.ts
@@ -119,6 +119,27 @@ export function getEntityInfo(identity: Shapes.Identity) {
     }
 }
 
+export function getExternalOrOfWindowIdentity(identity: Shapes.Identity): Shapes.ServiceIdentity|undefined {
+    const { uuid, name } = identity;
+    const externalConn = getExternalAppObjByUuid(uuid);
+    if (externalConn) {
+        return {...externalConn, isExternal: true };
+    }
+
+    const ofWindow = getWindowByUuidName(uuid, name);
+    const browserWindow = ofWindow && ofWindow.browserWindow;
+    if (browserWindow && !browserWindow.isDestroyed()) {
+        return { uuid, name, isExternal: false };
+    }
+}
+
+export function isLocalUuid(uuid: string): Boolean {
+    const externalConn = getExternalAppObjByUuid(uuid);
+    const app = getAppObjByUuid(uuid);
+
+    return externalConn || app ? true : false;
+}
+
 // Returns string on error
 export function setManifestProxySettings(proxySettings: ProxySettingsArgs): void|string {
 

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -22,10 +22,9 @@ export interface Identity {
     runtimeUuid?: string;
 }
 
-export interface ServiceIdentity {
-    uuid: string;
-    name?: string;
-    serviceName: string;
+export interface ServiceIdentity extends Identity {
+    serviceName?: string;
+    isExternal?: boolean;
 }
 
 export interface ResourceFetchIdentity extends Identity {


### PR DESCRIPTION
Js-adapter tests coming for services will cover testing. 

Tests: 
[Win7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5ad90b694ecc2a37d5a484c5)
[Win10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5ad90bd14ecc2a37d5a484c6)