### PR TITLE
RUN-4120 clean up all browserWindow's listeners on "closed"

### DIFF
--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -96,7 +96,6 @@ export interface Window {
 export interface OpenFinWindow {
     isIframe?: boolean;
     parentFrameId?: number;
-    _openListeners: (() => void)[];
     _options: WindowOptions;
     _window: BrowserWindow;
     app_uuid: string;


### PR DESCRIPTION
This change decreases memory leaks by approximately 13%

✅ [Windows 7 automated tests](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5afb1c4a4ecc2a37d5a48679)
✅ [Windows 10 automated tests](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5afb1eb34ecc2a37d5a4867a)