### PR TITLE
RUN-4238: not override remote-debugging-port from ChromeDriver

### DIFF
--- a/index.js
+++ b/index.js
@@ -168,10 +168,10 @@ if (coreState.argo['local-startup-url']) {
 
         if (typeof localConfig['devtools_port'] === 'number') {
             if (!coreState.argo['remote-debugging-port']) {
-                console.log('remote-debugging-port:', localConfig['devtools_port']);
+                log.writeToLog(1, `remote-debugging-port: ${localConfig['devtools_port']}`, true);
                 app.commandLine.appendSwitch('remote-debugging-port', localConfig['devtools_port'].toString());
             } else {
-                console.log('Ignoring devtools_port from manifest');
+                log.writeToLog(1, 'Ignoring devtools_port from manifest', true);
             }
         }
     } catch (err) {

--- a/index.js
+++ b/index.js
@@ -167,8 +167,12 @@ if (coreState.argo['local-startup-url']) {
         let localConfig = JSON.parse(fs.readFileSync(coreState.argo['local-startup-url']));
 
         if (typeof localConfig['devtools_port'] === 'number') {
-            console.log('remote-debugging-port:', localConfig['devtools_port']);
-            app.commandLine.appendSwitch('remote-debugging-port', localConfig['devtools_port'].toString());
+            if (!coreState.argo['remote-debugging-port']) {
+                console.log('remote-debugging-port:', localConfig['devtools_port']);
+                app.commandLine.appendSwitch('remote-debugging-port', localConfig['devtools_port'].toString());
+            } else {
+                console.log('Ignoring devtools_port from manifest');
+            }
         }
     } catch (err) {
         console.error(err);


### PR DESCRIPTION
Tests

[W10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b4fafd454b21953031f374f)
[W7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b4faf3b54b21953031f374e)

