### PR TITLE
RUN-4035 fixed bug that invoked un-subscription listener twice

### DIFF
--- a/src/browser/api/interappbus.js
+++ b/src/browser/api/interappbus.js
@@ -180,9 +180,6 @@ function subscribe(identity, payload, listener) {
     ofBus.on(keys.toWin, listener);
     ofBus.on(keys.toApp, listener);
 
-    // for the subscribe listeners:
-    //emitSubscriberAdded(identity, payload);
-
     //return a function that will unhook the listeners
     var unsubItem = {
         cbId,
@@ -190,8 +187,6 @@ function subscribe(identity, payload, listener) {
             ofBus.removeListener(keys.toAny, listener);
             ofBus.removeListener(keys.toWin, listener);
             ofBus.removeListener(keys.toApp, listener);
-
-            //emitSubscriberRemoved(identity, payload);
         }
     };
 

--- a/src/browser/api_protocol/api_handlers/interappbus.js
+++ b/src/browser/api_protocol/api_handlers/interappbus.js
@@ -55,8 +55,11 @@ function InterApplicationBusApiHandler() {
             subScriptionTypes.MESSAGE
         ];
 
-        InterApplicationBus.emitSubscriberRemoved(identity, payload);
         apiProtocolBase.removeSubscription(...subscriptionArgs);
+        if (apiProtocolBase.subscriptionExists(...subscriptionArgs)) {
+            //if it still has the subscription, it didn't emit subscriber removed event.
+            InterApplicationBus.emitSubscriberRemoved(identity, payload);
+        }
 
         ack(successAck);
     }


### PR DESCRIPTION
branched code from 8.56.30/staging instead.

✅ updated test results:
[Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5aded2374ecc2a37d5a484fa)
[Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5aded29c4ecc2a37d5a484fb)