### PR TITLE
RUN-4118: add cachePath to getRuntimeInfo

### DIFF
--- a/release.json
+++ b/release.json
@@ -1,3 +1,3 @@
 {
-  "fixVersion" : "8.56.31.*"
+  "fixVersion" : "9.61.32.*"
 }

--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -472,7 +472,8 @@ exports.System = {
         portDiscovery.getPortInfoByArgs(coreState.argo, socketServer.getPort());
         const manifestUrl = coreState.getConfigUrlByUuid(identity.uuid);
         const architecture = process.arch;
-        return { manifestUrl, port, securityRealm, version, architecture };
+        const cachePath = electronApp.getPath('userData');
+        return { manifestUrl, port, securityRealm, version, architecture, cachePath };
     },
     getRvmInfo: function(identity, callback, errorCallback) {
         let appObject = coreState.getAppObjByUuid(identity.uuid);


### PR DESCRIPTION
Tests
[W10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5af9e8214ecc2a37d5a48657)
[W7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5af9e6b74ecc2a37d5a48655)

[New test](https://testing-dashboard.openfin.co/#/app/tests/5afad8c64ecc2a37d5a4866c/edit)
