### PR TITLE
RUN-4329 Nested dependencies are not packaged

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,8 +12,33 @@ const asar = require('asar');
 const electronRebuild = require('electron-rebuild');
 const wrench = require('wrench');
 const openfinSign = require('openfin-sign'); // OpenFin signing module
+const childProcess = require('child_process');
 
-const dependencies = Object.keys(require('./package.json').dependencies).map(dep => `${dep}/**`);
+// Use NPM to query immediate and nested production dependencies
+const npmDeps = JSON.parse(childProcess.execSync('npm ls --json --prod').toString('utf8'));
+const fullDependencies = Object.entries(npmDeps.dependencies);
+
+// Flatten all production dependencies, including nested ones, into an array.
+// Prevents duplicates.
+function flattenDeep(arr1, usedModules) {
+    return arr1.reduce((acc, val) => {
+        // Add top level dependencies without duplicates
+        if(!usedModules[val[0]]) {
+            usedModules[val[0]] = true;
+            acc.push(`${val[0]}/**`); 
+        }
+
+        // Handle nested dependencies
+        const subDep = val[1].dependencies;
+        if(typeof subDep === 'object') {
+            acc = acc.concat(flattenDeep(Object.entries(subDep), usedModules));
+        } 
+
+        return acc;
+    }, []);
+}
+
+const dependencies = flattenDeep(fullDependencies, {});
 const srcFiles = ['src/**/*.js', 'index.js', 'Gruntfile.js'];
 const stagingNodeModulesPath = path.join('staging', 'core', 'node_modules');
 const jsAdapterPath = path.join('node_modules', 'hadouken-js-adapter', 'out');

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,6 +14,21 @@ const wrench = require('wrench');
 const openfinSign = require('openfin-sign'); // OpenFin signing module
 const childProcess = require('child_process');
 
+// Polyfill for pre Node v7.0.0
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries#Polyfill
+if (!Object.entries) {
+  Object.entries = function( obj ) {
+    var ownProps = Object.keys( obj ),
+        i = ownProps.length,
+        resArray = new Array(i); // preallocate the Array
+    while (i--) {
+      resArray[i] = [ownProps[i], obj[ownProps[i]]];
+    }
+    
+    return resArray;
+  };
+}
+
 // Use NPM to query immediate and nested production dependencies
 const npmDeps = JSON.parse(childProcess.execSync('npm ls --json --prod').toString('utf8'));
 const fullDependencies = Object.entries(npmDeps.dependencies);


### PR DESCRIPTION
# Packaging nested dependencies
Adding new dependencies to the core _(with nested dependencies)_ was problematic. The developer was forced to explicitly add all nested dependencies at the top-level of the project to avoid errors at runtime. 

This PR leverages NPM to query immediate and nested production dependencies ensuring all required modules are present in the final output asar/folder

**NOTE** : The _js-adapter_ includes `@types` as a production dependency.

#### Packaged dependencies before this PR
```
hadouken-js-adapter
minimist
options
rx
ultron
underscore
ws
```


#### Packaged dependencies after this PR
```
@types
hadouken-js-adapter
minimist
options
rx
ultron
underscore
ws
```

###### Test results _without_ the changes for `9.61.34.3`:
https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b5783fb54b21953031f37dc

###### Test results _with_ the changes applied to `9.61.34.3`:
https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b577cb354b21953031f37da
