### PR TITLE
Prevent mockery noise

### DIFF
--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -18,7 +18,10 @@ import * as mockery from 'mockery';
 import {mockElectron, lastLogValue, lastVlogValue} from './electron';
 
 mockery.registerMock('electron', mockElectron);
-mockery.enable();
+mockery.enable({
+    warnOnReplace: false,
+    warnOnUnregistered: false
+});
 import * as errors from '../src/common/errors';
 
 describe('Errors', () => {

--- a/test/global_hotkey.tests.ts
+++ b/test/global_hotkey.tests.ts
@@ -24,7 +24,10 @@ import route from '../src/common/route';
 const sinon = require('sinon');
 
 mockery.registerMock('electron', mockElectron);
-mockery.enable();
+mockery.enable({
+    warnOnReplace: false,
+    warnOnUnregistered: false
+});
 import { GlobalHotkey } from '../src/browser/api/global_hotkey';
 
 describe('GlobalHotkey', () => {

--- a/test/log.test.ts
+++ b/test/log.test.ts
@@ -19,7 +19,10 @@ import * as mockery from 'mockery';
 import {mockElectron, lastLogValue, lastVlogValue} from './electron';
 
 mockery.registerMock('electron', mockElectron);
-mockery.enable();
+mockery.enable({
+    warnOnReplace: false,
+    warnOnUnregistered: false
+});
 import * as log from '../src/browser/log';
 
 describe('log', () => {

--- a/test/peer_connection_manager.tests.ts
+++ b/test/peer_connection_manager.tests.ts
@@ -62,7 +62,10 @@ const nodeAdapter = {
 };
 
 mockery.registerMock('hadouken-js-adapter', nodeAdapter);
-mockery.enable();
+mockery.enable({
+    warnOnReplace: false,
+    warnOnUnregistered: false
+});
 
 
 before(() => {

--- a/test/rvm_message_bus.test.ts
+++ b/test/rvm_message_bus.test.ts
@@ -36,7 +36,10 @@ const mockWMCopyData = {
 
 mockery.registerMock('electron', mockElectron);
 mockery.registerMock('../transport', mockWMCopyData);
-mockery.enable();
+mockery.enable({
+    warnOnReplace: false,
+    warnOnUnregistered: false
+});
 
 import {rvmMessageBus, RVMMessageBus} from '../src/browser/rvm/rvm_message_bus';
 


### PR DESCRIPTION
ℹ️ **About**
This PR prevents `mockery` module to pollute (when running tests) standard out with noise about whether it's mocking or not mocking modules (screenshot below)
![screen shot 2018-07-05 at 4 18 30 pm](https://user-images.githubusercontent.com/5790216/42346526-f9a97674-8070-11e8-8eb5-28f2efaeb428.png)

**Automated test results**
✅ [Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b3e857054b21953031f3694)
✅ [Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b3e863f54b21953031f3695)