### PR TITLE
8.56.30/staging into 9.61.32/staging

### DIFF
--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -100,7 +100,6 @@ function five0BaseOptions() {
         'name': '',
         'opacity': 1,
         'plugins': false,
-        'spellCheck': false, // app level
         'resizable': true,
         'resize': true,
         'resizeRegion': {
@@ -112,6 +111,7 @@ function five0BaseOptions() {
         'shadow': false,
         'showTaskbarIcon': true,
         'smallWindow': false,
+        'spellCheck': false, // app level
         'state': 'normal',
         'taskbarIcon': '',
         'taskbarIconGroup': '',

--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -112,7 +112,6 @@ function five0BaseOptions() {
         'shadow': false,
         'showTaskbarIcon': true,
         'smallWindow': false,
-        'spellCheck': false, // app level
         'state': 'normal',
         'taskbarIcon': '',
         'taskbarIconGroup': '',


### PR DESCRIPTION
One small fix (duplicate `spellCheck` key). Tests are all clean
[win 10 x64](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b4379e254b21953031f36a9)
[Windows 7 (64-bit)](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b4378af54b21953031f36a7)
[Megatron W7 Runtime 32](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b4378cc54b21953031f36a8)