### PR TITLE
RUN-4032 - Fix for Application getInfo

### DIFF
--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -343,14 +343,22 @@ Application.getShortcuts = function(identity, callback, errorCallback) {
 };
 
 Application.getInfo = function(identity, callback) {
-    const app = Application.wrap(identity.uuid);
-    const manifestObj = coreState.getManifest(identity);
-    const { url: manifestUrl, manifest } = manifestObj;
+    const app = coreState.appByUuid(identity.uuid);
+    let manifestUrl = app && app._configUrl;
+    let manifest;
+    if (manifestUrl) {
+        manifest = coreState.getManifestByUrl(manifestUrl);
+    } else {
+        const manifestObj = coreState.getManifest(identity);
+        manifestUrl = manifestObj && manifestObj.url;
+        manifest = manifestObj && manifestObj.manifest;
+    }
 
     const parentUuid = Application.getParentApplication(identity);
+    const launchMode = app && app.appObj && app.appObj.launchMode;
 
     const response = {
-        launchMode: app.launchMode,
+        launchMode,
         manifestUrl,
         manifest,
         parentUuid

--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -347,8 +347,7 @@ Application.getInfo = function(identity, callback) {
     const manifestObj = coreState.getManifest(identity);
     const { url: manifestUrl, manifest } = manifestObj;
 
-    const parentApp = coreState.getAppAncestor(identity.uuid);
-    const parentUuid = (parentApp.uuid === identity.uuid) ? null : parentApp.uuid;
+    const parentUuid = Application.getParentApplication(identity);
 
     const response = {
         launchMode: app.launchMode,

--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -132,6 +132,7 @@ Application.create = function(opts, configUrl = '', parentIdentity = {}) {
 
     let appUrl = opts.url;
     const { uuid, name } = opts;
+    const initialAppOptions = Object.assign({}, opts);
 
     if (appUrl === undefined && opts.mainWindowOptions) {
         appUrl = opts.mainWindowOptions.url;
@@ -169,14 +170,15 @@ Application.create = function(opts, configUrl = '', parentIdentity = {}) {
     }
 
     const appObj = createAppObj(uuid, opts, configUrl);
+    const app = coreState.appByUuid(opts.uuid);
 
     if (parentIdentity && parentIdentity.uuid) {
         // This is a reference to the meta `app` object that is stored in core state,
         // not the actual `application` object created above. Here we are attaching the parent
         // identity to it.
-        const app = coreState.appByUuid(opts.uuid);
         app.parentUuid = parentUuid;
     }
+    app.initialAppOptions = initialAppOptions;
 
     return appObj;
 };
@@ -352,6 +354,7 @@ Application.getInfo = function(identity, callback) {
     const launchMode = app && app.appObj && app.appObj.launchMode;
 
     const response = {
+        initialOptions: app.initialAppOptions,
         launchMode,
         manifestUrl: url,
         manifest,

--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -346,14 +346,14 @@ Application.getInfo = function(identity, callback) {
     const app = coreState.appByUuid(identity.uuid);
 
     const manifestObj = coreState.getClosestManifest(identity);
-    const { url: manifestUrl, manifest } = manifestObj || {};
+    const { url, manifest } = manifestObj || {};
 
     const parentUuid = Application.getParentApplication(identity);
     const launchMode = app && app.appObj && app.appObj.launchMode;
 
     const response = {
         launchMode,
-        manifestUrl,
+        manifestUrl: url,
         manifest,
         parentUuid
     };

--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -344,15 +344,9 @@ Application.getShortcuts = function(identity, callback, errorCallback) {
 
 Application.getInfo = function(identity, callback) {
     const app = coreState.appByUuid(identity.uuid);
-    let manifestUrl = app && app._configUrl;
-    let manifest;
-    if (manifestUrl) {
-        manifest = coreState.getManifestByUrl(manifestUrl);
-    } else {
-        const manifestObj = coreState.getManifest(identity);
-        manifestUrl = manifestObj && manifestObj.url;
-        manifest = manifestObj && manifestObj.manifest;
-    }
+
+    const manifestObj = coreState.getClosestManifest(identity);
+    const { url: manifestUrl, manifest } = manifestObj || {};
 
     const parentUuid = Application.getParentApplication(identity);
     const launchMode = app && app.appObj && app.appObj.launchMode;

--- a/src/browser/core_state.ts
+++ b/src/browser/core_state.ts
@@ -32,7 +32,6 @@ import * as Shapes from '../shapes';
 import { writeToLog } from './log';
 import { FrameInfo } from './api/frame';
 import * as electronIPC from './transports/electron_ipc';
-import { AppObj } from '../shapes';
 
 export interface StartManifest {
     data: Shapes.Manifest;
@@ -100,11 +99,10 @@ export function getManifestByUrl(url: string): Shapes.Manifest {
 }
 
 export function getClosestManifest(identity: Shapes.Identity): ManifestInfo {
-    // Gets the manifest of the aplication or the closest parent with a saved manifest
-    const uuid = identity && identity.uuid;
+    // Gets an applications manifest or if not launched via manifest, the closest parent with a saved manifest
+    const { uuid } = identity;
     const app = appByUuid(uuid);
-    const appObj = app && app.appObj;
-    const url = app && app._configUrl || appObj && appObj._configUrl;
+    const url = app && app._configUrl || app.appObj && app.appObj._configUrl;
     if (url) {
         const manifest = getManifestByUrl(url);
         return { url, manifest };

--- a/src/browser/core_state.ts
+++ b/src/browser/core_state.ts
@@ -32,6 +32,7 @@ import * as Shapes from '../shapes';
 import { writeToLog } from './log';
 import { FrameInfo } from './api/frame';
 import * as electronIPC from './transports/electron_ipc';
+import { AppObj } from '../shapes';
 
 export interface StartManifest {
     data: Shapes.Manifest;
@@ -96,6 +97,21 @@ export function getManifest(identity: Shapes.Identity): ManifestInfo {
 
 export function getManifestByUrl(url: string): Shapes.Manifest {
    return manifests.get(url);
+}
+
+export function getClosestManifest(identity: Shapes.Identity): ManifestInfo {
+    // Gets the manifest of the aplication or the closest parent with a saved manifest
+    const uuid = identity && identity.uuid;
+    const app = appByUuid(uuid);
+    const appObj = app && app.appObj;
+    const url = app && app._configUrl || appObj && appObj._configUrl;
+    if (url) {
+        const manifest = getManifestByUrl(url);
+        return { url, manifest };
+    } else {
+        const parentApp = appByUuid(app.parentUuid);
+        return parentApp ? getClosestManifest(parentApp) : null;
+    }
 }
 
 export function setStartManifest(url: string, data: Shapes.Manifest): void {

--- a/src/browser/core_state.ts
+++ b/src/browser/core_state.ts
@@ -94,6 +94,10 @@ export function getManifest(identity: Shapes.Identity): ManifestInfo {
     return { url, manifest };
 }
 
+export function getManifestByUrl(url: string): Shapes.Manifest {
+   return manifests.get(url);
+}
+
 export function setStartManifest(url: string, data: Shapes.Manifest): void {
     startManifest = { url, data };
     setManifestProxySettings((data && data.proxy) || undefined);


### PR DESCRIPTION
This used to get the root ancestors manifest information, and now gets the closest parent (i.e. its own if launched from manifest, if not recursively check if parent was and return the first manifest.) . I also added initialOptions for when an app is not launched from manifest.  

I added a UUID check to [this test](https://testing-dashboard.openfin.co/#/app/tests/5b118f15f2f2e22fa4b7c266/edit) to ensure it is the correct manifest.

[PR for change to javascript-adapter docs](https://github.com/openfin/javascript-adapter/pull/447)

[Win7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b3b85ed54b21953031f366b)
[Win10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b3b875354b21953031f366e)
 [redo 1 failed win7 test](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b3b886854b21953031f3670)