### PR TITLE
RUN-4159 - Propagate events to system

### DIFF
--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -127,8 +127,6 @@ eventPropagationMap.forEach((systemEvent, eventString) => {
     });
 });
 
-delete eventPropagationMap;
-
 exports.System = {
     addEventListener: function(type, listener) {
         ofEvents.on(route.system(type), listener);

--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -123,7 +123,7 @@ eventPropagationMap.set(route.externalApplication('disconnected'), 'external-app
 eventPropagationMap.forEach((systemEvent, eventString) => {
     ofEvents.on(eventString, payload => {
         const systemEventProps = { topic: 'system', type: systemEvent };
-        const initialPayload = payload.data || [];
+        const initialPayload = Array.isArray(payload.data) ? payload.data : [payload];
         ofEvents.emit(route.system(systemEvent), Object.assign({}, ...initialPayload, systemEventProps));
     });
 });

--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -123,7 +123,8 @@ eventPropagationMap.set(route.externalApplication('disconnected'), 'external-app
 eventPropagationMap.forEach((systemEvent, eventString) => {
     ofEvents.on(eventString, payload => {
         const systemEventProps = { topic: 'system', type: systemEvent };
-        ofEvents.emit(route.system(systemEvent), Object.assign({}, ...payload.data, systemEventProps));
+        const initialPayload = payload.data || [];
+        ofEvents.emit(route.system(systemEvent), Object.assign({}, ...initialPayload, systemEventProps));
     });
 });
 

--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -109,53 +109,73 @@ electronApp.on('synth-desktop-icon-clicked', payload => {
     ofEvents.emit(route.system('desktop-icon-clicked'), payload);
 });
 
-ofEvents.on(route.application('created', '*'), payload => {
-    ofEvents.emit(route.system('application-created'), {
-        topic: 'system',
-        type: 'application-created',
-        uuid: payload.source
+const eventPropagationMap = new Map();
+eventPropagationMap.set(route.application('created', '*'), 'application-created');
+eventPropagationMap.set(route.application('started', '*'), 'application-started');
+eventPropagationMap.set(route.application('closed', '*'), 'application-closed');
+eventPropagationMap.set(route.application('crashed', '*'), 'application-crashed');
+eventPropagationMap.set(route.application('window-created', '*'), 'window-created');
+eventPropagationMap.set(route.application('window-started', '*'), 'window-started');
+eventPropagationMap.set(route.application('window-closed', '*'), 'window-closed');
+eventPropagationMap.set(route.application('window-crashed', '*'), 'window-crashed');
+eventPropagationMap.set(route.externalApplication('connected'), 'external-application-connected');
+eventPropagationMap.set(route.externalApplication('disconnected'), 'external-application-disconnected');
+
+eventPropagationMap.forEach((systemEvent, eventString) => {
+    ofEvents.on(eventString, payload => {
+        const systemEventProps = { topic: 'system', type: systemEvent };
+        ofEvents.emit(route.system(systemEvent), Object.assign({}, ...payload.data, systemEventProps));
     });
 });
 
-ofEvents.on(route.application('started', '*'), payload => {
-    ofEvents.emit(route.system('application-started'), {
-        topic: 'system',
-        type: 'application-started',
-        uuid: payload.source
-    });
-});
 
-ofEvents.on(route.application('closed', '*'), payload => {
-    ofEvents.emit(route.system('application-closed'), {
-        topic: 'system',
-        type: 'application-closed',
-        uuid: payload.source
-    });
-});
+// ofEvents.on(route.application('created', '*'), payload => {
+//     ofEvents.emit(route.system('application-created'), {
+//         topic: 'system',
+//         type: 'application-created',
+//         uuid: payload.source
+//     });
+// });
 
-ofEvents.on(route.application('crashed', '*'), payload => {
-    ofEvents.emit(route.system('application-crashed'), {
-        topic: 'system',
-        type: 'application-crashed',
-        uuid: payload.source
-    });
-});
+// ofEvents.on(route.application('started', '*'), payload => {
+//     ofEvents.emit(route.system('application-started'), {
+//         topic: 'system',
+//         type: 'application-started',
+//         uuid: payload.source
+//     });
+// });
 
-ofEvents.on(route.externalApplication('connected'), payload => {
-    ofEvents.emit(route.system('external-application-connected'), {
-        topic: 'system',
-        type: 'external-application-connected',
-        uuid: payload.uuid
-    });
-});
+// ofEvents.on(route.application('closed', '*'), payload => {
+//     ofEvents.emit(route.system('application-closed'), {
+//         topic: 'system',
+//         type: 'application-closed',
+//         uuid: payload.source
+//     });
+// });
 
-ofEvents.on(route.externalApplication('disconnected'), payload => {
-    ofEvents.emit(route.system('external-application-disconnected'), {
-        topic: 'system',
-        type: 'external-application-disconnected',
-        uuid: payload.uuid
-    });
-});
+// ofEvents.on(route.application('crashed', '*'), payload => {
+//     ofEvents.emit(route.system('application-crashed'), {
+//         topic: 'system',
+//         type: 'application-crashed',
+//         uuid: payload.source
+//     });
+// });
+
+// ofEvents.on(route.externalApplication('connected'), payload => {
+//     ofEvents.emit(route.system('external-application-connected'), {
+//         topic: 'system',
+//         type: 'external-application-connected',
+//         uuid: payload.uuid
+//     });
+// });
+
+// ofEvents.on(route.externalApplication('disconnected'), payload => {
+//     ofEvents.emit(route.system('external-application-disconnected'), {
+//         topic: 'system',
+//         type: 'external-application-disconnected',
+//         uuid: payload.uuid
+//     });
+// });
 
 exports.System = {
     addEventListener: function(type, listener) {

--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -115,7 +115,6 @@ eventPropagationMap.set(route.application('started', '*'), 'application-started'
 eventPropagationMap.set(route.application('closed', '*'), 'application-closed');
 eventPropagationMap.set(route.application('crashed', '*'), 'application-crashed');
 eventPropagationMap.set(route.application('window-created', '*'), 'window-created');
-eventPropagationMap.set(route.application('window-started', '*'), 'window-started');
 eventPropagationMap.set(route.application('window-closed', '*'), 'window-closed');
 eventPropagationMap.set(route.application('window-crashed', '*'), 'window-crashed');
 eventPropagationMap.set(route.externalApplication('connected'), 'external-application-connected');
@@ -128,54 +127,7 @@ eventPropagationMap.forEach((systemEvent, eventString) => {
     });
 });
 
-
-// ofEvents.on(route.application('created', '*'), payload => {
-//     ofEvents.emit(route.system('application-created'), {
-//         topic: 'system',
-//         type: 'application-created',
-//         uuid: payload.source
-//     });
-// });
-
-// ofEvents.on(route.application('started', '*'), payload => {
-//     ofEvents.emit(route.system('application-started'), {
-//         topic: 'system',
-//         type: 'application-started',
-//         uuid: payload.source
-//     });
-// });
-
-// ofEvents.on(route.application('closed', '*'), payload => {
-//     ofEvents.emit(route.system('application-closed'), {
-//         topic: 'system',
-//         type: 'application-closed',
-//         uuid: payload.source
-//     });
-// });
-
-// ofEvents.on(route.application('crashed', '*'), payload => {
-//     ofEvents.emit(route.system('application-crashed'), {
-//         topic: 'system',
-//         type: 'application-crashed',
-//         uuid: payload.source
-//     });
-// });
-
-// ofEvents.on(route.externalApplication('connected'), payload => {
-//     ofEvents.emit(route.system('external-application-connected'), {
-//         topic: 'system',
-//         type: 'external-application-connected',
-//         uuid: payload.uuid
-//     });
-// });
-
-// ofEvents.on(route.externalApplication('disconnected'), payload => {
-//     ofEvents.emit(route.system('external-application-disconnected'), {
-//         topic: 'system',
-//         type: 'external-application-disconnected',
-//         uuid: payload.uuid
-//     });
-// });
+delete eventPropagationMap;
 
 exports.System = {
     addEventListener: function(type, listener) {


### PR DESCRIPTION
Propagated window created, crashed, closed to system level eventing for layouts.  Should we do any other window or application events? 

[Win7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b060fbd4ecc2a37d5a48723)
[Win10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b0610f44ecc2a37d5a48724)

New Testrunner tests System events:
[window-created](https://testing-dashboard.openfin.co/#/app/tests/5aff47ee4ecc2a37d5a486ed/edit)
[window-closed](https://testing-dashboard.openfin.co/#/app/tests/5aff48984ecc2a37d5a486ee/edit)
[window-crashed](https://testing-dashboard.openfin.co/#/app/tests/5b060c7b4ecc2a37d5a48722/edit)