### PR TITLE
RUN-3607: Use userData instead of userCache in getLog{,List}

### DIFF
--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -289,7 +289,7 @@ exports.System = {
         if (pathSafeName === name) {
             var pattern = /^debug.*\.log$/;
             if (pattern.test(pathSafeName)) {
-                fs.readFile(electronApp.getPath('userCache') + '/' + pathSafeName, {
+                fs.readFile(electronApp.getPath('userData') + '/' + pathSafeName, {
                     encoding: 'utf8'
                 }, (err, data) => {
                     if (!err) {
@@ -306,7 +306,7 @@ exports.System = {
         }
     },
     getLogList: function(callback, options) {
-        fs.readdir(electronApp.getPath('userCache'), function(err, files) {
+        fs.readdir(electronApp.getPath('userData'), function(err, files) {
             let opts = options || {};
 
             if (!err) {
@@ -323,7 +323,7 @@ exports.System = {
                     var processFileStats = function() {
                         var name = logFiles[index++];
 
-                        fs.stat(electronApp.getPath('userCache') + '/' + name, (err, stats) => {
+                        fs.stat(electronApp.getPath('userData') + '/' + name, (err, stats) => {
                             if (!err) {
                                 fileStats.push({
                                     name: name,


### PR DESCRIPTION
**Theorem.** This change:
* fixes the functions' behaviour in OS X; and
* leaves the existing correct behaviour in Windows untouched.

_Proof._ OS X is currently single-tenant, so the `userData` and `userCache`
values are modified to write to a config URL-specific folder [1]. However, when
an app is started up, the logger is redirected to a different file, and more
importantly, resets the value of `userData` [2]. Ergo, `userData` now contains
the correct directory where logs reside, rather than `userCache`. ■

[1] https://github.com/HadoukenIO/core/blob/e38be77be1afd9f236bc91249cde9bb5de200582/index.js#L726,L727
[2] https://github.com/openfin/runtime/blob/fc0c28d9e3750d7bdb771a9676c11fd110f4afe9/atom/browser/api/atom_api_app.cc#L1713