### PR TITLE
RUN-4065 disable frame unhook

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -1082,7 +1082,7 @@ Window.close = function(identity, force, callback = () => {}) {
 };
 
 function dissabledFrameUnsubDecorator(identity) {
-    const windowKey = genWindowKey(identity)
+    const windowKey = genWindowKey(identity);
     return function() {
         let refCount = disabledFrameRef.get(windowKey) || 0;
         if (refCount > 1) {

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -1130,12 +1130,14 @@ Window.embed = function(identity, parentHwnd) {
 };
 
 Window.enableFrame = function(identity) {
+    const windowKey = genWindowKey(identity);
     let browserWindow = getElectronBrowserWindow(identity);
 
     if (!browserWindow) {
         return;
     }
-
+    let dframeRefCount = disabledFrameRef.get(windowKey) || 0;
+    disabledFrameRef.set(windowKey, --dframeRefCount);
     browserWindow.setUserMovementEnabled(true);
 };
 

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -1082,7 +1082,7 @@ Window.close = function(identity, force, callback = () => {}) {
 };
 
 function dissabledFrameUnsubDecorator(identity) {
-    const windowKey = genWindowKey(identity);
+    const windowKey = genWindowKey(identity)
     return function() {
         let refCount = disabledFrameRef.get(windowKey) || 0;
         if (refCount > 1) {
@@ -1095,7 +1095,7 @@ function dissabledFrameUnsubDecorator(identity) {
 
 Window.disableFrame = function(requestorIdentity, windowIdentity) {
     let browserWindow = getElectronBrowserWindow(windowIdentity);
-    const windowKey = `${windowIdentity.uuid}-${windowIdentity.name}`;
+    const windowKey = genWindowKey(windowIdentity);
 
     if (!browserWindow) {
         return;

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -1081,7 +1081,7 @@ Window.close = function(identity, force, callback = () => {}) {
     handleForceActions(identity, force, 'close-requested', payload, defaultAction);
 };
 
-function dissabledFrameUnsubDecorator(identity) {
+function disabledFrameUnsubDecorator(identity) {
     const windowKey = genWindowKey(identity);
     return function() {
         let refCount = disabledFrameRef.get(windowKey) || 0;
@@ -1094,7 +1094,7 @@ function dissabledFrameUnsubDecorator(identity) {
 }
 
 Window.disableFrame = function(requestorIdentity, windowIdentity) {
-    let browserWindow = getElectronBrowserWindow(windowIdentity);
+    const browserWindow = getElectronBrowserWindow(windowIdentity);
     const windowKey = genWindowKey(windowIdentity);
 
     if (!browserWindow) {
@@ -1103,7 +1103,7 @@ Window.disableFrame = function(requestorIdentity, windowIdentity) {
 
     let dframeRefCount = disabledFrameRef.get(windowKey) || 0;
     disabledFrameRef.set(windowKey, ++dframeRefCount);
-    subscriptionManager.registerSubscription(dissabledFrameUnsubDecorator(windowIdentity), requestorIdentity, `disable-frame-${windowKey}`);
+    subscriptionManager.registerSubscription(disabledFrameUnsubDecorator(windowIdentity), requestorIdentity, `disable-frame-${windowKey}`);
     browserWindow.setUserMovementEnabled(false);
 };
 

--- a/src/browser/api_protocol/api_handlers/window.js
+++ b/src/browser/api_protocol/api_handlers/window.js
@@ -476,7 +476,7 @@ function disableWindowFrame(identity, message, ack) {
     var payload = message.payload,
         windowIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
 
-    Window.disableFrame(windowIdentity);
+    Window.disableFrame(identity, windowIdentity);
     ack(successAck);
 }
 


### PR DESCRIPTION
Making sure that on a entity close/disconnect event we enable the window **frame**

Tests:

[Win10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b32687954b21953031f3632)
[Win7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b3267c154b21953031f3631)