### PR TITLE
RUN-4120 decreased initial browser process load

### DIFF
--- a/src/browser/core_state.ts
+++ b/src/browser/core_state.ts
@@ -745,10 +745,11 @@ export function getWindowInitialOptionSet(windowId: number): Shapes.WindowInitia
     const socketServerState = <PortInfo>getSocketServerState();
 
     return {
-        options,
-        entityInfo,
         elIPCConfig,
+        entityInfo,
+        frames: Array.from(ofWin.frames.values()),
+        options,
+        runtimeArguments: args,
         socketServerState,
-        frames: Array.from(ofWin.frames.values())
     };
 }

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -342,11 +342,12 @@ export interface ElectronIpcChannels {
 }
 
 export interface WindowInitialOptionSet {
-    options: WindowOptions;
-    entityInfo: FrameInfo;
-    socketServerState: PortInfo;
-    frames: ChildFrameInfo[];
     elIPCConfig: {
         channels: ElectronIpcChannels
     };
+    entityInfo: FrameInfo;
+    frames: ChildFrameInfo[];
+    options: WindowOptions;
+    runtimeArguments: string;
+    socketServerState: PortInfo;
 }


### PR DESCRIPTION
ℹ️ There are two types of changes in this PR:
1. **Decreased** initial browser process load by **17%** by simply using `fs` module to retrieve javascript-adapter and api-decorator from within the function. This change decreased initial browser process size from 10.6MB to 8.8MB (-1.8MB). This does not fix any memory leaks, just the initial load.
2. ES6 and readability refactor and clean-up

✅ [Windows 7 automated tests](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5afc51334ecc2a37d5a48691)
✅ [Windows 10 automated tests](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5afc52964ecc2a37d5a48692)