### PR TITLE
RUN-4102 enable safe errors mode by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,6 @@ let firstApp = null;
 let rvmBus;
 let otherInstanceRunning = false;
 let appIsReady = false;
-let handlingErrors = false;
 const deferredLaunches = [];
 const USER_DATA = app.getPath('userData');
 let resolveServerReady;
@@ -174,8 +173,8 @@ handleMacSingleTenant();
 // Opt in to launch crash reporter
 initializeCrashReporter(coreState.argo);
 
-// Opt in to display non-blocking errors
-handleSafeErrors(coreState.argo);
+// Safe errors initialization
+errors.initSafeErrors(coreState.argo);
 
 // Has a local copy of an app config
 if (coreState.argo['local-startup-url']) {
@@ -191,20 +190,10 @@ if (coreState.argo['local-startup-url']) {
     }
 }
 
-function handleSafeErrors(argo) {
-    if (!handlingErrors && argo['safe-errors']) {
-        process.on('uncaughtException', (err) => {
-            errors.createErrorUI(err);
-        });
-        handlingErrors = true;
-    }
-}
-
 const handleDelegatedLaunch = function(commandLine) {
     let otherInstanceArgo = minimist(commandLine);
 
     initializeCrashReporter(otherInstanceArgo);
-    handleSafeErrors(otherInstanceArgo);
 
     // delegated args from a second instance
     launchApp(otherInstanceArgo, false);

--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -17,6 +17,7 @@ import ofEvents from '../browser/of_events';
 import route from './route';
 import { app } from 'electron';
 import * as log from '../browser/log';
+
 /**
  * Interface of a converted JS error into a plain object
  */
@@ -37,7 +38,25 @@ export function errorToPOJO(error: Error): ErrorPlainObject {
     };
 }
 
-export function createErrorUI(err: Error) {
+/*
+    Safe errors
+*/
+let isInitSafeErrors = false;
+export function initSafeErrors(argo: any) {
+    // Safety check to make sure to process safe errors only once
+    // at first runtime instance initialization
+    if (isInitSafeErrors) {
+        return;
+    }
+
+    if (!argo['disable-safe-errors']) {
+        process.on('uncaughtException', createErrorUI);
+    }
+
+    isInitSafeErrors = true;
+}
+
+function createErrorUI(err: Error) {
     // prevent issue with circular dependencies.
     const Application = require('../browser/api/application').Application;
     const coreState = require('../browser/core_state');


### PR DESCRIPTION
ℹ️ **About**
This PR enables *safe-errors* mode by default, with an option to opt out by providing `--disable-safe-errors` runtime flag

🚥 **Automated test results**
✅ [Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b46329254b21953031f36e9)
✅ [Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b46335454b21953031f36ea)