### PR TITLE
RUN-4068 - Multi runtime services and slight refactor

### DIFF
--- a/src/browser/api/service.ts
+++ b/src/browser/api/service.ts
@@ -55,8 +55,8 @@ export module Service {
             const nackString = 'Register Failed: Please note that only one service may be registered per application.';
             throw new Error(nackString);
         }
-        const { uuid, isExternal } = targetApp;
-        const channelId = `${uuid}/${serviceId}`;
+        const { uuid, name, isExternal } = targetApp;
+        const channelId = `${uuid}/${name}/${serviceName}/${serviceId}`;
         const serviceIdentity = { ...targetApp, serviceName, channelId };
         serviceId = serviceId + 1;
 

--- a/src/browser/api/service.ts
+++ b/src/browser/api/service.ts
@@ -21,7 +21,6 @@ import route from '../../common/route';
 import { getExternalOrOfWindowIdentity } from '../core_state';
 
 const serviceMap: Map<string, ServiceIdentity> = new Map();
-let serviceId = 1;
 
 export module Service {
     export function addEventListener(targetIdentity: Identity, type: string, listener: (eventPayload: EventPayload) => void) : () => void {
@@ -56,9 +55,8 @@ export module Service {
             throw new Error(nackString);
         }
         const { uuid, name, isExternal } = targetApp;
-        const channelId = `${uuid}/${name}/${serviceName}/${serviceId}`;
+        const channelId = `${uuid}/${name}/${serviceName}`;
         const serviceIdentity = { ...targetApp, serviceName, channelId };
-        serviceId = serviceId + 1;
 
         serviceMap.set(channelId, serviceIdentity);
 

--- a/src/browser/api_protocol/api_handlers/service.ts
+++ b/src/browser/api_protocol/api_handlers/service.ts
@@ -39,8 +39,7 @@ export class ServiceApiHandler {
 
         const serviceIdentity = Service.registerService(identity, serviceName);
         const dataAck = Object.assign({}, successAck, { data: serviceIdentity });
-        const nackString = 'Register Failed: Please note that only one service may be registered per application.';
-        serviceIdentity ? ack(dataAck) : nack(nackString);
+        ack(dataAck);
     }
 
 }

--- a/src/browser/api_protocol/api_handlers/service_middleware.ts
+++ b/src/browser/api_protocol/api_handlers/service_middleware.ts
@@ -64,7 +64,9 @@ function setTargetIdentity(identity: Identity, payload: any): TargetIdentity {
         return { targetIdentity, serviceIdentity };
     }
     // Sender could be service or client, want service Identity sent in payload either way
-    const serviceIdentity = Service.getServiceByUuid(uuid) || Service.getServiceByUuid(identity.uuid);
+    let { serviceIdentity } = payload;
+    // Need this for backward compatibility - adapters did not send Service Identity in first iteration
+    serviceIdentity = serviceIdentity || Service.getServiceByUuid(uuid) || Service.getServiceByUuid(identity.uuid) || identity;
     const targetIdentity = getExternalOrOfWindowIdentity(payload);
     return { targetIdentity, serviceIdentity };
 }

--- a/src/browser/bounds_changed_state_tracker.js
+++ b/src/browser/bounds_changed_state_tracker.js
@@ -446,7 +446,8 @@ function BoundsChangedStateTracker(uuid, name, browserWindow) {
             const payload = { uuid, name, top: cachedBounds.y, left: cachedBounds.x };
             ofEvents.emit(route.window('begin-user-bounds-changing', uuid, name), Object.assign(payload, cachedBounds));
         },
