### PR TITLE
RUN-3911 normalize errors

### DIFF
--- a/assets/error.html
+++ b/assets/error.html
@@ -73,9 +73,8 @@
 	<div id="container-error">
 		<img class="error-icon" src="error-icon.png">
 		<div id="error-wrapper">
-			<div id="error-title">A JavaScript error occurred in the main process</div>
+			<div id="error-title"></div>
 			<div id="error-body">
-				<div>Uncaught Exception:</div>
 				<div id="error-message"></div>
 			</div>
 		</div>
@@ -98,15 +97,22 @@
 
 		async function getExceptionData() {
 			const wnd = await fin.Window.getCurrent();
-			const { customData } = await wnd.getOptions();
+			const { customData: { title, error } } = await wnd.getOptions();
+			const errorTitleEl = document.querySelector('#error-title');
 			const errorMessageEl = document.querySelector('#error-message');
-
-			errorMessageEl.innerHTML = customData.error.stack;
+			
+			if (title) {
+				errorTitleEl.innerHTML = title;
+			} else {
+				errorTitleEl.remove();
+			}
+			
+			errorMessageEl.innerHTML = error;
 			
 			// Keep increasing the height of the error dialog until
 			// the error message is fully visible. This will ensure
 			// error dialogs are not too big in height.
-			let resizeSafetyCount = 30; // for safety, max 30 resizes (300px)
+			let resizeSafetyCount = 50; // for safety, max 50 resizes (500px)
 			while (resizeSafetyCount-- && !isElementInViewport(errorMessageEl)) {
 				await wnd.resizeBy(0, 10);
 				await wait(); // needs a small break for resizing to be fully done
@@ -115,7 +121,7 @@
 			await wnd.show();
 			
 			document.body.addEventListener('copy', (event) => {
-				fin.Clipboard.writeText({ data: customData.error.stack });
+				fin.Clipboard.writeText({ data: error });
 			});
 		}
 

--- a/index.js
+++ b/index.js
@@ -572,7 +572,7 @@ function launchApp(argo, startExternalAdapterServer) {
         });
     }, (error) => {
         const title = errors.ERROR_TITLE_APP_INITIALIZATION;
-        const type = errors.ERROR_TYPE_APP_INITIALIZATION;
+        const type = errors.ERROR_BOX_TYPES.APP_INITIALIZATION;
         const args = { error, title, type };
         errors.showErrorBox(args)
             .catch((error) => log.writeToLog('info', error))
@@ -617,7 +617,7 @@ function initFirstApp(configObject, configUrl, licenseKey) {
 
         const message = startupAppOptions.loadErrorMessage;
         const title = errors.ERROR_TITLE_APP_INITIALIZATION;
-        const type = errors.ERROR_TYPE_APP_INITIALIZATION;
+        const type = errors.ERROR_BOX_TYPES.APP_INITIALIZATION;
         const args = { error, message, title, type };
         errors.showErrorBox(args)
             .catch((error) => log.writeToLog('info', error))

--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -32,7 +32,7 @@ import * as log from '../log';
 import SubscriptionManager from '../subscription_manager';
 import route from '../../common/route';
 import { isFileUrl, isHttpUrl, getIdentityFromObject } from '../../common/main';
-import { ERROR_TYPE_RENDERER_CRASH } from '../../common/errors';
+import { ERROR_BOX_TYPES } from '../../common/errors';
 
 const subscriptionManager = new SubscriptionManager();
 const TRAY_ICON_KEY = 'tray-icon-events';
@@ -659,7 +659,7 @@ function run(identity, mainWindowOpts, userAppConfigArgs) {
         coreState.removeApp(app.id);
 
         const shouldCloseRuntime =
-            app._options._type !== ERROR_TYPE_RENDERER_CRASH &&
+            app._options._type !== ERROR_BOX_TYPES.RENDERER_CRASH &&
             !app._options._runtimeAuthDialog &&
             !runtimeIsClosing &&
             coreState.shouldCloseRuntime();

--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -32,6 +32,7 @@ import * as log from '../log';
 import SubscriptionManager from '../subscription_manager';
 import route from '../../common/route';
 import { isFileUrl, isHttpUrl, getIdentityFromObject } from '../../common/main';
+import { ERROR_TYPE_RENDERER_CRASH } from '../../common/errors';
 
 const subscriptionManager = new SubscriptionManager();
 const TRAY_ICON_KEY = 'tray-icon-events';
@@ -657,7 +658,13 @@ function run(identity, mainWindowOpts, userAppConfigArgs) {
 
         coreState.removeApp(app.id);
 
-        if (!app._options._runtimeAuthDialog && !runtimeIsClosing && coreState.shouldCloseRuntime()) {
+        const shouldCloseRuntime =
+            app._options._type !== ERROR_TYPE_RENDERER_CRASH &&
+            !app._options._runtimeAuthDialog &&
+            !runtimeIsClosing &&
+            coreState.shouldCloseRuntime();
+
+        if (shouldCloseRuntime) {
             try {
                 runtimeIsClosing = true;
                 let appsToClose = coreState.getAllAppObjects();

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -36,12 +36,16 @@ import route from '../../common/route';
 import { FrameInfo } from './frame';
 import { System } from './system';
 import { isFileUrl, isHttpUrl, getIdentityFromObject } from '../../common/main';
-// constants
 import {
     DEFAULT_RESIZE_REGION_SIZE,
     DEFAULT_RESIZE_REGION_BOTTOM_RIGHT_CORNER,
     DEFAULT_RESIZE_SIDES
 } from '../../shapes';
+import {
+    ERROR_TITLE_RENDERER_CRASH,
+    ERROR_TYPE_RENDERER_CRASH,
+    showErrorBox
+} from '../../common/errors';
 
 const subscriptionManager = new SubscriptionManager();
 const isWin32 = process.platform === 'win32';
@@ -560,6 +564,15 @@ Window.create = function(id, opts) {
 
             if (isMainWindow) {
                 coreState.setAppRunningState(uuid, false);
+
+                // Show error box notifying the user of the crash
+                const message =
+                    `A crash occured in the renderer process of the ` +
+                    `application with the UUID "${uuid}"`;
+                const title = ERROR_TITLE_RENDERER_CRASH;
+                const type = ERROR_TYPE_RENDERER_CRASH;
+                const args = { message, title, type };
+                showErrorBox(args);
             }
         });
 

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -43,7 +43,7 @@ import {
 } from '../../shapes';
 import {
     ERROR_TITLE_RENDERER_CRASH,
-    ERROR_TYPE_RENDERER_CRASH,
+    ERROR_BOX_TYPES,
     showErrorBox
 } from '../../common/errors';
 
@@ -570,7 +570,8 @@ Window.create = function(id, opts) {
                     `A crash occured in the renderer process of the ` +
                     `application with the UUID "${uuid}"`;
                 const title = ERROR_TITLE_RENDERER_CRASH;
-                const type = ERROR_TYPE_RENDERER_CRASH;
+                const type = ERROR_BOX_TYPES.RENDERER_CRASH;
+                log.writeToLog('info', '==========> ' + type);
                 const args = { message, title, type };
                 showErrorBox(args);
             }

--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -1,7 +1,18 @@
+import { app } from 'electron';
+import { writeToLog } from '../browser/log';
+import * as path from 'path';
 import ofEvents from '../browser/of_events';
 import route from './route';
-import { app } from 'electron';
-import * as log from '../browser/log';
+
+// Error titles
+export const ERROR_TITLE_APP_INITIALIZATION = 'A JavaScript error occured during app initialization';
+export const ERROR_TITLE_MAIN_PROCESS = 'A JavaScript error occurred in the main process';
+export const ERROR_TITLE_RENDERER_CRASH = 'Renderer Crash';
+
+// Window types
+export const ERROR_TYPE_APP_INITIALIZATION = 'OF_error_box:app_initialization';
+export const ERROR_TYPE_MAIN_PROCESS = 'OF_error_box:main_process';
+export const ERROR_TYPE_RENDERER_CRASH = 'OF_error_box:renderer_crash';
 
 /**
  * Interface of a converted JS error into a plain object
@@ -10,6 +21,13 @@ interface ErrorPlainObject {
     stack: string;
     message: string;
     toString(): string;
+}
+
+interface ErrorBox {
+    error: Error; // error printed to logs
+    message?: string; // optional custom error message instead of error.stack
+    title?: string; // optional blue error title
+    type: string; // type of the error to add to window
 }
 
 /**
@@ -27,7 +45,7 @@ export function errorToPOJO(error: Error): ErrorPlainObject {
     Safe errors
 */
 let isInitSafeErrors = false;
-export function initSafeErrors(argo: any) {
+export function initSafeErrors(argo: any): void {
     // Safety check to make sure to process safe errors only once
     // at first runtime instance initialization
     if (isInitSafeErrors) {
@@ -35,58 +53,73 @@ export function initSafeErrors(argo: any) {
     }
 
     if (!argo['disable-safe-errors']) {
-        process.on('uncaughtException', createErrorUI);
+        process.on('uncaughtException', (error: Error) => {
+            const title = ERROR_TITLE_MAIN_PROCESS;
+            const type = ERROR_TYPE_MAIN_PROCESS;
+            showErrorBox({ error, title, type });
+        });
     }
 
     isInitSafeErrors = true;
 }
 
-function createErrorUI(err: Error) {
-    // prevent issue with circular dependencies.
-    const Application = require('../browser/api/application').Application;
-    const coreState = require('../browser/core_state');
+export function showErrorBox(data: ErrorBox): Promise<void> {
+    return new Promise((resolve) => {
 
-    const appUuid = `error-app-${app.generateGUID()}`;
+        // prevent issue with circular dependencies.
+        const { Application } = require('../browser/api/application');
+        const { argo, deleteApp } = require('../browser/core_state');
 
-    try {
-        const errorAppOptions = {
-            url: `file:///${__dirname}/../../assets/error.html`,
-            uuid: appUuid,
-            name: appUuid,
-            mainWindowOptions: {
-                icon: `file:///${__dirname}/../../assets/error-icon.png`,
-                defaultHeight: 200, // size increased later to fully fit error message
-                defaultWidth: 570,
-                defaultCentered: true,
-                saveWindowState: false,
-                showTaskbarIcon: false,
-                autoShow: false, // shown later after resizing is done
-                alwaysOnTop: true,
-                resizable: false,
-                contextMenu: false,
-                minimizable: false,
-                maximizable: false,
-                nonPersistent: true,
-                experimental: {
-                    'v2Api': true
-                },
-                customData: {
-                    error: errorToPOJO(err)
+        const { error, message, title = '', type } = data;
+        const uuid = `error-app-${app.generateGUID()}`;
+
+        writeToLog('info', error);
+
+        if (argo.noerrdialogs) {
+            return resolve();
+        }
+
+        try {
+            const options = {
+                _type: type,
+                url: `file:///${path.resolve(`${__dirname}/../../assets/error.html`)}`,
+                uuid,
+                name: uuid,
+                mainWindowOptions: {
+                    icon: `file:///${path.resolve(`${__dirname}/../../assets/error-icon.png`)}`,
+                    defaultHeight: 150, // size increased later to fully fit error message
+                    defaultWidth: 570,
+                    defaultCentered: true,
+                    saveWindowState: false,
+                    showTaskbarIcon: false,
+                    autoShow: false, // shown later after resizing is done
+                    alwaysOnTop: true,
+                    resizable: false,
+                    contextMenu: true,
+                    minimizable: false,
+                    maximizable: false,
+                    nonPersistent: true,
+                    experimental: {
+                        v2Api: true
+                    },
+                    customData: {
+                        error: message || error.stack,
+                        title
+                    }
                 }
-            }
-        };
+            };
 
-        Application.create(errorAppOptions);
+            Application.create(options);
 
-        ofEvents.once(route.application('closed', appUuid), () => {
-            coreState.deleteApp(appUuid);
-        });
+            ofEvents.once(route.application('closed', uuid), () => {
+                deleteApp(uuid);
+                resolve();
+            });
 
-        Application.run({ uuid: appUuid });
-        log.writeToLog('info', err);
+            Application.run({ uuid });
 
-    } catch (err) {
-        log.writeToLog('info', err);
-    }
-
+        } catch (error) {
+            writeToLog('info', error);
+        }
+    });
 }

--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -9,10 +9,12 @@ export const ERROR_TITLE_APP_INITIALIZATION = 'A JavaScript error occured during
 export const ERROR_TITLE_MAIN_PROCESS = 'A JavaScript error occurred in the main process';
 export const ERROR_TITLE_RENDERER_CRASH = 'Renderer Crash';
 
-// Window types
-export const ERROR_TYPE_APP_INITIALIZATION = 'OF_error_box:app_initialization';
-export const ERROR_TYPE_MAIN_PROCESS = 'OF_error_box:main_process';
-export const ERROR_TYPE_RENDERER_CRASH = 'OF_error_box:renderer_crash';
+// Error types
+export enum ERROR_BOX_TYPES {
+    APP_INITIALIZATION = 'OF_error_box:app_initialization',
+    MAIN_PROCESS = 'OF_error_box:main_process',
+    RENDERER_CRASH = 'OF_error_box:renderer_crash'
+}
 
 /**
  * Interface of a converted JS error into a plain object
@@ -55,7 +57,7 @@ export function initSafeErrors(argo: any): void {
     if (!argo['disable-safe-errors']) {
         process.on('uncaughtException', (error: Error) => {
             const title = ERROR_TITLE_MAIN_PROCESS;
-            const type = ERROR_TYPE_MAIN_PROCESS;
+            const type = ERROR_BOX_TYPES.MAIN_PROCESS;
             showErrorBox({ error, title, type });
         });
     }

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -220,6 +220,7 @@ export interface WindowOptions {
     title?: string;
     toShowOnRun?: boolean;
     transparent?: boolean;
+    _type?: 'OF_error_box:app_initialization'|'OF_error_box:main_process'|'OF_error_box:renderer_crash';
     url: string;
     uuid: string;
     waitForPageLoad?: boolean;

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -1,6 +1,7 @@
 
 import { PortInfo } from './browser/port_discovery';
 import { BrowserWindow as BrowserWindowElectron } from 'electron';
+import { ERROR_BOX_TYPES } from './common/errors';
 
 export interface Identity {
     uuid: string;
@@ -220,7 +221,7 @@ export interface WindowOptions {
     title?: string;
     toShowOnRun?: boolean;
     transparent?: boolean;
-    _type?: 'OF_error_box:app_initialization'|'OF_error_box:main_process'|'OF_error_box:renderer_crash';
+    _type?: ERROR_BOX_TYPES;
     url: string;
     uuid: string;
     waitForPageLoad?: boolean;


### PR DESCRIPTION
ℹ️ **About**
This PR:
1. Improves our custom error dialog
2. Uses our custom non-blocking error dialog to display app initialization errors (screenshot below)
3. Uses our custom non-blocking error dialog to notify users about renderer crashes (screenshot below)

➕ 3 new manual tests [here](https://github.com/openfin/test_apps/pull/32)

🚥 **Automated test results**
✅ [Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b59de3854b21953031f380d)
✅ [Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b59df4054b21953031f380e)

🖼 **Screenshots**

1. App initialization
![win10_safe_init](https://user-images.githubusercontent.com/5790216/43270134-545ba9f0-90c2-11e8-8290-86168abbc10a.png)

2. App initialization custom message (our `customWindowAlert` app config flag)
![win10_safe_init_custom](https://user-images.githubusercontent.com/5790216/43270191-6f6f77c6-90c2-11e8-90b4-7aa2abe7a95f.png)

3. Renderer crash
![win10_safe_renderer_crash](https://user-images.githubusercontent.com/5790216/43270211-7df77fdc-90c2-11e8-84fb-559add348049.png)
