### PR TITLE
RVM-621 Added the ability to close applications at the request of the RVM.

### DIFF
--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -119,7 +119,7 @@ electronApp.on('ready', function() {
             log.writeToLog('info', 'error processing RVM Request to close-app');
             log.writeToLog('info', err);
             rvmBus.sendCloseAppError(payload, err).catch(e => {
-                log.writeToLog('info', 'error sending close ap response to RVM');
+                log.writeToLog('info', 'error sending close app response to RVM');
                 log.writeToLog('info', err);
             });
         }

--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -105,6 +105,26 @@ electronApp.on('ready', function() {
         }
     });
 
+    // listen to and process close-app requests originating from the RVM.
+    rvmBus.on(route.rvmMessageBus('broadcast', 'application', 'close-app'), payload => {
+        try {
+            const { uuid } = payload;
+            log.writeToLog('info', `received an RVM request to close application with uuid ${uuid}`);
+            if (uuid) {
+                Application.close({ uuid }, true);
+                //we cannot wait for the callback here because of the shutdown sequence bug. also fire and forget mode.
+                rvmBus.sendCloseAppRequested(payload);
+            }
+        } catch (err) {
+            log.writeToLog('info', 'error processing RVM Request to close-app');
+            log.writeToLog('info', err);
+            rvmBus.sendCloseAppError(payload, err).catch(e => {
+                log.writeToLog('info', 'error sending close ap response to RVM');
+                log.writeToLog('info', err);
+            });
+        }
+    });
+
 });
 
 Application.create = function(opts, configUrl = '', parentIdentity = {}) {

--- a/src/browser/rvm/rvm_message_bus.ts
+++ b/src/browser/rvm/rvm_message_bus.ts
@@ -42,6 +42,7 @@ type relaunchOnCloseAction = 'relaunch-on-close';
 type getDesktopOwnerSettingsAction = 'get-desktop-owner-settings';
 type downloadRuntimeAction = 'runtime-download';
 
+
 export interface ApplicationLog extends RvmMsgBase {
     topic: applicationTopic;
     action: applicationLogAction;
@@ -102,6 +103,11 @@ interface DownloadRuntimeMsg extends RvmMsgBase {
     sourceUrl: string;
     action: downloadRuntimeAction;
 
+}
+
+export interface AppCloseRequestedOptions {
+    uuid: string;
+    sourceUrl: string;
 }
 
 // topic: application (used only by the utils module)
@@ -403,6 +409,42 @@ export class RVMMessageBus extends EventEmitter  {
             };
 
             this.publish(rvmMsg, resolve);
+        });
+    }
+
+    /**
+     * Confirms to the RVM that the close-app request has been processed.
+     */
+    public sendCloseAppRequested(opts: AppCloseRequestedOptions): Promise<RvmMsgBase> {
+        return new Promise((resolve, reject) => {
+            try {
+                const rvmMsg = {
+                    topic: 'application',
+                    action: 'close-app-requested',
+                    uuid: opts.uuid,
+                    sourceUrl: opts.sourceUrl
+                };
+                this.publish(rvmMsg, resolve);
+            } catch (err) {
+                reject(err);
+            }
+        });
+    }
+
+    public sendCloseAppError(opts: AppCloseRequestedOptions, err: Error): Promise<RvmMsgBase> {
+        return new Promise((resolve, reject) => {
+            try {
+                const rvmMsg = {
+                    topic: 'application',
+                    action: 'close-app-error',
+                    uuid: opts.uuid,
+                    sourceUrl: opts.sourceUrl,
+                    error: err.message
+                };
+                this.publish(rvmMsg, resolve);
+            } catch (err) {
+                reject(err);
+            }
         });
     }
 }


### PR DESCRIPTION
RVM now has the ability to request an app to be closed, this is related to Service life cycle.

Works relates to changes from @patpao on the RVM end.

Test results:
[Win 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5adfa2504ecc2a37d5a48506)
[Win 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5adfa2fa4ecc2a37d5a48508)