-        'end-user-bounds-change': () => {
+        'end-user-bounds-change': (p) => {
+            ofEvents.emit(route.window('end-user-bounds-changing', uuid, name), { hi: 'hi' });
             setUserBoundsChangeActive(false);
             handleBoundsChange(false, true);
         },

--- a/src/browser/bounds_changed_state_tracker.js
+++ b/src/browser/bounds_changed_state_tracker.js
@@ -447,8 +447,10 @@ function BoundsChangedStateTracker(uuid, name, browserWindow) {
             ofEvents.emit(route.window('begin-user-bounds-changing', uuid, name), Object.assign(payload, cachedBounds));
         },
         'end-user-bounds-change': (p) => {
-            ofEvents.emit(route.window('end-user-bounds-changing', uuid, name), { hi: 'hi' });
             setUserBoundsChangeActive(false);
+            const bounds = getCurrentBounds();
+            const payload = { uuid, name, top: bounds.y, left: bounds.x };
+            ofEvents.emit(route.window('end-user-bounds-changing', uuid, name), Object.assign(payload, bounds));
             handleBoundsChange(false, true);
         },
         'bounds-changed': () => {

--- a/src/browser/bounds_changed_state_tracker.js
+++ b/src/browser/bounds_changed_state_tracker.js
@@ -446,7 +446,7 @@ function BoundsChangedStateTracker(uuid, name, browserWindow) {
             const payload = { uuid, name, top: cachedBounds.y, left: cachedBounds.x };
             ofEvents.emit(route.window('begin-user-bounds-changing', uuid, name), Object.assign(payload, cachedBounds));
         },
-        'end-user-bounds-change': (p) => {
+        'end-user-bounds-change': () => {
             setUserBoundsChangeActive(false);
             const bounds = getCurrentBounds();
             const payload = { uuid, name, top: bounds.y, left: bounds.x };

--- a/src/browser/bounds_changed_state_tracker.js
+++ b/src/browser/bounds_changed_state_tracker.js
@@ -27,6 +27,8 @@ import * as Deferred from './deferred';
 let WindowGroups = require('./window_groups.js');
 import WindowGroupTransactionTracker from './window_group_transaction_tracker';
 import { toSafeInt } from '../common/safe_int';
+import ofEvents from './of_events';
+import route from '../common/route';
 
 const isWin32 = process.platform === 'win32';
 
@@ -440,6 +442,9 @@ function BoundsChangedStateTracker(uuid, name, browserWindow) {
     var _listeners = {
         'begin-user-bounds-change': () => {
             setUserBoundsChangeActive(true);
+            const cachedBounds = getCachedBounds();
+            const payload = { uuid, name, top: cachedBounds.y, left: cachedBounds.x };
+            ofEvents.emit(route.window('begin-user-bounds-changing', uuid, name), Object.assign(payload, cachedBounds));
         },
         'end-user-bounds-change': () => {
             setUserBoundsChangeActive(false);

--- a/src/browser/bounds_changed_state_tracker.js
+++ b/src/browser/bounds_changed_state_tracker.js
@@ -27,8 +27,6 @@ import * as Deferred from './deferred';
 let WindowGroups = require('./window_groups.js');
 import WindowGroupTransactionTracker from './window_group_transaction_tracker';
 import { toSafeInt } from '../common/safe_int';
-import ofEvents from './of_events';
-import route from '../common/route';
 
 const isWin32 = process.platform === 'win32';
 
@@ -442,15 +440,9 @@ function BoundsChangedStateTracker(uuid, name, browserWindow) {
     var _listeners = {
         'begin-user-bounds-change': () => {
             setUserBoundsChangeActive(true);
-            const cachedBounds = getCachedBounds();
-            const payload = { uuid, name, top: cachedBounds.y, left: cachedBounds.x };
-            ofEvents.emit(route.window('begin-user-bounds-changing', uuid, name), Object.assign(payload, cachedBounds));
         },
         'end-user-bounds-change': () => {
             setUserBoundsChangeActive(false);
-            const bounds = getCurrentBounds();
-            const payload = { uuid, name, top: bounds.y, left: bounds.x };
-            ofEvents.emit(route.window('end-user-bounds-changing', uuid, name), Object.assign(payload, bounds));
             handleBoundsChange(false, true);
         },
         'bounds-changed': () => {

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -23,8 +23,9 @@ export interface Identity {
 }
 
 export interface ServiceIdentity extends Identity {
-    serviceName?: string;
+    channelId?: string;
     isExternal?: boolean;
+    serviceName?: string;
 }
 
 export interface ResourceFetchIdentity extends Identity {


### PR DESCRIPTION
Did a slight refactor of services to:

- make multi-runtime work
- make it so a single app could both register as a service and connect to other services as a client
- make future changes to the handshake easier

Instead of using the UUID to store/lookup the service (on both core & adapters), we now use a "channelId".  ChannelId is currently just uuid/${number} where 'number' is just an incrementing number.  This new property will future changes to the handshake and the way the channel is stored in the core / adapters a bit easier.  The adapters are also now sending back the serviceIdentity (with channelID property) along with every message after the connection.  

This change should retain backward compatibility.  

Required javacript-adapter and js-adapter changes as well.  Ran the tests with and without the adapter changes to ensure backwards compatibility.  

[Win7 - w adapter chg](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b0da955f2f2e22fa4b7c23a) 
[Win10 - w adapter chg](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b0daa95f2f2e22fa4b7c23c)

[Win7 - w/o adapter](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b0da955f2f2e22fa4b7c23b) 
[Win10 - w/o adapter](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b0daa95f2f2e22fa4b7c23d)