### PR TITLE
RUN-4104: Add ability to mask RVM payloads; do so for application-log

### DIFF
--- a/src/browser/rvm/rvm_message_bus.ts
+++ b/src/browser/rvm/rvm_message_bus.ts
@@ -319,10 +319,6 @@ export class RVMMessageBus extends EventEmitter  {
 
         this.recordCallbackInfo(callback, timeToLive, envelope);
 
-        if (!maskPayload) {
-            log.writeToLog(1, envelope, true);
-        }
-
         return this.transport.publish(envelope, maskPayload);
     }
 

--- a/src/browser/rvm/rvm_message_bus.ts
+++ b/src/browser/rvm/rvm_message_bus.ts
@@ -295,7 +295,7 @@ export class RVMMessageBus extends EventEmitter  {
         });
     }
 
-    public publish = (msg: RvmMsgBase, callback: (x: any) => any = ()  => undefined): boolean => {
+    public publish = (msg: RvmMsgBase, callback: (x: any) => any = ()  => undefined, maskPayload?: boolean): boolean => {
 
         if (!msg || typeof msg !== 'object') {
             log.writeToLog('ERROR', 'Argument must be an object');
@@ -319,9 +319,11 @@ export class RVMMessageBus extends EventEmitter  {
 
         this.recordCallbackInfo(callback, timeToLive, envelope);
 
-        log.writeToLog(1, envelope, true);
+        if (!maskPayload) {
+            log.writeToLog(1, envelope, true);
+        }
 
-        return this.transport.publish(envelope);
+        return this.transport.publish(envelope, maskPayload);
     }
 
     public registerLicenseInfo = (licInfo: LicenseInfo, sourceUrl: string = null): boolean => {

--- a/src/browser/rvm/utils.ts
+++ b/src/browser/rvm/utils.ts
@@ -26,7 +26,6 @@ interface SendToRVMOpts {
     data?: any;
     runtimeVersion?: string;
     payload?: any;
-    maskPayload?: boolean;
 }
 
 // 1 MB
@@ -52,8 +51,7 @@ function flushConsoleMessageQueue(): void {
         runtimeVersion: System.getVersion(),
         payload: {
             messages: JSON.parse(JSON.stringify(consoleMessageQueue))
-        },
-        maskPayload: true
+        }
     };
 
     consoleMessageQueue = [];
@@ -85,7 +83,7 @@ export function addConsoleMessageToRVMMessageQueue(consoleMessage: ConsoleMessag
 /**
  * Helper that uses RVM bus to send and receive payloads to/from RVM
  */
-export function sendToRVM(opts: SendToRVMOpts): Promise<any> {
+export function sendToRVM(opts: SendToRVMOpts, maskPayload?: boolean): Promise<any> {
     return new Promise((resolve, reject) => {
 
         // Make sure there is a connection with RVM
@@ -132,7 +130,7 @@ export function sendToRVM(opts: SendToRVMOpts): Promise<any> {
 
             resolve(payload);
 
-        }, opts.maskPayload);
+        }, maskPayload);
 
         if (!messageSent) {
             reject(new Error('Failed to send a message to the RVM'));

--- a/src/browser/rvm/utils.ts
+++ b/src/browser/rvm/utils.ts
@@ -55,7 +55,7 @@ function flushConsoleMessageQueue(): void {
     };
 
     consoleMessageQueue = [];
-    sendToRVM(obj);
+    sendToRVM(obj, true);
 }
 
 export function addConsoleMessageToRVMMessageQueue(consoleMessage: ConsoleMessage): void {

--- a/src/browser/rvm/utils.ts
+++ b/src/browser/rvm/utils.ts
@@ -26,6 +26,7 @@ interface SendToRVMOpts {
     data?: any;
     runtimeVersion?: string;
     payload?: any;
+    maskPayload?: boolean;
 }
 
 // 1 MB
@@ -51,7 +52,8 @@ function flushConsoleMessageQueue(): void {
         runtimeVersion: System.getVersion(),
         payload: {
             messages: JSON.parse(JSON.stringify(consoleMessageQueue))
-        }
+        },
+        maskPayload: true
     };
 
     consoleMessageQueue = [];
@@ -130,7 +132,7 @@ export function sendToRVM(opts: SendToRVMOpts): Promise<any> {
 
             resolve(payload);
 
-        });
+        }, opts.maskPayload);
 
         if (!messageSent) {
             reject(new Error('Failed to send a message to the RVM'));

--- a/src/browser/transports/wm_copydata.ts
+++ b/src/browser/transports/wm_copydata.ts
@@ -57,7 +57,7 @@ class WMCopyDataTransport extends BaseTransport {
         });
     }
 
-    public publish(data: any): boolean {
+    public publish(data: any, maskPayload?: boolean): boolean {
         // on windows x64 platform still returns win32
         if (process.platform.indexOf('win32') !== -1) {
 
@@ -68,7 +68,7 @@ class WMCopyDataTransport extends BaseTransport {
             let sent = false;
             let i = 0;
             for (i = 0; i < this.messageRetry && !sent; i++) {
-                sent = this._messageWindow.sendbyname(this.targetClass, '', JSON.stringify(data));
+                sent = this._messageWindow.sendbyname(this.targetClass, '', JSON.stringify(data), !!maskPayload);
                 if (!sent) {
                     log.writeToLog(1, 'error sending message to ' + this.targetClass + ', retry=' + i, true);
                 }


### PR DESCRIPTION
[JIRA](https://appoji.jira.com/browse/RUN-4104)

Also, if the payload is to be masked, it's not written to the log.

[Runtime PR](https://github.com/openfin/runtime/pull/996)

[Test results](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5afb140f4ecc2a37d5a48677)