### PR TITLE
Feature/run 4065 disable frame unhook

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -1082,7 +1082,7 @@ Window.close = function(identity, force, callback = () => {}) {
 };
 
 function dissabledFrameUnsubDecorator(identity) {
-    const windowKey = genWindowKey(identity)
+    const windowKey = genWindowKey(identity);
     return function() {
         let refCount = disabledFrameRef.get(windowKey) || 0;
         if (refCount > 1) {

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -1082,7 +1082,7 @@ Window.close = function(identity, force, callback = () => {}) {
 };
 
 function dissabledFrameUnsubDecorator(identity) {
-    const windowKey = genWindowKey(identity);
+    const windowKey = genWindowKey(identity)
     return function() {
         let refCount = disabledFrameRef.get(windowKey) || 0;
         if (refCount > 1) {
@@ -1095,7 +1095,7 @@ function dissabledFrameUnsubDecorator(identity) {
 
 Window.disableFrame = function(requestorIdentity, windowIdentity) {
     let browserWindow = getElectronBrowserWindow(windowIdentity);
-    const windowKey = `${windowIdentity.uuid}-${windowIdentity.name}`;
+    const windowKey = genWindowKey(windowIdentity);
 
     if (!browserWindow) {
         return;

--- a/src/browser/api_protocol/api_handlers/window.js
+++ b/src/browser/api_protocol/api_handlers/window.js
@@ -476,7 +476,7 @@ function disableWindowFrame(identity, message, ack) {
     var payload = message.payload,
         windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
 
-    Window.disableFrame(windowIdentity);
+    Window.disableFrame(identity, windowIdentity);
     ack(successAck);
 }
 


### PR DESCRIPTION
Making sure that on a entity close/disconnect event we enable the window frame

Tests: 

[Win7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b319bfb54b21953031f362d)
[Win10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b319cc654b21953031f362e)

TODO: 
- [ ] Manual test.