### PR TITLE
changed mocha test reporting

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -169,7 +169,10 @@ module.exports = (grunt) => {
         },
         mochaTest: {
             default: {
-                src: ['staging/core/test/**.js']
+                src: ['staging/core/test/**.js'],
+                options: {
+                    reporter: 'dot'
+                }
             }
         }
     });


### PR DESCRIPTION
ℹ️ **About**
This PR changes the way Mocha reports back test results.
It was too verbose, we only really care about failed tests. Let's change it.

**Before** (99+ lines, both succeeded and failed tests are shown)
![screen shot 2018-07-05 at 2 21 06 pm](https://user-images.githubusercontent.com/5790216/42340844-27249d5c-805f-11e8-8720-9c5bb70eb90f.png)

**Now** (2 lines, only failed tests are shown)
![screen shot 2018-07-05 at 2 22 04 pm](https://user-images.githubusercontent.com/5790216/42340858-3146d0b6-805f-11e8-9f3d-f55aacebb0ea.png)
