### PR TITLE
RUN-3988 mesh join group 1st cut

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -1418,7 +1418,6 @@ Window.leaveGroup = function(identity, locals) {
 Window.setWindowGroupUuid = function(identity, uuid) {
     const ofWindow = Window.wrap(identity.uuid, identity.name);
     Window.leaveGroup(identity);
-    // LEAVE GROUP HERE? 
     ofWindow.meshGroupUuid = uuid;
     return Window.getNativeId(identity);
 };

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -497,7 +497,6 @@ Window.create = function(id, opts) {
         browserWindow._options = _options;
 
         // set taskbar icon
-        // DOES THIS MESS UP OTHER EXTERNAL WINDOWS?
         if (!browserWindow.isExternalWindow()) {
             setTaskbar(browserWindow);
         }
@@ -1072,15 +1071,9 @@ Window.close = function(identity, force, callback = () => {}) {
 
     let defaultAction = () => {
         if (!browserWindow.isDestroyed()) {
-            const ofWindow = Window.wrap(identity.uuid, identity.name);
-            ofWindow.forceClose = true;
-
-            if (beforeWindowClose) {
-                beforeWindowClose().then(browserWindow.close);
-            } else {
-                browserWindow.close();
-            }
-
+            let openfinWindow = Window.wrap(identity.uuid, identity.name);
+            openfinWindow.forceClose = true;
+            browserWindow.close();
         }
     };
 
@@ -1408,10 +1401,6 @@ Window.isShowing = function(identity) {
     let browserWindow = getElectronBrowserWindow(identity);
 
     return !!(browserWindow && browserWindow.isVisible());
-};
-
-Window.setBeforeWindowClose = (fn) => {
-    beforeWindowClose = fn;
 };
 
 const meshJoinGroupEvents = (identity, grouping) => {

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -497,7 +497,7 @@ Window.create = function(id, opts) {
         browserWindow._options = _options;
 
         // set taskbar icon
-        if (!browserWindow.isExternalWindow()) {
+        if (!opts.meshJoinGroup) {
             setTaskbar(browserWindow);
         }
 

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -1412,73 +1412,105 @@ Window.isShowing = function(identity) {
 };
 
 const meshJoinGroupEvents = (identity, grouping) => {
-    const beginSubscription = {
-        uuid: grouping.uuid,
-        name: grouping.name,
-        listenType: 'on',
-        className: 'window',
-        eventName: 'begin-user-bounds-changed'
-    };
 
-    addRemoteSubscription(beginSubscription);
+    const initEvent = (event, other) => {
+        const subscription = {
+            uuid: grouping.uuid,
+            name: grouping.name,
+            listenType: 'on',
+            className: 'window',
+            eventName: event
+        }
+        addRemoteSubscription(subscription);
 
-    const endSubscription = {
-        uuid: grouping.uuid,
-        name: grouping.name,
-        listenType: 'on',
-        className: 'window',
-        eventName: 'end-user-bounds-changed'
-    };
+        const oldEvent = route.window(event, grouping.uuid, grouping.name);
+        const newEvent = route.externalWindow(other, identity.uuid, grouping.name);
 
-    addRemoteSubscription(endSubscription);
-    const changingSubscription = {
-        uuid: grouping.uuid,
-        name: grouping.name,
-        listenType: 'on',
-        className: 'window',
-        eventName: 'bounds-changing'
-    };
+        ofEvents.on(oldEvent, payload => {
+            const newPayload = Object.assign({}, payload);
+            newPayload.uuid = identity.uuid;
+            ofEvents.emit(newEvent, newPayload);
+        });
+    }
 
-    addRemoteSubscription(changingSubscription);
+    initEvent('begin-user-bounds-changed', 'begin-user-bounds-change');
+    initEvent('end-user-bounds-changed', 'end-user-bounds-change');
+    initEvent('bounds-changing', 'moving');
+    initEvent('bounds-changed', 'bounds-changed');
 
-    const changedSubscription = {
-        uuid: grouping.uuid,
-        name: grouping.name,
-        listenType: 'on',
-        className: 'window',
-        eventName: 'bounds-changed'
-    };
 
-    addRemoteSubscription(changedSubscription);
+    // do focus
 
-    const oldBegin = route.window('begin-user-bounds-changed', grouping.uuid, grouping.name);
-    const newBegin = route.externalWindow('begin-user-bounds-change', identity.uuid, grouping.name);
-    const oldEnd = route.window('end-user-bounds-changed', grouping.uuid, grouping.name);
-    const newEnd = route.externalWindow('end-user-bounds-change', identity.uuid, grouping.name);
-    const oldChanging = route.window('bounds-changing', grouping.uuid, grouping.name);
-    const newChanging = route.externalWindow('moving', identity.uuid, grouping.name);
-    const oldChanged = route.window('bounds-changed', grouping.uuid, grouping.name);
-    const newChanged = route.externalWindow('bounds-changed', identity.uuid, grouping.name);
-    ofEvents.on(oldBegin, payload => {
-        const newPayload = Object.assign({}, payload);
-        newPayload.uuid = identity.uuid;
-        ofEvents.emit(newBegin, newPayload);
-    });
-    ofEvents.on(oldEnd, payload => {
-        const newPayload = Object.assign({}, payload);
-        newPayload.uuid = identity.uuid;
-        ofEvents.emit(newEnd, newPayload);
-    });
-    ofEvents.on(oldChanging, payload => {
-        const newPayload = Object.assign({}, payload);
-        newPayload.uuid = identity.uuid;
-        ofEvents.emit(newChanging, newPayload);
-    });
-    ofEvents.on(oldChanged, payload => {
-        const newPayload = Object.assign({}, payload);
-        newPayload.uuid = identity.uuid;
-        ofEvents.emit(newChanged, newPayload);
-    });
+    // remove child by id (corestate) on close of parent
+
+
+    // const beginSubscription = {
+    //     uuid: grouping.uuid,
+    //     name: grouping.name,
+    //     listenType: 'on',
+    //     className: 'window',
+    //     eventName: 'begin-user-bounds-changed'
+    // };
+
+    // addRemoteSubscription(beginSubscription);
+
+    // const endSubscription = {
+    //     uuid: grouping.uuid,
+    //     name: grouping.name,
+    //     listenType: 'on',
+    //     className: 'window',
+    //     eventName: 'end-user-bounds-changed'
+    // };
+
+    // addRemoteSubscription(endSubscription);
+    // const changingSubscription = {
+    //     uuid: grouping.uuid,
+    //     name: grouping.name,
+    //     listenType: 'on',
+    //     className: 'window',
+    //     eventName: 'bounds-changing'
+    // };
+
+    // addRemoteSubscription(changingSubscription);
+
+    // const changedSubscription = {
+    //     uuid: grouping.uuid,
+    //     name: grouping.name,
+    //     listenType: 'on',
+    //     className: 'window',
+    //     eventName: 'bounds-changed'
+    // };
+
+    // addRemoteSubscription(changedSubscription);
+
+    // const oldBegin = route.window('begin-user-bounds-changed', grouping.uuid, grouping.name);
+    // const newBegin = route.externalWindow('begin-user-bounds-change', identity.uuid, grouping.name);
+    // const oldEnd = route.window('end-user-bounds-changed', grouping.uuid, grouping.name);
+    // const newEnd = route.externalWindow('end-user-bounds-change', identity.uuid, grouping.name);
+    // const oldChanging = route.window('bounds-changing', grouping.uuid, grouping.name);
+    // const newChanging = route.externalWindow('moving', identity.uuid, grouping.name);
+    // const oldChanged = route.window('bounds-changed', grouping.uuid, grouping.name);
+    // const newChanged = route.externalWindow('bounds-changed', identity.uuid, grouping.name);
+    // ofEvents.on(oldBegin, payload => {
+    //     const newPayload = Object.assign({}, payload);
+    //     newPayload.uuid = identity.uuid;
+    //     ofEvents.emit(newBegin, newPayload);
+    // });
+    // ofEvents.on(oldEnd, payload => {
+    //     const newPayload = Object.assign({}, payload);
+    //     newPayload.uuid = identity.uuid;
+    //     ofEvents.emit(newEnd, newPayload);
+    // });
+    // ofEvents.on(oldChanging, payload => {
+    //     const newPayload = Object.assign({}, payload);
+    //     newPayload.uuid = identity.uuid;
+    //     ofEvents.emit(newChanging, newPayload);
+    // });
+    // ofEvents.on(oldChanged, payload => {
+    //     const newPayload = Object.assign({}, payload);
+    //     newPayload.uuid = identity.uuid;
+    //     ofEvents.emit(newChanged, newPayload);
+    // });
 };
 
 Window.joinGroup = function(identity, grouping, locals) {

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -1255,12 +1255,6 @@ Window.getNativeId = function(identity) {
     return browserWindow.nativeId;
 };
 
-Window.setWindowGroupUuid = function(identity, uuid) {
-    const ofWindow = Window.wrap(identity.uuid, identity.name);
-    ofWindow.groupUuid = uuid;
-    return Window.getNativeId(identity);
-}
-
 Window.getNativeWindow = function() {};
 
 Window.getOptions = function(identity) {
@@ -1461,7 +1455,7 @@ Window.joinGroup = function(identity, grouping, locals) {
 
 Window.leaveGroup = function(identity, locals) {
     let openfinWindow;
-    if (locals) {
+    if (locals && typeof locals === 'object') {
         openfinWindow = Window.wrap(locals.uuid, locals.name);
     }
     openfinWindow = openfinWindow || Window.wrap(identity.uuid, identity.name);
@@ -1472,6 +1466,15 @@ Window.leaveGroup = function(identity, locals) {
     }
 
     WindowGroups.leaveGroup(openfinWindow);
+};
+
+
+Window.setWindowGroupUuid = function(identity, uuid) {
+    const ofWindow = Window.wrap(identity.uuid, identity.name);
+    // Window.leaveGroup(identity);
+    // LEAVE EXTERNAL GROUPS - EVENT?
+    ofWindow.meshGroupUuid = uuid;
+    return Window.getNativeId(identity);
 };
 
 

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -1420,7 +1420,7 @@ const meshJoinGroupEvents = (identity, grouping) => {
 
     Object.keys(eventMap).forEach(key => {
         const event = key;
-        const bwEvent = eventMap[key]
+        const bwEvent = eventMap[key];
 
         const subscription = {
             uuid: grouping.uuid,
@@ -1438,7 +1438,7 @@ const meshJoinGroupEvents = (identity, grouping) => {
             newPayload.uuid = identity.uuid;
             ofEvents.emit(newEvent, newPayload);
         });
-        
+
         unsubscriptions.push(addRemoteSubscription(subscription));
     });
 
@@ -1447,7 +1447,7 @@ const meshJoinGroupEvents = (identity, grouping) => {
         const childClose = route.externalWindow('close', grouping.uuid, grouping.name);
         ofEvents.on(externalClose, () => unsubs.forEach(unsub => unsub()));
         ofEvents.on(childClose, () => unsubs.forEach(unsub => unsub()));
-    })
+    });
 };
 
 Window.joinGroup = function(identity, grouping, locals) {

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -499,6 +499,8 @@ Window.create = function(id, opts) {
         // set taskbar icon
         if (!opts.meshJoinGroup) {
             setTaskbar(browserWindow);
+        } else {
+            _options.meshJoinGroup = true;
         }
 
         // apply options to browserWindow
@@ -1975,6 +1977,10 @@ function createWindowTearDown(identity, id) {
                         name: child.name,
                         uuid: child.uuid
                     };
+
+                    if (child._options.meshJoinGroup && child.browserWindow.isExternalWindow()) {
+                        browserWindow.setExternalWindowNativeId('0x0');
+                    }
 
                     Window.close(childIdentity, true, () => {
                         closedChildren++;

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -1374,73 +1374,16 @@ Window.isShowing = function(identity) {
     return !!(browserWindow && browserWindow.isVisible());
 };
 
-// const meshJoinGroupEvents = (identity, grouping) => {
-
-//     const unsubscriptions = [];
-//     const eventMap = {
-//         'begin-user-bounds-changed': 'begin-user-bounds-change',
-//         'end-user-bounds-changed': 'end-user-bounds-change',
-//         'bounds-changing': 'moving',
-//         'bounds-changed': 'bounds-changed',
-//         'focused': 'focus',
-//         'minimized': 'state-change',
-//         'maximized': 'state-change',
-//         'restored': 'state-change',
-//         'closed': 'close',
-//     };
-
-//     Object.keys(eventMap).forEach(key => {
-//         const event = key;
-//         const bwEvent = eventMap[key];
-
-//         const subscription = {
-//             uuid: grouping.uuid,
-//             name: grouping.name,
-//             listenType: 'on',
-//             className: 'window',
-//             eventName: event
-//         };
-
-//         const incomingEvent = route.window(event, grouping.uuid, grouping.name);
-//         const newEvent = route.externalWindow(bwEvent, identity.uuid, grouping.name);
-
-//         ofEvents.on(incomingEvent, payload => {
-//             const newPayload = Object.assign({}, payload);
-//             newPayload.uuid = identity.uuid;
-//             ofEvents.emit(newEvent, newPayload);
-//         });
-
-//         unsubscriptions.push(addRemoteSubscription(subscription));
-//     });
-
-//     Promise.all(unsubscriptions).then(unsubs => {
-//         const realWindowClose = route.window('closed', grouping.uuid, grouping.name);
-//         const externalWindowClose = route.externalWindow('close', identity.uuid, grouping.name);
-//         ofEvents.once(realWindowClose, () => unsubs.forEach(unsub => unsub()));
-//         ofEvents.once(externalWindowClose, () => unsubs.forEach(unsub => unsub()));
-//     });
-// };
-
 Window.joinGroup = function(identity, grouping, locals) {
     let identityOfWindow;
     let groupingOfWindow;
     if (locals) {
-        const { requester, hwnd, groupingHwnd } = locals;
+        const { hwnd, groupingHwnd } = locals;
         if (hwnd) {
-            if (typeof hwnd !== 'object') {
-                // meshJoinGroupEvents(requester, identity);
-                identityOfWindow = Window.wrap(requester.uuid, identity.name);
-            } else {
-                identityOfWindow = Window.wrap(hwnd.uuid, hwnd.name);
-            }
+            identityOfWindow = Window.wrap(hwnd.uuid, hwnd.name);
         }
         if (groupingHwnd) {
-            if (typeof groupingHwnd !== 'object') {
-                // meshJoinGroupEvents(requester, grouping);
-                groupingOfWindow = Window.wrap(requester.uuid, grouping.name);
-            } else {
-                groupingOfWindow = Window.wrap(groupingHwnd.uuid, groupingHwnd.name);
-            }
+            groupingOfWindow = Window.wrap(groupingHwnd.uuid, groupingHwnd.name);
         }
     }
     identityOfWindow = identityOfWindow || Window.wrap(identity.uuid, identity.name);
@@ -1474,8 +1417,8 @@ Window.leaveGroup = function(identity, locals) {
 
 Window.setWindowGroupUuid = function(identity, uuid) {
     const ofWindow = Window.wrap(identity.uuid, identity.name);
-    // Window.leaveGroup(identity);
-    // LEAVE EXTERNAL GROUPS - EVENT?
+    Window.leaveGroup(identity);
+    // LEAVE GROUP HERE? 
     ofWindow.meshGroupUuid = uuid;
     return Window.getNativeId(identity);
 };

--- a/src/browser/api_protocol/api_handlers/mesh_middleware.ts
+++ b/src/browser/api_protocol/api_handlers/mesh_middleware.ts
@@ -157,7 +157,8 @@ const handleExternalWindow = async (identity: Identity, toGroup: Identity) => {
         const childWindowOptions = {
             uuid: identity.uuid,
             name,
-            hwnd: hwnd.data
+            hwnd: hwnd.data,
+            meshJoinGroup: true
         };
         const parent = coreState.getWindowByUuidName(identity.uuid, identity.name);
         const parentId = parent && parent.browserWindow && parent.browserWindow.id;

--- a/src/browser/api_protocol/api_handlers/mesh_middleware.ts
+++ b/src/browser/api_protocol/api_handlers/mesh_middleware.ts
@@ -285,7 +285,9 @@ async function meshJoinWindowGroupMiddleware(msg: MessagePackage, next: (locals?
             // THE BELOW IS NOT CHANGING GROUPINGUUID.....
             // const message = {...data, groupingUuid: externalParentUuid, groupingWindowName: externalParentUuid };
             const message = {...data };
-            message.payload = {...message.payload, groupingUuid: externalParentUuid, groupingWindowName: externalParentUuid };
+            if (action !== 'leave-window-group') {
+                message.payload = {...message.payload, groupingUuid: externalParentUuid, groupingWindowName: externalParentUuid };
+            }
             id.runtime.fin.System.executeOnRemote({ uuid: externalParentUuid, name: externalParentUuid }, message)
             .then(ack)
             .catch(nack);

--- a/src/browser/api_protocol/api_handlers/mesh_middleware.ts
+++ b/src/browser/api_protocol/api_handlers/mesh_middleware.ts
@@ -18,14 +18,9 @@ import { MessagePackage } from '../transport_strategy/api_transport_base';
 import * as log from '../../log';
 import { default as connectionManager } from '../../connection_manager';
 import ofEvents from '../../of_events';
-import { Identity, OpenFinWindow } from '../../../shapes';
-import { BrowserWindow } from 'electron';
-import route from '../../../common/route';
-import { addRemoteSubscription } from '../../remote_subscriptions';
+import { meshJoinWindowGroupMiddleware } from './mesh_window_grouping';
 
-const { Window } = require('../../api/window');
 const coreState = require('../../core_state');
-const WindowGroup = require('../../window_groups.js');
 
 
 const SUBSCRIBE_ACTION = 'subscribe';
@@ -38,7 +33,6 @@ const apiMessagesToIgnore: any = {
     'send-message': true,
     'subscribe': true,
     'join-window-group': true,
-    // 'leave-window-group': true,
     'unsubscribe': true,
     'subscriber-added': true,
     'subscriber-removed': true,
@@ -136,198 +130,6 @@ function sendMessageMiddleware(msg: MessagePackage, next: () => void) {
         next();
     }
 }
-
-const meshJoinGroupEvents = (identity: Identity, grouping: Identity) => {
-
-    const unsubscriptions: any = [];
-    const localUnsubscriptions: any = [];
-    const eventMap: any = {
-        'begin-user-bounds-changed': 'begin-user-bounds-change',
-        'end-user-bounds-changed': 'end-user-bounds-change',
-        'bounds-changing': 'moving',
-        'bounds-changed': 'bounds-changed',
-        'focused': 'focus',
-        'minimized': 'state-change',
-        'maximized': 'state-change',
-        'restored': 'state-change',
-        'closed': 'close'
-    };
-
-    Object.keys(eventMap).forEach(key => {
-        const event = key;
-        const bwEvent = eventMap[key];
-
-        const subscription: any = {
-            uuid: grouping.uuid,
-            name: grouping.name,
-            listenType: 'on',
-            className: 'window',
-            eventName: event
-        };
-
-        const incomingEvent = route.window(event, grouping.uuid, grouping.name);
-        const newEvent = route.externalWindow(bwEvent, identity.uuid, grouping.name);
-
-        const internalListener = (payload: any) => {
-            const newPayload = Object.assign({}, payload);
-            newPayload.uuid = identity.uuid;
-            ofEvents.emit(newEvent, newPayload);
-        };
-
-        ofEvents.on(incomingEvent, internalListener);
-        localUnsubscriptions.push(() => ofEvents.removeListener(incomingEvent, internalListener));
-        unsubscriptions.push(addRemoteSubscription(subscription));
-    });
-
-    Promise.all(unsubscriptions).then((unsubs: any) => {
-        const externalWindowClose = route.externalWindow('close', identity.uuid, grouping.name);
-        ofEvents.on(externalWindowClose, () => {
-            unsubs.forEach((unsub: any) => unsub());
-            localUnsubscriptions.forEach((unsub: any) => unsub());
-        });
-    });
-};
-
-const handleExternalWindow = async (action: string, identity: Identity, toGroup: Identity): Promise<string|void| Identity> => {
-    const { uuid, name } = toGroup;
-    // ADD HASH TO NAME - return it to the other window to be stored in groupUuid as external/uuid/name
-    if (!uuid || isLocalUuid(uuid)) {
-        return;
-    }
-    const registeredWindow = WindowGroup.getMeshWindow(toGroup);
-    if (registeredWindow || action === 'leave-window-group') {
-        // External window already created and registered
-        return registeredWindow;
-    }
-    const getHwndMessage = {
-        action: 'set-mesh-group-uuid',
-        payload: {
-            uuid,
-            name,
-            meshGroupUuid: identity.uuid
-        }
-    };
-    const id = await connectionManager.resolveIdentity({uuid});
-    const hwnd = await id.runtime.fin.System.executeOnRemote(identity, getHwndMessage);
-
-    const childWindowOptions = {
-        uuid: identity.uuid,
-        name,
-        hwnd: hwnd.data,
-        meshJoinGroupIdentity: { uuid, name }
-    };
-    const parent = coreState.getWindowByUuidName(identity.uuid, identity.uuid);
-    const parentId = parent && parent.browserWindow && parent.browserWindow.id;
-    const childBw = new BrowserWindow(childWindowOptions);
-    const childId = childBw && childBw.id;
-
-    if (!coreState.addChildToWin(parentId, childId)) {
-        console.warn('failed to add child window');
-    }
-    Window.create(childId, childWindowOptions);
-
-    meshJoinGroupEvents(identity, toGroup);
-    WindowGroup.addMeshWindow(toGroup, childWindowOptions);
-
-    return hwnd.data;
-};
-
-const meshJoinWindowGroupMiddleware = async (msg: MessagePackage, next: (locals?: object) => void): Promise<void> => {
-    const { identity, data, ack, nack } = msg;
-    const payload = data && data.payload;
-    const action = data && data.action;
-    const isJoinWindowGroupAction = action === 'join-window-group' || action === 'leave-window-group';
-    const isValidIdentity = typeof (identity) === 'object';
-    const optInFlag = coreState.argo['mesh-join-group'];
-
-    if (!isJoinWindowGroupAction || !isValidIdentity || !optInFlag) {
-        next();
-        return;
-    }
-    // CHECK TO MAKE SURE WE ARE ON WINDOWS?
-    const window: Identity = {
-        uuid: payload.uuid,
-        name: payload.name
-    };
-    const grouping: Identity = {
-        uuid: payload.groupingUuid,
-        name: payload.groupingWindowName
-    };
-
-    // If grouping is not local, make sure window isnt in a group in it's own runtime
-    if (grouping.uuid && !isLocalUuid(grouping.uuid)) {
-        const getGroupMessage = {
-            action: 'get-window-group',
-            payload: grouping
-        };
-        const id = await connectionManager.resolveIdentity({uuid: grouping.uuid});
-        const windowGroupResponse = await id.runtime.fin.System.executeOnRemote(identity, getGroupMessage);
-        const windowGroup = windowGroupResponse && windowGroupResponse.data;
-        if (windowGroup && windowGroup.length) {
-            // If it is in a group in another RT - send to its own RT to execute
-            id.runtime.fin.System.executeOnRemote(grouping, data)
-            .then(ack)
-            .catch(nack);
-            return;
-        }
-    }
-
-    const handleExternallyGroupedLocalWindow = async (ofWindow: OpenFinWindow, msg: MessagePackage) => {
-        const externalParentUuid = ofWindow && ofWindow.meshGroupUuid;
-        const { data, ack, nack } = msg;
-        const action = data && data.action;
-
-        const id = await connectionManager.resolveIdentity({uuid: externalParentUuid});
-        const message = {...data };
-        if (action !== 'leave-window-group') {
-            message.payload = {...message.payload, groupingUuid: externalParentUuid, groupingWindowName: externalParentUuid };
-        }
-        id.runtime.fin.System.executeOnRemote({ uuid: externalParentUuid, name: externalParentUuid }, message)
-        .then(ack)
-        .catch(nack);
-        return;
-    };
-
-    // if local grouping window is in a group in another RT, handle in that runtime
-    const groupingOfWindow: OpenFinWindow|undefined = coreState.getWindowByUuidName(grouping.uuid, grouping.name);
-    if (groupingOfWindow && groupingOfWindow.meshGroupUuid) {
-        return await handleExternallyGroupedLocalWindow(groupingOfWindow, msg);
-    }
-    // if local window leaving group is in a group in another RT, handle in that runtime
-    if (action === 'leave-window-group') {
-        const ofWindow: OpenFinWindow|undefined = coreState.getWindowByUuidName(window.uuid, window.name);
-        if (ofWindow && ofWindow.meshGroupUuid) {
-            return await handleExternallyGroupedLocalWindow(ofWindow, msg);
-        }
-    }
-
-    let parentIdentity;
-    // If local grouping window is in a group locally, see if there are any external windows in the group
-    if (groupingOfWindow && groupingOfWindow.groupUuid) {
-        const targetGroup = Window.getGroup(grouping);
-
-        if (targetGroup && targetGroup.length) {
-            targetGroup.forEach((win: Identity) => {
-                // const ofWindow = coreState.getWindowByUuidName(grouping.uuid, grouping.name);
-                const ofWindow = coreState.getWindowByUuidName(win.uuid, win.name);
-                if (ofWindow._options.meshJoinGroupIdentity) {
-                    // there is an external window; delegate new window parent to same app
-                    parentIdentity = { uuid: ofWindow.uuid, name: ofWindow.uuid };
-                }
-            });
-        }
-    }
-    const locals: any = {};
-    parentIdentity = parentIdentity || identity;
-    try {
-        locals.hwnd = await handleExternalWindow(action, parentIdentity, window);
-        locals.groupingHwnd = await handleExternalWindow(action, parentIdentity, grouping);
-        next(locals);
-    } catch (err) {
-        log.writeToLog('info', err);
-        nack(err);
-    }
-};
 
 //on a non InterAppBus API call, forward the message to the runtime that owns the uuid.
 function ferryActionMiddleware(msg: MessagePackage, next: () => void) {

--- a/src/browser/api_protocol/api_handlers/mesh_middleware.ts
+++ b/src/browser/api_protocol/api_handlers/mesh_middleware.ts
@@ -182,8 +182,9 @@ async function meshJoinWindowGroupMiddleware(msg: MessagePackage, next: (locals?
     const action = data && data.action;
     const isJoinWindowGroupAction = action === 'join-window-group';
     const isValidIdentity = typeof (identity) === 'object';
+    const optInFlag = coreState.argo['mesh-join-group'];
 
-    if (!isJoinWindowGroupAction || !isValidIdentity) {
+    if (!isJoinWindowGroupAction || !isValidIdentity || !optInFlag) {
         next();
         return;
     }
@@ -285,4 +286,4 @@ function registerMiddleware (requestHandler: RequestHandler<MessagePackage>): vo
     requestHandler.addPreProcessor(aggregateFromExternalRuntime);
 }
 
-export { registerMiddleware, isLocalUuid };
+export { registerMiddleware };

--- a/src/browser/api_protocol/api_handlers/mesh_middleware.ts
+++ b/src/browser/api_protocol/api_handlers/mesh_middleware.ts
@@ -134,7 +134,7 @@ function sendMessageMiddleware(msg: MessagePackage, next: () => void) {
     }
 }
 
-const handleExternalWindow = async (identity: Identity, toGroup: Identity): Promise<string|void> => {
+const handleExternalWindow = async (identity: Identity, toGroup: Identity): Promise<string|void|Error> => {
     const { uuid, name } = toGroup;
     if (coreState.getWindowByUuidName(identity.uuid, name)) {
         // External window already created and registered

--- a/src/browser/api_protocol/api_handlers/mesh_middleware.ts
+++ b/src/browser/api_protocol/api_handlers/mesh_middleware.ts
@@ -134,7 +134,7 @@ function sendMessageMiddleware(msg: MessagePackage, next: () => void) {
     }
 }
 
-const handleExternalWindow = async (identity: Identity, toGroup: Identity) => {
+const handleExternalWindow = async (identity: Identity, toGroup: Identity): Promise<string|void> => {
     const { uuid, name } = toGroup;
     if (coreState.getWindowByUuidName(identity.uuid, name)) {
         // External window already created and registered
@@ -170,14 +170,14 @@ const handleExternalWindow = async (identity: Identity, toGroup: Identity) => {
         }
         Window.create(childId, childWindowOptions);
 
-        return hwnd;
+        return hwnd.data;
     } catch (e) {
         log.writeToLog('info', e);
         return e;
     }
 };
 
-async function meshJoinWindowGroupMiddleware(msg: MessagePackage, next: (locals?: object) => void) {
+async function meshJoinWindowGroupMiddleware(msg: MessagePackage, next: (locals?: object) => void): Promise<void> {
     const { identity, data, ack, nack } = msg;
     const payload = data && data.payload;
     const action = data && data.action;

--- a/src/browser/api_protocol/api_handlers/mesh_window_grouping.ts
+++ b/src/browser/api_protocol/api_handlers/mesh_window_grouping.ts
@@ -1,0 +1,239 @@
+/*
+Copyright 2018 OpenFin Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+import { default as RequestHandler } from '../transport_strategy/base_handler';
+import { MessagePackage } from '../transport_strategy/api_transport_base';
+import * as log from '../../log';
+import { default as connectionManager } from '../../connection_manager';
+import ofEvents from '../../of_events';
+import { Identity, OpenFinWindow, APIPayloadAck, EventPayload } from '../../../shapes';
+import { BrowserWindow } from 'electron';
+import route from '../../../common/route';
+import { addRemoteSubscription, RemoteSubscriptionProps } from '../../remote_subscriptions';
+
+const { Window } = require('../../api/window');
+const coreState = require('../../core_state');
+const WindowGroup = require('../../window_groups.js');
+
+
+const isLocalUuid = (uuid: string): Boolean => {
+    const externalConn = coreState.getExternalAppObjByUuid(uuid);
+    const app = coreState.getAppObjByUuid(uuid);
+
+    return externalConn || app ? true : false;
+};
+
+const handleExternallyGroupedLocalWindow = async (ofWindow: OpenFinWindow, msg: MessagePackage) => {
+    const externalParentUuid = ofWindow && ofWindow.meshGroupUuid;
+    const { data, ack, nack } = msg;
+    const action = data && data.action;
+
+    const id = await connectionManager.resolveIdentity({uuid: externalParentUuid});
+    const message = {...data };
+    if (action !== 'leave-window-group') {
+        message.payload = {...message.payload, groupingUuid: externalParentUuid, groupingWindowName: externalParentUuid };
+    }
+    id.runtime.fin.System.executeOnRemote({ uuid: externalParentUuid, name: externalParentUuid }, message)
+    .then(ack)
+    .catch(nack);
+    return;
+};
+
+const meshJoinGroupEvents = (identity: Identity, grouping: Identity): void => {
+    const unsubscriptions: (Promise<() => void>)[] = [];
+    const localUnsubscriptions: (() => void)[] = [];
+    const eventMap: any = {
+        'begin-user-bounds-changed': 'begin-user-bounds-change',
+        'end-user-bounds-changed': 'end-user-bounds-change',
+        'bounds-changing': 'moving',
+        'bounds-changed': 'bounds-changed',
+        'focused': 'focus',
+        'minimized': 'state-change',
+        'maximized': 'state-change',
+        'restored': 'state-change',
+        'closed': 'close'
+    };
+
+    Object.keys(eventMap).forEach(key => {
+        const event = key;
+        const bwEvent = eventMap[key];
+
+        const subscription: RemoteSubscriptionProps = {
+            uuid: grouping.uuid,
+            name: grouping.name,
+            listenType: 'on',
+            className: 'window',
+            eventName: event
+        };
+
+        const incomingEvent = route.window(event, grouping.uuid, grouping.name);
+        const newEvent = route.externalWindow(bwEvent, identity.uuid, grouping.name);
+
+        const internalListener = (payload: EventPayload) => {
+            const newPayload = Object.assign({}, payload);
+            newPayload.uuid = identity.uuid;
+            ofEvents.emit(newEvent, newPayload);
+        };
+
+        ofEvents.on(incomingEvent, internalListener);
+        localUnsubscriptions.push(() => ofEvents.removeListener(incomingEvent, internalListener));
+        unsubscriptions.push(addRemoteSubscription(subscription));
+    });
+
+    Promise.all(unsubscriptions).then(unsubs => {
+        const externalWindowClose = route.externalWindow('close', identity.uuid, grouping.name);
+        ofEvents.on(externalWindowClose, () => {
+            unsubs.forEach(unsub => unsub());
+            localUnsubscriptions.forEach(unsub => unsub());
+        });
+    });
+};
+
+// Sets meshGroupUuid on the window in the runtime of the target and returns the nativeId of the window
+const setMeshJoinGroup = async (parent: Identity, toGroup: Identity): Promise<APIPayloadAck> => {
+    const { uuid, name } = toGroup;
+    const parentUuid = parent && parent.uuid;
+
+    const meshJoinGroupMessage = {
+        action: 'set-mesh-group-uuid',
+        payload: {
+            uuid,
+            name,
+            meshGroupUuid: parentUuid
+        }
+    };
+    const id = await connectionManager.resolveIdentity({uuid});
+    return await id.runtime.fin.System.executeOnRemote({uuid, name}, meshJoinGroupMessage);
+};
+
+const handleExternalWindow = async (action: string, identity: Identity, toGroup: Identity): Promise<void|Identity> => {
+    const { uuid, name } = toGroup;
+    // ADD HASH TO NAME - return it to the other window to be stored in groupUuid as external/uuid/name
+    if (!uuid || isLocalUuid(uuid)) {
+        return;
+    }
+    const registeredWindow = WindowGroup.getMeshWindow(toGroup);
+    if (registeredWindow || action === 'leave-window-group') {
+        // External window already created and registered
+        return registeredWindow;
+    }
+
+    // below call sets meshGroupUuid on the runtime of the target and returns the nativeId of the window
+    const nativeIdResponse = await setMeshJoinGroup(identity, toGroup);
+
+    const childWindowOptions = {
+        uuid: identity.uuid,
+        name,
+        hwnd: nativeIdResponse.data,
+        meshJoinGroupIdentity: { uuid, name }
+    };
+    const parent = coreState.getWindowByUuidName(identity.uuid, identity.uuid);
+    const parentId = parent && parent.browserWindow && parent.browserWindow.id;
+    const childBw = new BrowserWindow(childWindowOptions);
+    const childId = childBw && childBw.id;
+
+    if (!coreState.addChildToWin(parentId, childId)) {
+        console.warn('failed to add child window');
+    }
+    Window.create(childId, childWindowOptions);
+
+    meshJoinGroupEvents(identity, toGroup);
+    WindowGroup.addMeshWindow(toGroup, childWindowOptions);
+
+    return childWindowOptions;
+};
+
+export const meshJoinWindowGroupMiddleware = async (msg: MessagePackage, next: (locals?: object) => void): Promise<void> => {
+    const { identity, data, ack, nack } = msg;
+    const payload = data && data.payload;
+    const action = data && data.action;
+    const isJoinWindowGroupAction = action === 'join-window-group' || action === 'leave-window-group';
+    const isValidIdentity = typeof (identity) === 'object';
+    const optInFlag = coreState.argo['mesh-join-group'];
+
+    if (!isJoinWindowGroupAction || !isValidIdentity || !optInFlag) {
+        next();
+        return;
+    }
+    // CHECK TO MAKE SURE WE ARE ON WINDOWS?
+    const window: Identity = {
+        uuid: payload.uuid,
+        name: payload.name
+    };
+    const grouping: Identity = {
+        uuid: payload.groupingUuid,
+        name: payload.groupingWindowName
+    };
+
+    // If grouping is not local, make sure target window isnt in a group in it's own runtime
+    if (grouping.uuid && !isLocalUuid(grouping.uuid)) {
+        const getGroupMessage = {
+            action: 'get-window-group',
+            payload: grouping
+        };
+        const id = await connectionManager.resolveIdentity({uuid: grouping.uuid});
+        const windowGroupResponse = await id.runtime.fin.System.executeOnRemote(identity, getGroupMessage);
+        const windowGroup = windowGroupResponse && windowGroupResponse.data;
+        if (windowGroup && windowGroup.length) {
+            // If it is in a group in another RT - send to its own RT to execute
+            id.runtime.fin.System.executeOnRemote(grouping, data)
+            .then(ack)
+            .catch(nack);
+            return;
+        }
+    }
+
+    // If local grouping window is in a group in another RT, handle in that runtime
+    const groupingOfWindow: OpenFinWindow|undefined = coreState.getWindowByUuidName(grouping.uuid, grouping.name);
+    if (groupingOfWindow && groupingOfWindow.meshGroupUuid) {
+        return await handleExternallyGroupedLocalWindow(groupingOfWindow, msg);
+    }
+
+    // If local window leaving group is in a group in another RT, handle in that runtime
+    if (action === 'leave-window-group') {
+        const ofWindow: OpenFinWindow|undefined = coreState.getWindowByUuidName(window.uuid, window.name);
+        if (ofWindow && ofWindow.meshGroupUuid) {
+            await handleExternallyGroupedLocalWindow(ofWindow, msg);
+            ofWindow.meshGroupUuid = null;
+            return;
+        }
+    }
+
+    let parentIdentity;
+    // If local grouping window is in a group locally, see if there are any external windows in the group
+    if (groupingOfWindow && groupingOfWindow.groupUuid) {
+        const targetGroup = Window.getGroup(grouping);
+        if (targetGroup && targetGroup.length) {
+            targetGroup.forEach((win: Identity) => {
+                // const ofWindow = coreState.getWindowByUuidName(grouping.uuid, grouping.name);
+                const ofWindow = coreState.getWindowByUuidName(win.uuid, win.name);
+                if (ofWindow._options.meshJoinGroupIdentity) {
+                    // there is an external window; delegate new window parent to same app
+                    parentIdentity = { uuid: ofWindow.uuid, name: ofWindow.uuid };
+                }
+            });
+        }
+    }
+    const locals: any = {};
+    parentIdentity = parentIdentity || identity;
+    try {
+        locals.hwnd = await handleExternalWindow(action, parentIdentity, window);
+        locals.groupingHwnd = await handleExternalWindow(action, parentIdentity, grouping);
+        next(locals);
+    } catch (err) {
+        log.writeToLog('info', err);
+        nack(err);
+    }
+};

--- a/src/browser/api_protocol/api_handlers/mesh_window_grouping.ts
+++ b/src/browser/api_protocol/api_handlers/mesh_window_grouping.ts
@@ -13,7 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-import { default as RequestHandler } from '../transport_strategy/base_handler';
 import { MessagePackage } from '../transport_strategy/api_transport_base';
 import * as log from '../../log';
 import { default as connectionManager } from '../../connection_manager';
@@ -120,7 +119,7 @@ const setMeshJoinGroup = async (parent: Identity, toGroup: Identity): Promise<AP
 
 const handleExternalWindow = async (action: string, identity: Identity, toGroup: Identity): Promise<void|Identity> => {
     const { uuid, name } = toGroup;
-    // ADD HASH TO NAME - return it to the other window to be stored in groupUuid as external/uuid/name
+
     if (!uuid || isLocalUuid(uuid)) {
         return;
     }
@@ -145,7 +144,7 @@ const handleExternalWindow = async (action: string, identity: Identity, toGroup:
     const childId = childBw && childBw.id;
 
     if (!coreState.addChildToWin(parentId, childId)) {
-        console.warn('failed to add child window');
+        log.writeToLog('info', 'failed to add child window');
     }
     Window.create(childId, childWindowOptions);
 
@@ -218,8 +217,8 @@ export const meshJoinWindowGroupMiddleware = async (msg: MessagePackage, next: (
         if (targetGroup && targetGroup.length) {
             targetGroup.forEach((win: Identity) => {
                 // const ofWindow = coreState.getWindowByUuidName(grouping.uuid, grouping.name);
-                const ofWindow = coreState.getWindowByUuidName(win.uuid, win.name);
-                if (ofWindow._options.meshJoinGroupIdentity) {
+                const ofWindow: OpenFinWindow|undefined = coreState.getWindowByUuidName(win.uuid, win.name);
+                if (ofWindow && ofWindow._options.meshJoinGroupIdentity) {
                     // there is an external window; delegate new window parent to same app
                     parentIdentity = { uuid: ofWindow.uuid, name: ofWindow.uuid };
                 }

--- a/src/browser/api_protocol/api_handlers/middleware_entity_existence.ts
+++ b/src/browser/api_protocol/api_handlers/middleware_entity_existence.ts
@@ -26,6 +26,7 @@ const apisToIgnore = new Set([
     'create-child-window',
     'is-application-running',
     'join-window-group',
+    'leave-window-group',
     //TODO: we do not check run for .NET, the adapter will create an application then run it without waiting for the ack.
     'run-application',
     // Window

--- a/src/browser/api_protocol/api_handlers/middleware_entity_existence.ts
+++ b/src/browser/api_protocol/api_handlers/middleware_entity_existence.ts
@@ -23,6 +23,7 @@ import { windowApiMap } from './window.js';
 const apisToIgnore = new Set([
     // Application
     'create-application',
+    'join-window-group',
     'create-child-window',
     'is-application-running',
     //TODO: we do not check run for .NET, the adapter will create an application then run it without waiting for the ack.

--- a/src/browser/api_protocol/api_handlers/middleware_entity_existence.ts
+++ b/src/browser/api_protocol/api_handlers/middleware_entity_existence.ts
@@ -23,9 +23,9 @@ import { windowApiMap } from './window.js';
 const apisToIgnore = new Set([
     // Application
     'create-application',
-    'join-window-group',
     'create-child-window',
     'is-application-running',
+    'join-window-group',
     //TODO: we do not check run for .NET, the adapter will create an application then run it without waiting for the ack.
     'run-application',
     // Window

--- a/src/browser/api_protocol/api_handlers/middleware_entity_existence.ts
+++ b/src/browser/api_protocol/api_handlers/middleware_entity_existence.ts
@@ -19,20 +19,24 @@ import { appByUuid, windowExists } from '../../core_state';
 import { applicationApiMap } from './application.js';
 import { MessagePackage } from '../transport_strategy/api_transport_base';
 import { windowApiMap } from './window.js';
+const coreState = require('../../core_state');
 
 const apisToIgnore = new Set([
     // Application
     'create-application',
     'create-child-window',
     'is-application-running',
-    'join-window-group',
-    'leave-window-group',
     //TODO: we do not check run for .NET, the adapter will create an application then run it without waiting for the ack.
     'run-application',
     // Window
     'window-exists',
     'window-is-notification-type'
 ]);
+
+if (coreState.argo && coreState.argo['mesh-join-group']) {
+    apisToIgnore.add('join-window-group');
+    apisToIgnore.add('leave-window-group');
+}
 
 /**
  * Verifies that API is called on applications and windows that exist,

--- a/src/browser/api_protocol/api_handlers/window.js
+++ b/src/browser/api_protocol/api_handlers/window.js
@@ -36,7 +36,6 @@ module.exports.windowApiMap = {
     'focus-window': focusWindow,
     'get-current-window-options': getCurrentWindowOptions,
     'get-all-frames': getAllFrames,
-    'get-hwnd': getHwnd,
     'get-window-bounds': getWindowBounds,
     'get-window-group': getWindowGroup,
     'get-window-info': getWindowInfo,
@@ -332,12 +331,6 @@ function hideWindow(identity, message, ack) {
 
     Window.hide(windowIdentity);
     ack(successAck);
-}
-
-function getHwnd(identity, message, ack) {
-    const { payload } = message;
-    const windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-    return Window.getHwnd(windowIdentity);
 }
 
 function getAllFrames(identity, message) {

--- a/src/browser/api_protocol/api_handlers/window.js
+++ b/src/browser/api_protocol/api_handlers/window.js
@@ -65,6 +65,7 @@ module.exports.windowApiMap = {
     'show-menu': showMenu,
     'show-window': showWindow,
     'set-foreground-window': setForegroundWindow,
+    'set-mesh-group-uuid': setMeshWindowGroupUuid,
     'set-window-bounds': setWindowBounds,
     'set-window-preload-state': setWindowPreloadState,
     'set-zoom-level': setZoomLevel,
@@ -393,7 +394,7 @@ function getWindowNativeId(identity, message, ack) {
 
 function setMeshWindowGroupUuid(identity, message, ack) {
     const { payload } = message;
-    const uuid = payload && payload.groupUuid;
+    const uuid = payload && payload.meshGroupUuid;
     const dataAck = _.clone(successAck);
     const windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
 

--- a/src/browser/api_protocol/api_handlers/window.js
+++ b/src/browser/api_protocol/api_handlers/window.js
@@ -309,7 +309,7 @@ function joinWindowGroup(identity, message, ack) {
     const windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
     const groupingIdentity = apiProtocolBase.getGroupingWindowIdentity(payload);
     const { locals } = message;
-    if (locals && locals.hwnd || locals.groupingHwnd) {
+    if (locals && (locals.hwnd || locals.groupingHwnd)) {
         locals.requester = identity;
     }
     Window.joinGroup(windowIdentity, groupingIdentity, locals);

--- a/src/browser/api_protocol/api_handlers/window.js
+++ b/src/browser/api_protocol/api_handlers/window.js
@@ -290,8 +290,10 @@ function maximizeWindow(identity, message, ack) {
 function leaveWindowGroup(identity, message, ack) {
     var payload = message.payload,
         windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
-
-    Window.leaveGroup(windowIdentity);
+    const { locals } = message;
+    //rename from hwnd
+    const hwnd = locals && locals.hwnd;
+    Window.leaveGroup(windowIdentity, hwnd);
     ack(successAck);
 }
 
@@ -386,6 +388,16 @@ function getWindowNativeId(identity, message, ack) {
         windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
 
     dataAck.data = Window.getNativeId(windowIdentity);
+    ack(dataAck);
+}
+
+function setMeshWindowGroupUuid(identity, message, ack) {
+    const { payload } = message;
+    const uuid = payload && payload.groupUuid;
+    const dataAck = _.clone(successAck);
+    const windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+
+    dataAck.data = Window.setWindowGroupUuid(windowIdentity, uuid);
     ack(dataAck);
 }
 

--- a/src/browser/api_protocol/api_handlers/window.js
+++ b/src/browser/api_protocol/api_handlers/window.js
@@ -309,7 +309,7 @@ function joinWindowGroup(identity, message, ack) {
         windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload),
         groupingIdentity = apiProtocolBase.getGroupingWindowIdentity(payload);
 
-    Window.joinGroup(windowIdentity, groupingIdentity);
+    Window.joinGroup(windowIdentity, groupingIdentity, payload.hwnd);
     ack(successAck);
 }
 

--- a/src/browser/api_protocol/api_handlers/window.js
+++ b/src/browser/api_protocol/api_handlers/window.js
@@ -299,10 +299,9 @@ function leaveWindowGroup(identity, message, ack) {
 }
 
 function joinWindowGroup(identity, message, ack) {
-    const payload = message.payload;
+    const { payload, locals } = message;
     const windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
     const groupingIdentity = apiProtocolBase.getGroupingWindowIdentity(payload);
-    const { locals } = message;
 
     Window.joinGroup(windowIdentity, groupingIdentity, locals);
     ack(successAck);

--- a/src/browser/api_protocol/api_handlers/window.js
+++ b/src/browser/api_protocol/api_handlers/window.js
@@ -36,6 +36,7 @@ module.exports.windowApiMap = {
     'focus-window': focusWindow,
     'get-current-window-options': getCurrentWindowOptions,
     'get-all-frames': getAllFrames,
+    'get-hwnd': getHwnd,
     'get-window-bounds': getWindowBounds,
     'get-window-group': getWindowGroup,
     'get-window-info': getWindowInfo,
@@ -305,11 +306,14 @@ function leaveWindowGroup(identity, message, ack) {
 }
 
 function joinWindowGroup(identity, message, ack) {
-    var payload = message.payload,
-        windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload),
-        groupingIdentity = apiProtocolBase.getGroupingWindowIdentity(payload);
-
-    Window.joinGroup(windowIdentity, groupingIdentity, payload.hwnd);
+    const payload = message.payload;
+    const windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+    const groupingIdentity = apiProtocolBase.getGroupingWindowIdentity(payload);
+    const { locals } = message;
+    if (locals && locals.hwnd || locals.groupingHwnd) {
+        locals.requester = identity;
+    }
+    Window.joinGroup(windowIdentity, groupingIdentity, locals);
     ack(successAck);
 }
 
@@ -330,6 +334,11 @@ function hideWindow(identity, message, ack) {
     ack(successAck);
 }
 
+function getHwnd(identity, message, ack) {
+    const { payload } = message;
+    const windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
+    return Window.getHwnd(windowIdentity);
+}
 
 function getAllFrames(identity, message) {
     const { payload } = message;

--- a/src/browser/api_protocol/api_handlers/window.js
+++ b/src/browser/api_protocol/api_handlers/window.js
@@ -303,9 +303,7 @@ function joinWindowGroup(identity, message, ack) {
     const windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
     const groupingIdentity = apiProtocolBase.getGroupingWindowIdentity(payload);
     const { locals } = message;
-    if (locals && (locals.hwnd || locals.groupingHwnd)) {
-        locals.requester = identity;
-    }
+
     Window.joinGroup(windowIdentity, groupingIdentity, locals);
     ack(successAck);
 }

--- a/src/browser/bounds_changed_state_tracker.js
+++ b/src/browser/bounds_changed_state_tracker.js
@@ -16,6 +16,7 @@ limitations under the License.
 /*
     src/browser/bounds_changed_state_tracker.js
  */
+import * as log from './log'
 
 let windowTransaction = require('electron').windowTransaction;
 
@@ -306,6 +307,7 @@ function BoundsChangedStateTracker(uuid, name, browserWindow) {
                     }
 
                     WindowGroups.getGroup(groupUuid).filter((win) => {
+                        log.writeToLog(1, `***** win name/uuid, name ${win.uuid} ${win.name} -  ${name}`, true);
                         win.browserWindow.bringToFront();
                         return win.name !== name;
                     }).forEach((win) => {

--- a/src/browser/bounds_changed_state_tracker.js
+++ b/src/browser/bounds_changed_state_tracker.js
@@ -465,9 +465,6 @@ function BoundsChangedStateTracker(uuid, name, browserWindow) {
 
                     if (groupLeader.type === 'api') {
                         handleBoundsChange(false, true);
-                        // if (ofWindow._options.meshJoinGroupIdentity) {
-
-                        // }
                     }
                 } else {
                     if (!animations.getAnimationHandler().hasWindow(browserWindow.id) && !isUserBoundsChangeActive()) {

--- a/src/browser/bounds_changed_state_tracker.js
+++ b/src/browser/bounds_changed_state_tracker.js
@@ -16,8 +16,6 @@ limitations under the License.
 /*
     src/browser/bounds_changed_state_tracker.js
  */
-import * as log from './log'
-
 let windowTransaction = require('electron').windowTransaction;
 
 let _ = require('underscore');
@@ -307,7 +305,6 @@ function BoundsChangedStateTracker(uuid, name, browserWindow) {
                     }
 
                     WindowGroups.getGroup(groupUuid).filter((win) => {
-                        log.writeToLog(1, `***** win name/uuid, name ${win.uuid} ${win.name} -  ${name}`, true);
                         win.browserWindow.bringToFront();
                         return win.name !== name;
                     }).forEach((win) => {

--- a/src/browser/bounds_changed_state_tracker.js
+++ b/src/browser/bounds_changed_state_tracker.js
@@ -456,6 +456,7 @@ function BoundsChangedStateTracker(uuid, name, browserWindow) {
 
                     if (groupLeader.type === 'api') {
                         handleBoundsChange(false, true);
+                        //TBD:  if external window, ignore next bounds changed
                     }
                 } else {
                     if (!animations.getAnimationHandler().hasWindow(browserWindow.id) && !isUserBoundsChangeActive()) {

--- a/src/browser/bounds_changed_state_tracker.js
+++ b/src/browser/bounds_changed_state_tracker.js
@@ -384,7 +384,6 @@ function BoundsChangedStateTracker(uuid, name, browserWindow) {
             sizeChanged = false;
             positionChanged = false;
         }
-        var ofWindow = coreState.getWindowByUuidName(uuid, name) || {};
 
         return dispatchedChange;
     };
@@ -466,9 +465,9 @@ function BoundsChangedStateTracker(uuid, name, browserWindow) {
 
                     if (groupLeader.type === 'api') {
                         handleBoundsChange(false, true);
-                        if (ofWindow._options.meshJoinGroupIdentity) {
+                        // if (ofWindow._options.meshJoinGroupIdentity) {
 
-                        }
+                        // }
                     }
                 } else {
                     if (!animations.getAnimationHandler().hasWindow(browserWindow.id) && !isUserBoundsChangeActive()) {

--- a/src/browser/external_window_event_adapter.js
+++ b/src/browser/external_window_event_adapter.js
@@ -142,7 +142,7 @@ class ExternalWindowEventAdapter {
                     browserWindow.emit('bounds-changed');
                 }
             }
-        }
+        };
 
         Object.keys(eventMap).forEach(key => {
             const eventString = route.externalWindow(key, uuid, name);
@@ -150,118 +150,7 @@ class ExternalWindowEventAdapter {
 
             ofEvents.on(eventString, listener);
             unsubscriptions.push(() => ofEvents.removeListener(eventString, listener));
-        })
-        // ofEvents.on(route.externalWindow('focus', uuid, name), () => {
-        //     if (!browserWindow.isDestroyed()) {
-        //         browserWindow.emit('focus');
-        //     }
-        // });
-
-        // ofEvents.on(route.externalWindow('blur', uuid, name), () => {
-        //     browserWindow.emit('blur');
-        // });
-
-        // ofEvents.on(route.externalWindow('state-change', uuid, name), () => {
-        //     let prevState = cachedState || 'normal';
-
-        //     let currState = 'normal';
-        //     if (browserWindow.isMinimized()) {
-        //         currState = 'minimized';
-        //     } else if (browserWindow.isMaximized()) {
-        //         currState = 'maximized';
-        //     }
-
-        //     if (prevState !== currState) {
-        //         if (currState === 'minimized') {
-        //             browserWindow.emit('minimize');
-        //         } else if (currState === 'maximized') {
-        //             browserWindow.emit('maximize');
-        //         } else {
-        //             browserWindow.emit('restore');
-        //         }
-
-        //         cachedState = currState;
-        //     }
-        // });
-
-        // ofEvents.on(route.externalWindow('bounds-changed', uuid, name), () => {
-        //     browserWindow.emit('bounds-changed');
-        // });
-
-        // ofEvents.on(route.externalWindow('visibility-changed', uuid, name), (visibility) => {
-        //     browserWindow.emit('visibility-changed', {}, visibility);
-        // });
-
-        // ofEvents.on(route.externalWindow('begin-user-bounds-change', uuid, name), (coordinates) => {
-        //     if (!disabledFrameState.leftButtonDown && !browserWindow.isUserMovementEnabled()) {
-        //         // left mouse button is now in the down position
-        //         disabledFrameState.leftButtonDown = true;
-        //         // get current cursor position
-        //         disabledFrameState.cursorStart = {
-        //             x: coordinates.x, // todo: may need to convert screen to dpi
-        //             y: coordinates.y
-        //         };
-        //         // save the disabled frame's previous cursor position
-        //         disabledFrameState.cursorPrev = disabledFrameState.cursorStart;
-        //         // save the disabled frame's initial bounds
-        //         disabledFrameState.boundsStart = browserWindow.getBounds();
-        //     }
-        //     browserWindow.emit('begin-user-bounds-change');
-        // });
-
-        // ofEvents.on(route.externalWindow('end-user-bounds-change', uuid, name), () => {
-        //     if (disabledFrameState.leftButtonDown) {
-        //         if (disabledFrameState.changeType !== -1) {
-        //             browserWindow.emit('disabled-frame-bounds-changed', {}, browserWindow.getBounds(), disabledFrameState.changeType);
-        //         }
-
-        //         // reset
-        //         disabledFrameState.leftButtonDown = false;
-        //         disabledFrameState.changeType = -1;
-        //     }
-        //     browserWindow.emit('end-user-bounds-change');
-        // });
-
-        // ofEvents.on(route.externalWindow('sizing', uuid, name), (bounds) => {
-        //     if (disabledFrameState.leftButtonDown) {
-        //         // check if the position has also changed by checking whether the origins match up
-        //         if (disabledFrameState.changeType !== 2) {
-        //             let xDelta = bounds.x !== disabledFrameState.boundsStart.x;
-        //             let yDelta = bounds.y !== disabledFrameState.boundsStart.y;
-        //             disabledFrameState.changeType = xDelta || yDelta ? 2 : 1;
-        //         }
-
-        //         browserWindow.emit('disabled-frame-bounds-changing', {}, bounds, disabledFrameState.changeType);
-        //     }
-        // });
-
-        // ofEvents.on(route.externalWindow('moving', uuid, name), () => {
-        //     if (disabledFrameState.leftButtonDown) {
-        //         let bounds = browserWindow.getBounds();
-        //         let mousePosition = MonitorInfo.getMousePosition();
-        //         let cursorCurr = {
-        //             x: mousePosition.left,
-        //             y: mousePosition.top
-        //         };
-
-        //         disabledFrameState.changeType = 0;
-
-        //         // get the cursor delta
-        //         let xCursorDelta = cursorCurr.x - disabledFrameState.cursorPrev.x;
-        //         let yCursorDelta = cursorCurr.y - disabledFrameState.cursorPrev.y;
-
-        //         if (xCursorDelta !== 0 || yCursorDelta !== 0) {
-        //             bounds.x = (cursorCurr.x - disabledFrameState.cursorStart.x) + disabledFrameState.boundsStart.x;
-        //             bounds.y = (cursorCurr.y - disabledFrameState.cursorStart.y) + disabledFrameState.boundsStart.y;
-
-        //             browserWindow.emit('disabled-frame-bounds-changing', {}, bounds, disabledFrameState.changeType);
-
-        //             disabledFrameState.cursorPrev = cursorCurr;
-        //         }
-        //     } else {
-        //         browserWindow.emit('bounds-changed');
-        //     }
-        // });
+        });
 
         ofEvents.once(route.externalWindow('close', uuid, name), () => {
             if (!browserWindow.isDestroyed()) {

--- a/src/browser/external_window_event_adapter.js
+++ b/src/browser/external_window_event_adapter.js
@@ -22,9 +22,6 @@ electronApp.on('ready', () => {
 });
 import route from '../common/route';
 
-
-import * as log from './log'
-
 class ExternalWindowEventAdapter {
     constructor(browserWindow) {
         let options = browserWindow && browserWindow._options;
@@ -123,7 +120,6 @@ class ExternalWindowEventAdapter {
         });
 
         ofEvents.on(route.externalWindow('moving', uuid, name), () => {
-            log.writeToLog(1, `**** in moving - lbd ${disabledFrameState.leftButtonDown}`, true);
             if (disabledFrameState.leftButtonDown) {
                 let bounds = browserWindow.getBounds();
                 let mousePosition = MonitorInfo.getMousePosition();
@@ -141,8 +137,6 @@ class ExternalWindowEventAdapter {
                 if (xCursorDelta !== 0 || yCursorDelta !== 0) {
                     bounds.x = (cursorCurr.x - disabledFrameState.cursorStart.x) + disabledFrameState.boundsStart.x;
                     bounds.y = (cursorCurr.y - disabledFrameState.cursorStart.y) + disabledFrameState.boundsStart.y;
-
-                    log.writeToLog(1, `**** in moving ${JSON.stringify(bounds, undefined, 4)}`, true);
 
                     browserWindow.emit('disabled-frame-bounds-changing', {}, bounds, disabledFrameState.changeType);
 

--- a/src/browser/external_window_event_adapter.js
+++ b/src/browser/external_window_event_adapter.js
@@ -17,6 +17,7 @@ let ofEvents = require('./of_events.js').default;
 let electronApp = require('electron').app;
 
 let MonitorInfo;
+const unsubscriptions = [];
 electronApp.on('ready', () => {
     MonitorInfo = require('./monitor_info.js');
 });
@@ -37,124 +38,238 @@ class ExternalWindowEventAdapter {
 
         let cachedState = null;
 
-        ofEvents.on(route.externalWindow('focus', uuid, name), () => {
-            if (!browserWindow.isDestroyed()) {
-                browserWindow.emit('focus');
-            }
-        });
+        const eventMap = {
+            'focus': () => {
+                if (!browserWindow.isDestroyed()) {
+                    browserWindow.emit('focus');
+                }
+            },
+            'blur': () => {
+                browserWindow.emit('blur');
+            },
+            'state-change': () => {
+                let prevState = cachedState || 'normal';
 
-        ofEvents.on(route.externalWindow('blur', uuid, name), () => {
-            browserWindow.emit('blur');
-        });
-
-        ofEvents.on(route.externalWindow('state-change', uuid, name), () => {
-            let prevState = cachedState || 'normal';
-
-            let currState = 'normal';
-            if (browserWindow.isMinimized()) {
-                currState = 'minimized';
-            } else if (browserWindow.isMaximized()) {
-                currState = 'maximized';
-            }
-
-            if (prevState !== currState) {
-                if (currState === 'minimized') {
-                    browserWindow.emit('minimize');
-                } else if (currState === 'maximized') {
-                    browserWindow.emit('maximize');
-                } else {
-                    browserWindow.emit('restore');
+                let currState = 'normal';
+                if (browserWindow.isMinimized()) {
+                    currState = 'minimized';
+                } else if (browserWindow.isMaximized()) {
+                    currState = 'maximized';
                 }
 
-                cachedState = currState;
-            }
-        });
+                if (prevState !== currState) {
+                    if (currState === 'minimized') {
+                        browserWindow.emit('minimize');
+                    } else if (currState === 'maximized') {
+                        browserWindow.emit('maximize');
+                    } else {
+                        browserWindow.emit('restore');
+                    }
 
-        ofEvents.on(route.externalWindow('bounds-changed', uuid, name), () => {
-            browserWindow.emit('bounds-changed');
-        });
-
-        ofEvents.on(route.externalWindow('visibility-changed', uuid, name), (visibility) => {
-            browserWindow.emit('visibility-changed', {}, visibility);
-        });
-
-        ofEvents.on(route.externalWindow('begin-user-bounds-change', uuid, name), (coordinates) => {
-            if (!disabledFrameState.leftButtonDown && !browserWindow.isUserMovementEnabled()) {
-                // left mouse button is now in the down position
-                disabledFrameState.leftButtonDown = true;
-                // get current cursor position
-                disabledFrameState.cursorStart = {
-                    x: coordinates.x, // todo: may need to convert screen to dpi
-                    y: coordinates.y
-                };
-                // save the disabled frame's previous cursor position
-                disabledFrameState.cursorPrev = disabledFrameState.cursorStart;
-                // save the disabled frame's initial bounds
-                disabledFrameState.boundsStart = browserWindow.getBounds();
-            }
-            browserWindow.emit('begin-user-bounds-change');
-        });
-
-        ofEvents.on(route.externalWindow('end-user-bounds-change', uuid, name), () => {
-            if (disabledFrameState.leftButtonDown) {
-                if (disabledFrameState.changeType !== -1) {
-                    browserWindow.emit('disabled-frame-bounds-changed', {}, browserWindow.getBounds(), disabledFrameState.changeType);
+                    cachedState = currState;
                 }
-
-                // reset
-                disabledFrameState.leftButtonDown = false;
-                disabledFrameState.changeType = -1;
-            }
-            browserWindow.emit('end-user-bounds-change');
-        });
-
-        ofEvents.on(route.externalWindow('sizing', uuid, name), (bounds) => {
-            if (disabledFrameState.leftButtonDown) {
-                // check if the position has also changed by checking whether the origins match up
-                if (disabledFrameState.changeType !== 2) {
-                    let xDelta = bounds.x !== disabledFrameState.boundsStart.x;
-                    let yDelta = bounds.y !== disabledFrameState.boundsStart.y;
-                    disabledFrameState.changeType = xDelta || yDelta ? 2 : 1;
+            },
+            'bounds-changed': () => {
+                browserWindow.emit('bounds-changed');
+            },
+            'visibility-changed': (visibility) => {
+                browserWindow.emit('visibility-changed', {}, visibility);
+            },
+            'begin-user-bounds-change': (coordinates) => {
+                if (!disabledFrameState.leftButtonDown && !browserWindow.isUserMovementEnabled()) {
+                    // left mouse button is now in the down position
+                    disabledFrameState.leftButtonDown = true;
+                    // get current cursor position
+                    disabledFrameState.cursorStart = {
+                        x: coordinates.x, // todo: may need to convert screen to dpi
+                        y: coordinates.y
+                    };
+                    // save the disabled frame's previous cursor position
+                    disabledFrameState.cursorPrev = disabledFrameState.cursorStart;
+                    // save the disabled frame's initial bounds
+                    disabledFrameState.boundsStart = browserWindow.getBounds();
                 }
+                browserWindow.emit('begin-user-bounds-change');
+            },
+            'end-user-bounds-change': () => {
+                if (disabledFrameState.leftButtonDown) {
+                    if (disabledFrameState.changeType !== -1) {
+                        browserWindow.emit('disabled-frame-bounds-changed', {}, browserWindow.getBounds(), disabledFrameState.changeType);
+                    }
 
-                browserWindow.emit('disabled-frame-bounds-changing', {}, bounds, disabledFrameState.changeType);
-            }
-        });
-
-        ofEvents.on(route.externalWindow('moving', uuid, name), () => {
-            if (disabledFrameState.leftButtonDown) {
-                let bounds = browserWindow.getBounds();
-                let mousePosition = MonitorInfo.getMousePosition();
-                let cursorCurr = {
-                    x: mousePosition.left,
-                    y: mousePosition.top
-                };
-
-                disabledFrameState.changeType = 0;
-
-                // get the cursor delta
-                let xCursorDelta = cursorCurr.x - disabledFrameState.cursorPrev.x;
-                let yCursorDelta = cursorCurr.y - disabledFrameState.cursorPrev.y;
-
-                if (xCursorDelta !== 0 || yCursorDelta !== 0) {
-                    bounds.x = (cursorCurr.x - disabledFrameState.cursorStart.x) + disabledFrameState.boundsStart.x;
-                    bounds.y = (cursorCurr.y - disabledFrameState.cursorStart.y) + disabledFrameState.boundsStart.y;
+                    // reset
+                    disabledFrameState.leftButtonDown = false;
+                    disabledFrameState.changeType = -1;
+                }
+                browserWindow.emit('end-user-bounds-change');
+            },
+            'sizing': (bounds) => {
+                if (disabledFrameState.leftButtonDown) {
+                    // check if the position has also changed by checking whether the origins match up
+                    if (disabledFrameState.changeType !== 2) {
+                        let xDelta = bounds.x !== disabledFrameState.boundsStart.x;
+                        let yDelta = bounds.y !== disabledFrameState.boundsStart.y;
+                        disabledFrameState.changeType = xDelta || yDelta ? 2 : 1;
+                    }
 
                     browserWindow.emit('disabled-frame-bounds-changing', {}, bounds, disabledFrameState.changeType);
-
-                    disabledFrameState.cursorPrev = cursorCurr;
                 }
-            } else {
-                browserWindow.emit('bounds-changed');
-            }
-        });
+            },
+            'moving': () => {
+                if (disabledFrameState.leftButtonDown) {
+                    let bounds = browserWindow.getBounds();
+                    let mousePosition = MonitorInfo.getMousePosition();
+                    let cursorCurr = {
+                        x: mousePosition.left,
+                        y: mousePosition.top
+                    };
 
-        ofEvents.on(route.externalWindow('close', uuid, name), () => {
+                    disabledFrameState.changeType = 0;
+
+                    // get the cursor delta
+                    let xCursorDelta = cursorCurr.x - disabledFrameState.cursorPrev.x;
+                    let yCursorDelta = cursorCurr.y - disabledFrameState.cursorPrev.y;
+
+                    if (xCursorDelta !== 0 || yCursorDelta !== 0) {
+                        bounds.x = (cursorCurr.x - disabledFrameState.cursorStart.x) + disabledFrameState.boundsStart.x;
+                        bounds.y = (cursorCurr.y - disabledFrameState.cursorStart.y) + disabledFrameState.boundsStart.y;
+
+                        browserWindow.emit('disabled-frame-bounds-changing', {}, bounds, disabledFrameState.changeType);
+
+                        disabledFrameState.cursorPrev = cursorCurr;
+                    }
+                } else {
+                    browserWindow.emit('bounds-changed');
+                }
+            }
+        }
+
+        Object.keys(eventMap).forEach(key => {
+            const eventString = route.externalWindow(key, uuid, name);
+            const listener = eventMap[key];
+
+            ofEvents.on(eventString, listener);
+            unsubscriptions.push(() => ofEvents.removeListener(eventString, listener));
+        })
+        // ofEvents.on(route.externalWindow('focus', uuid, name), () => {
+        //     if (!browserWindow.isDestroyed()) {
+        //         browserWindow.emit('focus');
+        //     }
+        // });
+
+        // ofEvents.on(route.externalWindow('blur', uuid, name), () => {
+        //     browserWindow.emit('blur');
+        // });
+
+        // ofEvents.on(route.externalWindow('state-change', uuid, name), () => {
+        //     let prevState = cachedState || 'normal';
+
+        //     let currState = 'normal';
+        //     if (browserWindow.isMinimized()) {
+        //         currState = 'minimized';
+        //     } else if (browserWindow.isMaximized()) {
+        //         currState = 'maximized';
+        //     }
+
+        //     if (prevState !== currState) {
+        //         if (currState === 'minimized') {
+        //             browserWindow.emit('minimize');
+        //         } else if (currState === 'maximized') {
+        //             browserWindow.emit('maximize');
+        //         } else {
+        //             browserWindow.emit('restore');
+        //         }
+
+        //         cachedState = currState;
+        //     }
+        // });
+
+        // ofEvents.on(route.externalWindow('bounds-changed', uuid, name), () => {
+        //     browserWindow.emit('bounds-changed');
+        // });
+
+        // ofEvents.on(route.externalWindow('visibility-changed', uuid, name), (visibility) => {
+        //     browserWindow.emit('visibility-changed', {}, visibility);
+        // });
+
+        // ofEvents.on(route.externalWindow('begin-user-bounds-change', uuid, name), (coordinates) => {
+        //     if (!disabledFrameState.leftButtonDown && !browserWindow.isUserMovementEnabled()) {
+        //         // left mouse button is now in the down position
+        //         disabledFrameState.leftButtonDown = true;
+        //         // get current cursor position
+        //         disabledFrameState.cursorStart = {
+        //             x: coordinates.x, // todo: may need to convert screen to dpi
+        //             y: coordinates.y
+        //         };
+        //         // save the disabled frame's previous cursor position
+        //         disabledFrameState.cursorPrev = disabledFrameState.cursorStart;
+        //         // save the disabled frame's initial bounds
+        //         disabledFrameState.boundsStart = browserWindow.getBounds();
+        //     }
+        //     browserWindow.emit('begin-user-bounds-change');
+        // });
+
+        // ofEvents.on(route.externalWindow('end-user-bounds-change', uuid, name), () => {
+        //     if (disabledFrameState.leftButtonDown) {
+        //         if (disabledFrameState.changeType !== -1) {
+        //             browserWindow.emit('disabled-frame-bounds-changed', {}, browserWindow.getBounds(), disabledFrameState.changeType);
+        //         }
+
+        //         // reset
+        //         disabledFrameState.leftButtonDown = false;
+        //         disabledFrameState.changeType = -1;
+        //     }
+        //     browserWindow.emit('end-user-bounds-change');
+        // });
+
+        // ofEvents.on(route.externalWindow('sizing', uuid, name), (bounds) => {
+        //     if (disabledFrameState.leftButtonDown) {
+        //         // check if the position has also changed by checking whether the origins match up
+        //         if (disabledFrameState.changeType !== 2) {
+        //             let xDelta = bounds.x !== disabledFrameState.boundsStart.x;
+        //             let yDelta = bounds.y !== disabledFrameState.boundsStart.y;
+        //             disabledFrameState.changeType = xDelta || yDelta ? 2 : 1;
+        //         }
+
+        //         browserWindow.emit('disabled-frame-bounds-changing', {}, bounds, disabledFrameState.changeType);
+        //     }
+        // });
+
+        // ofEvents.on(route.externalWindow('moving', uuid, name), () => {
+        //     if (disabledFrameState.leftButtonDown) {
+        //         let bounds = browserWindow.getBounds();
+        //         let mousePosition = MonitorInfo.getMousePosition();
+        //         let cursorCurr = {
+        //             x: mousePosition.left,
+        //             y: mousePosition.top
+        //         };
+
+        //         disabledFrameState.changeType = 0;
+
+        //         // get the cursor delta
+        //         let xCursorDelta = cursorCurr.x - disabledFrameState.cursorPrev.x;
+        //         let yCursorDelta = cursorCurr.y - disabledFrameState.cursorPrev.y;
+
+        //         if (xCursorDelta !== 0 || yCursorDelta !== 0) {
+        //             bounds.x = (cursorCurr.x - disabledFrameState.cursorStart.x) + disabledFrameState.boundsStart.x;
+        //             bounds.y = (cursorCurr.y - disabledFrameState.cursorStart.y) + disabledFrameState.boundsStart.y;
+
+        //             browserWindow.emit('disabled-frame-bounds-changing', {}, bounds, disabledFrameState.changeType);
+
+        //             disabledFrameState.cursorPrev = cursorCurr;
+        //         }
+        //     } else {
+        //         browserWindow.emit('bounds-changed');
+        //     }
+        // });
+
+        ofEvents.once(route.externalWindow('close', uuid, name), () => {
             if (!browserWindow.isDestroyed()) {
                 browserWindow.emit('close');
                 browserWindow.close();
                 browserWindow.emit('closed');
             }
+            unsubscriptions.forEach(unsub => unsub());
         });
     }
 }

--- a/src/browser/external_window_event_adapter.js
+++ b/src/browser/external_window_event_adapter.js
@@ -38,7 +38,9 @@ class ExternalWindowEventAdapter {
         let cachedState = null;
 
         ofEvents.on(route.externalWindow('focus', uuid, name), () => {
-            browserWindow.emit('focus');
+            if (!browserWindow.isDestroyed()) {
+                browserWindow.emit('focus');
+            }
         });
 
         ofEvents.on(route.externalWindow('blur', uuid, name), () => {
@@ -148,9 +150,11 @@ class ExternalWindowEventAdapter {
         });
 
         ofEvents.on(route.externalWindow('close', uuid, name), () => {
-            browserWindow.emit('close');
-            browserWindow.close();
-            browserWindow.emit('closed');
+            if (!browserWindow.isDestroyed()) {
+                browserWindow.emit('close');
+                browserWindow.close();
+                browserWindow.emit('closed');
+            }
         });
     }
 }

--- a/src/browser/external_window_event_adapter.js
+++ b/src/browser/external_window_event_adapter.js
@@ -17,7 +17,6 @@ let ofEvents = require('./of_events.js').default;
 let electronApp = require('electron').app;
 
 let MonitorInfo;
-const unsubscriptions = [];
 electronApp.on('ready', () => {
     MonitorInfo = require('./monitor_info.js');
 });
@@ -28,6 +27,7 @@ class ExternalWindowEventAdapter {
         let options = browserWindow && browserWindow._options;
         let uuid = options.uuid;
         let name = options.name;
+        const unsubscriptions = [];
 
         let disabledFrameState = {
             leftButtonDown: false,

--- a/src/browser/external_window_event_adapter.js
+++ b/src/browser/external_window_event_adapter.js
@@ -22,6 +22,9 @@ electronApp.on('ready', () => {
 });
 import route from '../common/route';
 
+
+import * as log from './log'
+
 class ExternalWindowEventAdapter {
     constructor(browserWindow) {
         let options = browserWindow && browserWindow._options;
@@ -120,6 +123,7 @@ class ExternalWindowEventAdapter {
         });
 
         ofEvents.on(route.externalWindow('moving', uuid, name), () => {
+            log.writeToLog(1, `**** in moving - lbd ${disabledFrameState.leftButtonDown}`, true);
             if (disabledFrameState.leftButtonDown) {
                 let bounds = browserWindow.getBounds();
                 let mousePosition = MonitorInfo.getMousePosition();
@@ -137,6 +141,8 @@ class ExternalWindowEventAdapter {
                 if (xCursorDelta !== 0 || yCursorDelta !== 0) {
                     bounds.x = (cursorCurr.x - disabledFrameState.cursorStart.x) + disabledFrameState.boundsStart.x;
                     bounds.y = (cursorCurr.y - disabledFrameState.cursorStart.y) + disabledFrameState.boundsStart.y;
+
+                    log.writeToLog(1, `**** in moving ${JSON.stringify(bounds, undefined, 4)}`, true);
 
                     browserWindow.emit('disabled-frame-bounds-changing', {}, bounds, disabledFrameState.changeType);
 

--- a/src/browser/remote_subscriptions.ts
+++ b/src/browser/remote_subscriptions.ts
@@ -47,7 +47,7 @@ const pendingRemoteSubscriptions: Map<number, RemoteSubscription> = new Map();
 /**
  * Shape of remote subscription props
  */
-interface RemoteSubscriptionProps extends Identity {
+export interface RemoteSubscriptionProps extends Identity {
     className: 'application'|'window'|'system'; // names of the class event emitters, used for subscriptions
     eventName: string; // name of the type of the event to subscribe to
     listenType: 'on'|'once'; // used to set up subscription type

--- a/src/browser/remote_subscriptions.ts
+++ b/src/browser/remote_subscriptions.ts
@@ -95,9 +95,11 @@ export function addRemoteSubscription(subscriptionProps: RemoteSubscriptionProps
         connectionManager.resolveIdentity({
             uuid: subscription.uuid
 
-        }).then((id) => {
+        // }).then((id) => {
+        }).then(async (id) => {
             // Found app/window in a remote runtime, subscribing
-            applyRemoteSubscription(subscription, id.runtime);
+            // applyRemoteSubscription(subscription, id.runtime);
+            await applyRemoteSubscription(subscription, id.runtime);
 
         }).catch(() => {
             // App/window not found. We are assuming it will come up sometime in the future.
@@ -138,9 +140,6 @@ async function applyRemoteSubscription(subscription: RemoteSubscription, runtime
         cleanUpSubscription(subscription, runtimeKey);
     };
 
-    // Subscribe to an event on a remote runtime
-    classEventEmitter[listenType](eventName, listener);
-
     // Store a cleanup function for the added listener in
     // un-subscription map, so that later we can remove extra subscriptions
     if (!Array.isArray(unSubscriptions.get(runtimeKey))) {
@@ -149,6 +148,10 @@ async function applyRemoteSubscription(subscription: RemoteSubscription, runtime
     unSubscriptions.get(runtimeKey).push(() => {
         classEventEmitter.removeListener(eventName, listener);
     });
+
+    // Subscribe to an event on a remote runtime
+    // classEventEmitter[listenType](eventName, listener);
+    await classEventEmitter[listenType](eventName, listener);
 }
 
 /**

--- a/src/browser/remote_subscriptions.ts
+++ b/src/browser/remote_subscriptions.ts
@@ -47,7 +47,7 @@ const pendingRemoteSubscriptions: Map<number, RemoteSubscription> = new Map();
 /**
  * Shape of remote subscription props
  */
-export interface RemoteSubscriptionProps extends Identity {
+interface RemoteSubscriptionProps extends Identity {
     className: 'application'|'window'|'system'; // names of the class event emitters, used for subscriptions
     eventName: string; // name of the type of the event to subscribe to
     listenType: 'on'|'once'; // used to set up subscription type
@@ -95,11 +95,9 @@ export function addRemoteSubscription(subscriptionProps: RemoteSubscriptionProps
         connectionManager.resolveIdentity({
             uuid: subscription.uuid
 
-        // }).then((id) => {
-        }).then(async (id) => {
+        }).then((id) => {
             // Found app/window in a remote runtime, subscribing
-            // applyRemoteSubscription(subscription, id.runtime);
-            await applyRemoteSubscription(subscription, id.runtime);
+            applyRemoteSubscription(subscription, id.runtime);
 
         }).catch(() => {
             // App/window not found. We are assuming it will come up sometime in the future.
@@ -150,8 +148,7 @@ async function applyRemoteSubscription(subscription: RemoteSubscription, runtime
     });
 
     // Subscribe to an event on a remote runtime
-    // classEventEmitter[listenType](eventName, listener);
-    await classEventEmitter[listenType](eventName, listener);
+    classEventEmitter[listenType](eventName, listener);
 }
 
 /**

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -55,6 +55,7 @@ declare module 'electron' {
     export class BrowserWindow {
         constructor(props: any);
 
+        id: number;
         _options: {
             minWidth: number;
             minHeight: number;

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -77,6 +77,7 @@ declare module 'electron' {
         emit(routeString: string, ...args: any[]): void;
         getBounds(): Rectangle;
         setWindowPlacement(bounds: Rectangle): void;
+        close(): void;
     }
 
     export class ipcMain {

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -111,6 +111,7 @@ export interface OpenFinWindow {
     preloadScripts: PreloadScriptState[];
     uuid: string;
     mainFrameRoutingId: number;
+    meshGroupUuid: string;
 }
 
 export interface BrowserWindow {

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -213,6 +213,7 @@ export interface WindowOptions {
     maxHeight?: number;
     maximizable?: boolean;
     maxWidth?: number;
+    meshJoinGroupIdentity?: Identity;
     minHeight?: number;
     minimizable?: boolean;
     minWidth?: number;


### PR DESCRIPTION
*** DO NOT REVIEW ***


Currently the runtime where the request is made is the one handling the join group unless the target 
window is already in a group in another runtime. The middleware checks to see if either of the windows in another runtime, if so - it gets the nativeId from the other runtime, creates an external window (identity that makes the join group api call is the parent window), and subscribes to the necessary events, then uses the created external window to handle group movements.  

It is currently creating the externalWindow as window underneath the application that called joinGroup.  This may need to change.  

Known Issues / Further Work:
- getGroup needs to be fixed to work cross runtime and to return the correct window (not external window)
- Some issues delegating the parent app when using 3+ runtimes (need to solve getGroup to fix)
- Grouping breaks when parent application is closed (app where joinGroup is called from)
- mergeGroups has not been addressed
- does not work when called from an external adapter (or anything without a browserWindow)
- Not all use cases with 3+ runtimes have been tested
- API calls have not been fully tested in all cases (window hidden, minimized, etc.)
- If called with two windows with the same name from two different apps (different UUIDs) the second will fail
- close-requested has not been tested

It currently cannot be tested with the js-adapter since calls from an external-adapter fail.  This is all behind a flag (`mesh-join-group`).


Tests: 
[Win7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5ace55104ecc2a37d5a48452)
[Win10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5ace55804ecc2a37d5a48453)