### PR TITLE
RUN-4322 getApplicationGroups should only return necessary properties

### DIFF
--- a/src/browser/api_protocol/api_handlers/application.js
+++ b/src/browser/api_protocol/api_handlers/application.js
@@ -183,9 +183,7 @@ function getApplicationGroups(identity, message, ack) {
     dataAck.data = _.map(groups, groupOfWindows => {
         return _.map(groupOfWindows, window => {
             if (payload.crossApp === true) {
-                var _window = _.clone(window);
-                _window.windowName = window.name;
-                return _window;
+                return { uuid: window.uuid, name: window.name, windowName: window.name };
             } else {
                 return window.name; // backward compatible
             }


### PR DESCRIPTION
[Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b563e9c54b21953031f37ba)

[Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b563c5754b21953031f37b8)