### PR TITLE
unsubscriptions.get is not a function exception

### DIFF
--- a/src/browser/remote_subscriptions.ts
+++ b/src/browser/remote_subscriptions.ts
@@ -92,19 +92,19 @@ export function addRemoteSubscription(subscriptionProps: RemoteSubscriptionProps
             subscription.unSubscriptions = new Map();
         }
 
-        return connectionManager.resolveIdentity({
+        connectionManager.resolveIdentity({
             uuid: subscription.uuid
 
         }).then((id) => {
             // Found app/window in a remote runtime, subscribing
-            return applyRemoteSubscription(subscription, id.runtime);
+            applyRemoteSubscription(subscription, id.runtime);
 
         }).catch(() => {
             // App/window not found. We are assuming it will come up sometime in the future.
             // For now, subscribe in all current connected runtimes and add the subscription
             // to the pending list for future runtimes
             pendingRemoteSubscriptions.set(subscription._id, subscription);
-            return connectionManager.connections.forEach((runtime) => {
+            connectionManager.connections.forEach((runtime) => {
                 applyRemoteSubscription(subscription, runtime);
             });
 

--- a/src/browser/remote_subscriptions.ts
+++ b/src/browser/remote_subscriptions.ts
@@ -146,7 +146,7 @@ async function applyRemoteSubscription(subscription: RemoteSubscription, runtime
 
 
     // Subscribe to an event on a remote runtime
-    await classEventEmitter[listenType](eventName, listener);
+    classEventEmitter[listenType](eventName, listener);
 
 
     // Store a cleanup function for the added listener in


### PR DESCRIPTION
Fixed issue where remote subscriptions `unSubscriptions`map was being cleared on disconnect but not recreated on runtime re-connect.

### Issue description:

The subscription object is initialized once in [addRemoteSubscription](https://github.com/HadoukenIO/core/blob/develop/src/browser/remote_subscriptions.ts#L80) and cleaned on disconnects on [unSubscribe](https://github.com/HadoukenIO/core/blob/develop/src/browser/remote_subscriptions.ts#L212). This does not take into consideration the fact that this subscription will be re-enabled if the identity is found in a new runtime or if it is a system subscription via [applyAllRemoteSubscriptions](https://github.com/HadoukenIO/core/blob/develop/src/browser/remote_subscriptions.ts#L226)

### The fix: 

When we [applyRemoteSubscription](https://github.com/HadoukenIO/core/blob/develop/src/browser/remote_subscriptions.ts#L122) we check to see if the unsubscription map has been cleared and reset it if it has been.
### Test results: 

[Win10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b3b8c8a54b21953031f3672)
[Win7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b3b8b6354b21953031f3671)

TODO:
- [ ] New js-adapter test