### PR TITLE
RUN-4211 Fixed notification ondismiss not working issue

### DIFF
--- a/src/browser/api/notifications/subscriptions.ts
+++ b/src/browser/api/notifications/subscriptions.ts
@@ -540,7 +540,7 @@ function routeRequest(id: any, msg: NotificationMessage, ack: any) {
             break;
 
         case NoteAction.dismiss:
-            dispatchEvent('dismiss', msg);
+            requestNoteClose(msg);
             break;
 
         case NoteAction.show:


### PR DESCRIPTION
This PR fixed notification ondismiss not working issue.

Tests: [Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b460a4054b21953031f36e3)   [Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b460b4b54b21953031f36e6)

[Manual Test added](https://github.com/openfin/test_apps/pull/30)