### PR TITLE
RUN-4059 - Additional payload added to System.getAllWindows

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -1081,7 +1081,6 @@ Window.disableFrame = function(identity) {
     }
 
     browserWindow.setUserMovementEnabled(false);
-    setOptOnBrowserWin('frame', false, browserWindow);
 };
 
 Window.embed = function(identity, parentHwnd) {
@@ -1114,7 +1113,6 @@ Window.enableFrame = function(identity) {
     }
 
     browserWindow.setUserMovementEnabled(true);
-    setOptOnBrowserWin('frame', true, browserWindow);
 };
 
 Window.executeJavascript = function(identity, code, callback = () => {}) {

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -1081,6 +1081,7 @@ Window.disableFrame = function(identity) {
     }
 
     browserWindow.setUserMovementEnabled(false);
+    setOptOnBrowserWin('frame', false, browserWindow);
 };
 
 Window.embed = function(identity, parentHwnd) {
@@ -1113,6 +1114,7 @@ Window.enableFrame = function(identity) {
     }
 
     browserWindow.setUserMovementEnabled(true);
+    setOptOnBrowserWin('frame', true, browserWindow);
 };
 
 Window.executeJavascript = function(identity, code, callback = () => {}) {

--- a/src/browser/core_state.ts
+++ b/src/browser/core_state.ts
@@ -508,16 +508,19 @@ export function getAllAppObjects(): Shapes.AppObj[] {
 }
 
 export function getAllWindows(): WindowMeta[] {
-    const getBounds = require('./api/window.js').Window.getBounds; // do not move this line!
+    const windowApi = require('./api/window.js').Window; // do not move this line!
     return apps.map(app => {
         const windowBounds = app.children
             .filter(win => win.openfinWindow)
             .map(win => {
-                const bounds = getBounds({
+                const identity = {
                     name: win.openfinWindow.name,
                     uuid: win.openfinWindow.uuid
-                });
+                };
+                const bounds = windowApi.getBounds(identity);
                 bounds.name = win.openfinWindow.name;
+                bounds.state = windowApi.getState(identity);
+                bounds.isShowing = windowApi.isShowing(identity);
                 return bounds;
             });
 


### PR DESCRIPTION
Edit: removed incorrect language around frame options 

Per customer request, we are adding state ('normal', 'minimized', 'maximized') and isShowing (boolean) to the System.getAllWindows call.  

[Testrunner Test:](https://testing-dashboard.openfin.co/#/app/tests/5af9dd2b4ecc2a37d5a48649/edit) that tests new payload

[Win7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5af9de7f4ecc2a37d5a4864c)
[Win10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5af9dfb74ecc2a37d5a4864d)