### PR TITLE
RUN-4143 - Emit Begin User Bounds Changing

### DIFF
--- a/src/browser/bounds_changed_state_tracker.js
+++ b/src/browser/bounds_changed_state_tracker.js
@@ -446,7 +446,8 @@ function BoundsChangedStateTracker(uuid, name, browserWindow) {
             const payload = { uuid, name, top: cachedBounds.y, left: cachedBounds.x };
             ofEvents.emit(route.window('begin-user-bounds-changing', uuid, name), Object.assign(payload, cachedBounds));
         },
-        'end-user-bounds-change': () => {
+        'end-user-bounds-change': (p) => {
+            ofEvents.emit(route.window('end-user-bounds-changing', uuid, name), { hi: 'hi' });
             setUserBoundsChangeActive(false);
             handleBoundsChange(false, true);
         },

--- a/src/browser/bounds_changed_state_tracker.js
+++ b/src/browser/bounds_changed_state_tracker.js
@@ -447,8 +447,10 @@ function BoundsChangedStateTracker(uuid, name, browserWindow) {
             ofEvents.emit(route.window('begin-user-bounds-changing', uuid, name), Object.assign(payload, cachedBounds));
         },
         'end-user-bounds-change': (p) => {
-            ofEvents.emit(route.window('end-user-bounds-changing', uuid, name), { hi: 'hi' });
             setUserBoundsChangeActive(false);
+            const bounds = getCurrentBounds();
+            const payload = { uuid, name, top: bounds.y, left: bounds.x };
+            ofEvents.emit(route.window('end-user-bounds-changing', uuid, name), Object.assign(payload, bounds));
             handleBoundsChange(false, true);
         },
         'bounds-changed': () => {

--- a/src/browser/bounds_changed_state_tracker.js
+++ b/src/browser/bounds_changed_state_tracker.js
@@ -446,7 +446,7 @@ function BoundsChangedStateTracker(uuid, name, browserWindow) {
             const payload = { uuid, name, top: cachedBounds.y, left: cachedBounds.x };
             ofEvents.emit(route.window('begin-user-bounds-changing', uuid, name), Object.assign(payload, cachedBounds));
         },
-        'end-user-bounds-change': (p) => {
+        'end-user-bounds-change': () => {
             setUserBoundsChangeActive(false);
             const bounds = getCurrentBounds();
             const payload = { uuid, name, top: bounds.y, left: bounds.x };

--- a/src/browser/bounds_changed_state_tracker.js
+++ b/src/browser/bounds_changed_state_tracker.js
@@ -27,6 +27,8 @@ import * as Deferred from './deferred';
 let WindowGroups = require('./window_groups.js');
 import WindowGroupTransactionTracker from './window_group_transaction_tracker';
 import { toSafeInt } from '../common/safe_int';
+import ofEvents from './of_events';
+import route from '../common/route';
 
 const isWin32 = process.platform === 'win32';
 
@@ -440,6 +442,9 @@ function BoundsChangedStateTracker(uuid, name, browserWindow) {
     var _listeners = {
         'begin-user-bounds-change': () => {
             setUserBoundsChangeActive(true);
+            const cachedBounds = getCachedBounds();
+            const payload = { uuid, name, top: cachedBounds.y, left: cachedBounds.x };
+            ofEvents.emit(route.window('begin-user-bounds-changing', uuid, name), Object.assign(payload, cachedBounds));
         },
         'end-user-bounds-change': () => {
             setUserBoundsChangeActive(false);


### PR DESCRIPTION
Emit the `begin-user-bounds-changing` event for use in layouts / snap-and-dock.  

See [javascript-adapter](TBD) PR for documentation.

[Win7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5aff1c294ecc2a37d5a486df)
[Win10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5aff1db84ecc2a37d5a486e0)