### PR TITLE
updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ _The following setup is known to be working well. You can try other versions at 
 own risk of losing a lot of time._
 * [Visual Studio 2015 Build Tools](http://landinghub.visualstudio.com/visual-cpp-build-tools) *
 * [OpenFin runtime executables](https://developer.openfin.co/versions/?product=Runtime&version=stabe) 
-* [Node](https://nodejs.org/download/release/v6.9.0/) 6.9.0
+* [Node](https://nodejs.org/download/release/v6.14.2/) 6.14.2
 * Grunt (`grunt-cli` 1.2.0)
 * [Python 2.7.12](https://www.python.org/downloads/release/python-2712/)
 * _Optional:_ `node-inspector` 0.12.3 _(problems with 0.12.4 - 0.12.8)_


### PR DESCRIPTION
Npm that comes with node v6.9.0 seems to have problems with shrink-wrapping extraneous packages (openfin-sign)