### PR TITLE
Made 'will-close' eveent public as 'closing'

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -125,6 +125,9 @@ let browserWindowEventMap = {
     },
     'unmaximize': {
         topic: 'restored'
+    },
+    'will-close': {
+        topic: 'closing'
     }
     // 'move': {
     //     topic: 'bounds-changing'


### PR DESCRIPTION
Exposing internal `will-close` event publicly as `closing`.

### Test Results:
[Win 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b48049954b21953031f3711)
[Win 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b4805b754b21953031f3712)

### TODO:
- [ ] New tests in test runner
- [X] [Docs PR](https://github.com/openfin/javascript-adapter/pull/453)