### PR TITLE
RUN-4120 clean up all webContents' listeners on "close"

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -581,6 +581,10 @@ Window.create = function(id, opts) {
             }
         };
 
+        webContents.once('close', () => {
+            webContents.removeAllListeners();
+        });
+
         webContents.on('crashed', (event, killed, terminationStatus) => {
             emitToAppAndWin('crashed', {
                 reason: terminationStatus


### PR DESCRIPTION
This change decreases memory leaks by approximately 12%

✅ [Windows 7 automated tests](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5afaf4b34ecc2a37d5a4866d)
✅ [Windows 10 automated tests](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5afaf6524ecc2a37d5a4866e)