### PR TITLE
RUN-4042: remove process from monitor when release is called

### DIFF
--- a/src/browser/process_tracker.js
+++ b/src/browser/process_tracker.js
@@ -328,6 +328,10 @@ ProcessTracker.prototype.release = function(uuid) {
         throw new Error(`Error releasing external process, cannot release nonpersistent processes`);
     }
 
+    if (this._processes[pid].monitor) {
+        this._processMonitor.remove(this._processes[pid].process);
+    }
+
     this._processes[pid].monitor = false;
 };
 


### PR DESCRIPTION
When release a running external process the first time, better remove it from internal [process monitor](https://github.com/openfin/runtime/blob/develop/docs/api/process-monitor.md) as well.