### PR TITLE
RUN-4266 cannot-destructure-uuid-undefined

### DIFF
--- a/src/browser/subscription_manager.ts
+++ b/src/browser/subscription_manager.ts
@@ -28,7 +28,8 @@ export default class SubscriptionManager {
     constructor() {
         this.subscriptionList = new Map();
 
-        ofEvents.on(route.window('closed', '*'), (identity: Identity) => {
+        ofEvents.on(route.window('closed', '*'), (event: any) => {
+            const identity: Identity = event.data[0];
             this.removeAllSubscriptions(identity);
         });
 

--- a/test/global_hotkey.tests.ts
+++ b/test/global_hotkey.tests.ts
@@ -202,7 +202,7 @@ describe('GlobalHotkey', () => {
 
         GlobalHotkey.register(identity, hotkey, spy);
         //we simulate a window close.
-        ofEvents.emit(route.window('closed', '*'), identity);
+        ofEvents.emit(route.window('closed', identity.uuid, identity.name), identity);
         const isRegistered = GlobalHotkey.isRegistered(hotkey);
         assert.deepStrictEqual(isRegistered, false, 'Expected hotkey to not be registered');
     });
@@ -242,7 +242,7 @@ describe('GlobalHotkey', () => {
         GlobalHotkey.register(identity2, hotkey, spy2);
 
         //we simulate a window close.
-        ofEvents.emit(route.window('closed', '*'), identity2);
+        ofEvents.emit(route.window('closed', identity2.uuid, identity2.name), identity2);
 
         mockElectron.globalShortcut.mockRaiseEvent(hotkey);
         assert.ok(spy.calledOnce, 'Expected the global shortcut to be called');


### PR DESCRIPTION
Fixes the core error when restarting an application listening to 'application-created'.

Tests: [7](https://testing-dashboard.open) [10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b50f34354b21953031f375c)