### PR TITLE
RUN-4241 - Fix undefined return when parent is in another runtime

### DIFF
--- a/src/browser/core_state.ts
+++ b/src/browser/core_state.ts
@@ -632,7 +632,9 @@ export function getAppAncestor(descendantAppUuid: string): Shapes.App {
     const app = appByUuid(descendantAppUuid);
 
     if (app && app.parentUuid) {
-        return getAppAncestor(app.parentUuid);
+        // If parentApp exists but can't be found in coreState, it is in another runtime
+        const parentApp = appByUuid(descendantAppUuid);
+        return parentApp ? getAppAncestor(app.parentUuid) : app;
     } else {
         return app;
     }

--- a/src/browser/core_state.ts
+++ b/src/browser/core_state.ts
@@ -633,7 +633,7 @@ export function getAppAncestor(descendantAppUuid: string): Shapes.App {
 
     if (app && app.parentUuid) {
         // If parentApp exists but can't be found in coreState, it is in another runtime
-        const parentApp = appByUuid(descendantAppUuid);
+        const parentApp = appByUuid(app.parentUuid);
         return parentApp ? getAppAncestor(app.parentUuid) : app;
     } else {
         return app;


### PR DESCRIPTION
This is an interim fix to getAppAncestor, it would return undefined if the parent application was in another runtime.  Now, it will return the app before it.  

I created a [JIRA](https://appoji.jira.com/browse/RUN-4241) to investigate and fix this more permanently as I dont think we would always want to get the app ancestor if it is in another runtime (see JIRA).

[Win7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b3b867c54b21953031f366c)
[Win10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b3b879c54b21953031f366f)
