### PR TITLE
RUN-4293: backgroundThrottling not being passed to Runtime

### DIFF
--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -235,7 +235,8 @@ module.exports = {
             plugins: newOptions.plugins,
             preload: (!useNodeInRenderer ? noNodePreload : ''),
             sandbox: !useNodeInRenderer,
-            spellCheck: newOptions.spellCheck
+            spellCheck: newOptions.spellCheck,
+            backgroundThrottling: newOptions.backgroundThrottling
         };
 
         if (coreState.argo['disable-web-security'] || newOptions.webSecurity === false) {


### PR DESCRIPTION
Tests 

[W10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b4f7dbf54b21953031f374c)
[W7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b4f7ce054b21953031f374b)
