### PR TITLE
bumped js-adapter to 0.34.1-alpha.2

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4,145 +4,145 @@
   "dependencies": {
     "@sinonjs/formatio": {
       "version": "2.0.0",
-      "from": "@sinonjs/formatio@>=2.0.0 <3.0.0",
+      "from": "@sinonjs/formatio@https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
       "dev": true
     },
     "@sinonjs/samsam": {
       "version": "2.0.0",
-      "from": "@sinonjs/samsam@>=2.0.0 <3.0.0",
+      "from": "@sinonjs/samsam@https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.0.0.tgz",
       "dev": true
     },
     "@types/minimist": {
       "version": "1.2.0",
-      "from": "@types/minimist@>=1.2.0 <2.0.0",
+      "from": "@types/minimist@https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
       "dev": true
     },
     "@types/mocha": {
       "version": "5.2.5",
-      "from": "@types/mocha@>=5.2.5 <6.0.0",
+      "from": "@types/mocha@https://registry.npmjs.org/@types/mocha/-/mocha-5.2.5.tgz",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.5.tgz",
       "dev": true
     },
     "@types/mockery": {
       "version": "1.4.29",
-      "from": "@types/mockery@>=1.4.29 <2.0.0",
+      "from": "@types/mockery@https://registry.npmjs.org/@types/mockery/-/mockery-1.4.29.tgz",
       "resolved": "https://registry.npmjs.org/@types/mockery/-/mockery-1.4.29.tgz",
       "dev": true
     },
     "@types/node": {
       "version": "10.5.2",
-      "from": "@types/node@>=10.5.2 <11.0.0",
+      "from": "@types/node@https://registry.npmjs.org/@types/node/-/node-10.5.2.tgz",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.5.2.tgz",
       "dev": true
     },
     "@types/rx": {
       "version": "4.1.1",
-      "from": "@types/rx@>=4.1.1 <5.0.0",
+      "from": "@types/rx@https://registry.npmjs.org/@types/rx/-/rx-4.1.1.tgz",
       "resolved": "https://registry.npmjs.org/@types/rx/-/rx-4.1.1.tgz",
       "dev": true
     },
     "@types/rx-core": {
       "version": "4.0.3",
-      "from": "@types/rx-core@*",
+      "from": "@types/rx-core@https://registry.npmjs.org/@types/rx-core/-/rx-core-4.0.3.tgz",
       "resolved": "https://registry.npmjs.org/@types/rx-core/-/rx-core-4.0.3.tgz",
       "dev": true
     },
     "@types/rx-core-binding": {
       "version": "4.0.4",
-      "from": "@types/rx-core-binding@*",
+      "from": "@types/rx-core-binding@https://registry.npmjs.org/@types/rx-core-binding/-/rx-core-binding-4.0.4.tgz",
       "resolved": "https://registry.npmjs.org/@types/rx-core-binding/-/rx-core-binding-4.0.4.tgz",
       "dev": true
     },
     "@types/rx-lite": {
       "version": "4.0.5",
-      "from": "@types/rx-lite@*",
+      "from": "@types/rx-lite@https://registry.npmjs.org/@types/rx-lite/-/rx-lite-4.0.5.tgz",
       "resolved": "https://registry.npmjs.org/@types/rx-lite/-/rx-lite-4.0.5.tgz",
       "dev": true
     },
     "@types/rx-lite-aggregates": {
       "version": "4.0.3",
-      "from": "@types/rx-lite-aggregates@*",
+      "from": "@types/rx-lite-aggregates@https://registry.npmjs.org/@types/rx-lite-aggregates/-/rx-lite-aggregates-4.0.3.tgz",
       "resolved": "https://registry.npmjs.org/@types/rx-lite-aggregates/-/rx-lite-aggregates-4.0.3.tgz",
       "dev": true
     },
     "@types/rx-lite-async": {
       "version": "4.0.2",
-      "from": "@types/rx-lite-async@*",
+      "from": "@types/rx-lite-async@https://registry.npmjs.org/@types/rx-lite-async/-/rx-lite-async-4.0.2.tgz",
       "resolved": "https://registry.npmjs.org/@types/rx-lite-async/-/rx-lite-async-4.0.2.tgz",
       "dev": true
     },
     "@types/rx-lite-backpressure": {
       "version": "4.0.3",
-      "from": "@types/rx-lite-backpressure@*",
+      "from": "@types/rx-lite-backpressure@https://registry.npmjs.org/@types/rx-lite-backpressure/-/rx-lite-backpressure-4.0.3.tgz",
       "resolved": "https://registry.npmjs.org/@types/rx-lite-backpressure/-/rx-lite-backpressure-4.0.3.tgz",
       "dev": true
     },
     "@types/rx-lite-coincidence": {
       "version": "4.0.3",
-      "from": "@types/rx-lite-coincidence@*",
+      "from": "@types/rx-lite-coincidence@https://registry.npmjs.org/@types/rx-lite-coincidence/-/rx-lite-coincidence-4.0.3.tgz",
       "resolved": "https://registry.npmjs.org/@types/rx-lite-coincidence/-/rx-lite-coincidence-4.0.3.tgz",
       "dev": true
     },
     "@types/rx-lite-experimental": {
       "version": "4.0.1",
-      "from": "@types/rx-lite-experimental@*",
+      "from": "@types/rx-lite-experimental@https://registry.npmjs.org/@types/rx-lite-experimental/-/rx-lite-experimental-4.0.1.tgz",
       "resolved": "https://registry.npmjs.org/@types/rx-lite-experimental/-/rx-lite-experimental-4.0.1.tgz",
       "dev": true
     },
     "@types/rx-lite-joinpatterns": {
       "version": "4.0.1",
-      "from": "@types/rx-lite-joinpatterns@*",
+      "from": "@types/rx-lite-joinpatterns@https://registry.npmjs.org/@types/rx-lite-joinpatterns/-/rx-lite-joinpatterns-4.0.1.tgz",
       "resolved": "https://registry.npmjs.org/@types/rx-lite-joinpatterns/-/rx-lite-joinpatterns-4.0.1.tgz",
       "dev": true
     },
     "@types/rx-lite-testing": {
       "version": "4.0.1",
-      "from": "@types/rx-lite-testing@*",
+      "from": "@types/rx-lite-testing@https://registry.npmjs.org/@types/rx-lite-testing/-/rx-lite-testing-4.0.1.tgz",
       "resolved": "https://registry.npmjs.org/@types/rx-lite-testing/-/rx-lite-testing-4.0.1.tgz",
       "dev": true
     },
     "@types/rx-lite-time": {
       "version": "4.0.3",
-      "from": "@types/rx-lite-time@*",
+      "from": "@types/rx-lite-time@https://registry.npmjs.org/@types/rx-lite-time/-/rx-lite-time-4.0.3.tgz",
       "resolved": "https://registry.npmjs.org/@types/rx-lite-time/-/rx-lite-time-4.0.3.tgz",
       "dev": true
     },
     "@types/rx-lite-virtualtime": {
       "version": "4.0.3",
-      "from": "@types/rx-lite-virtualtime@*",
+      "from": "@types/rx-lite-virtualtime@https://registry.npmjs.org/@types/rx-lite-virtualtime/-/rx-lite-virtualtime-4.0.3.tgz",
       "resolved": "https://registry.npmjs.org/@types/rx-lite-virtualtime/-/rx-lite-virtualtime-4.0.3.tgz",
       "dev": true
     },
     "@types/underscore": {
       "version": "1.8.8",
-      "from": "@types/underscore@>=1.8.8 <2.0.0",
+      "from": "@types/underscore@https://registry.npmjs.org/@types/underscore/-/underscore-1.8.8.tgz",
       "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.8.8.tgz",
       "dev": true
     },
     "abbrev": {
       "version": "1.1.1",
-      "from": "abbrev@>=1.0.0 <2.0.0",
+      "from": "abbrev@https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "dev": true
     },
     "acorn": {
       "version": "5.7.1",
-      "from": "acorn@>=5.5.0 <6.0.0",
+      "from": "acorn@https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
       "dev": true
     },
     "acorn-jsx": {
       "version": "3.0.1",
-      "from": "acorn-jsx@>=3.0.0 <4.0.0",
+      "from": "acorn-jsx@https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "dev": true,
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
-          "from": "acorn@>=3.0.4 <4.0.0",
+          "from": "acorn@https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
           "dev": true
         }
@@ -150,67 +150,67 @@
     },
     "ajv": {
       "version": "5.5.2",
-      "from": "ajv@>=5.1.0 <6.0.0",
+      "from": "ajv@https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "dev": true
     },
     "ajv-keywords": {
       "version": "2.1.1",
-      "from": "ajv-keywords@>=2.1.0 <3.0.0",
+      "from": "ajv-keywords@https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
       "dev": true
     },
     "ansi-escapes": {
       "version": "3.1.0",
-      "from": "ansi-escapes@>=3.0.0 <4.0.0",
+      "from": "ansi-escapes@https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
       "dev": true
     },
     "ansi-regex": {
       "version": "2.1.1",
-      "from": "ansi-regex@>=2.0.0 <3.0.0",
+      "from": "ansi-regex@https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
       "dev": true
     },
     "ansi-styles": {
       "version": "2.2.1",
-      "from": "ansi-styles@>=2.2.1 <3.0.0",
+      "from": "ansi-styles@https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "dev": true
     },
     "anymatch": {
       "version": "1.3.2",
-      "from": "anymatch@>=1.1.0 <2.0.0",
+      "from": "anymatch@https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
       "dev": true
     },
     "aproba": {
       "version": "1.2.0",
-      "from": "aproba@>=1.0.3 <2.0.0",
+      "from": "aproba@https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
       "dev": true
     },
     "are-we-there-yet": {
       "version": "1.1.5",
-      "from": "are-we-there-yet@>=1.1.2 <1.2.0",
+      "from": "are-we-there-yet@https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "dev": true,
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
+          "from": "isarray@https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "dev": true
         },
         "readable-stream": {
           "version": "2.3.6",
-          "from": "readable-stream@>=2.0.6 <3.0.0",
+          "from": "readable-stream@https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "dev": true
         },
         "string_decoder": {
           "version": "1.1.1",
-          "from": "string_decoder@>=1.1.1 <1.2.0",
+          "from": "string_decoder@https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "dev": true
         }
@@ -218,13 +218,13 @@
     },
     "argparse": {
       "version": "1.0.10",
-      "from": "argparse@>=1.0.2 <2.0.0",
+      "from": "argparse@https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "dev": true,
       "dependencies": {
         "sprintf-js": {
           "version": "1.0.3",
-          "from": "sprintf-js@>=1.0.2 <1.1.0",
+          "from": "sprintf-js@https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
           "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
           "dev": true
         }
@@ -232,488 +232,494 @@
     },
     "arr-diff": {
       "version": "2.0.0",
-      "from": "arr-diff@>=2.0.0 <3.0.0",
+      "from": "arr-diff@https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "dev": true
     },
     "arr-flatten": {
       "version": "1.1.0",
-      "from": "arr-flatten@>=1.0.1 <2.0.0",
+      "from": "arr-flatten@https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
       "dev": true
     },
     "array-differ": {
       "version": "1.0.0",
-      "from": "array-differ@>=1.0.0 <2.0.0",
+      "from": "array-differ@https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
       "dev": true
     },
     "array-find-index": {
       "version": "1.0.2",
-      "from": "array-find-index@>=1.0.1 <2.0.0",
+      "from": "array-find-index@https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "dev": true
     },
     "array-union": {
       "version": "1.0.2",
-      "from": "array-union@>=1.0.1 <2.0.0",
+      "from": "array-union@https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "dev": true
     },
     "array-uniq": {
       "version": "1.0.3",
-      "from": "array-uniq@>=1.0.1 <2.0.0",
+      "from": "array-uniq@https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
       "dev": true
     },
     "array-unique": {
       "version": "0.2.1",
-      "from": "array-unique@>=0.2.1 <0.3.0",
+      "from": "array-unique@https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
       "dev": true
     },
     "arrify": {
       "version": "1.0.1",
-      "from": "arrify@>=1.0.0 <2.0.0",
+      "from": "arrify@https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "dev": true
     },
     "asar": {
       "version": "0.14.3",
-      "from": "asar@>=0.14.3 <0.15.0",
+      "from": "asar@https://registry.npmjs.org/asar/-/asar-0.14.3.tgz",
       "resolved": "https://registry.npmjs.org/asar/-/asar-0.14.3.tgz",
       "dev": true
     },
     "asn1": {
       "version": "0.2.3",
-      "from": "asn1@>=0.2.3 <0.3.0",
+      "from": "asn1@https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
       "dev": true
     },
     "assert-plus": {
       "version": "1.0.0",
-      "from": "assert-plus@>=1.0.0 <2.0.0",
+      "from": "assert-plus@https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "dev": true
     },
     "async": {
       "version": "1.5.2",
-      "from": "async@>=1.5.2 <1.6.0",
+      "from": "async@https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "dev": true
     },
     "async-each": {
       "version": "0.1.6",
-      "from": "async-each@>=0.1.5 <0.2.0",
+      "from": "async-each@https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz",
       "resolved": "https://registry.npmjs.org/async-each/-/async-each-0.1.6.tgz",
       "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
-      "from": "asynckit@>=0.4.0 <0.5.0",
+      "from": "asynckit@https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "dev": true
     },
     "aws-sign2": {
       "version": "0.7.0",
-      "from": "aws-sign2@>=0.7.0 <0.8.0",
+      "from": "aws-sign2@https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "dev": true
     },
     "aws4": {
       "version": "1.7.0",
-      "from": "aws4@>=1.6.0 <2.0.0",
+      "from": "aws4@https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
       "dev": true
     },
     "babel-code-frame": {
       "version": "6.26.0",
-      "from": "babel-code-frame@>=6.26.0 <7.0.0",
+      "from": "babel-code-frame@https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "dev": true
     },
     "babel-core": {
       "version": "6.26.3",
-      "from": "babel-core@>=6.26.3 <7.0.0",
+      "from": "babel-core@https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
       "dev": true
     },
     "babel-generator": {
       "version": "6.26.1",
-      "from": "babel-generator@>=6.26.0 <7.0.0",
+      "from": "babel-generator@https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
       "dev": true
     },
     "babel-helper-call-delegate": {
       "version": "6.24.1",
-      "from": "babel-helper-call-delegate@>=6.24.1 <7.0.0",
+      "from": "babel-helper-call-delegate@https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
       "dev": true
     },
     "babel-helper-define-map": {
       "version": "6.26.0",
-      "from": "babel-helper-define-map@>=6.24.1 <7.0.0",
+      "from": "babel-helper-define-map@https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
       "dev": true
     },
     "babel-helper-function-name": {
       "version": "6.24.1",
-      "from": "babel-helper-function-name@>=6.24.1 <7.0.0",
+      "from": "babel-helper-function-name@https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
       "dev": true
     },
     "babel-helper-get-function-arity": {
       "version": "6.24.1",
-      "from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
+      "from": "babel-helper-get-function-arity@https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
       "dev": true
     },
     "babel-helper-hoist-variables": {
       "version": "6.24.1",
-      "from": "babel-helper-hoist-variables@>=6.24.1 <7.0.0",
+      "from": "babel-helper-hoist-variables@https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
       "dev": true
     },
     "babel-helper-optimise-call-expression": {
       "version": "6.24.1",
-      "from": "babel-helper-optimise-call-expression@>=6.24.1 <7.0.0",
+      "from": "babel-helper-optimise-call-expression@https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
       "dev": true
     },
     "babel-helper-regex": {
       "version": "6.26.0",
-      "from": "babel-helper-regex@>=6.24.1 <7.0.0",
+      "from": "babel-helper-regex@https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
       "dev": true
     },
     "babel-helper-replace-supers": {
       "version": "6.24.1",
-      "from": "babel-helper-replace-supers@>=6.24.1 <7.0.0",
+      "from": "babel-helper-replace-supers@https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
       "dev": true
     },
     "babel-helpers": {
       "version": "6.24.1",
-      "from": "babel-helpers@>=6.24.1 <7.0.0",
+      "from": "babel-helpers@https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "dev": true
     },
     "babel-messages": {
       "version": "6.23.0",
-      "from": "babel-messages@>=6.23.0 <7.0.0",
+      "from": "babel-messages@https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "dev": true
     },
     "babel-plugin-check-es2015-constants": {
       "version": "6.22.0",
-      "from": "babel-plugin-check-es2015-constants@>=6.22.0 <7.0.0",
+      "from": "babel-plugin-check-es2015-constants@https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "dev": true
     },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.22.0",
-      "from": "babel-plugin-transform-es2015-arrow-functions@>=6.22.0 <7.0.0",
+      "from": "babel-plugin-transform-es2015-arrow-functions@https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "dev": true
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
       "version": "6.22.0",
-      "from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.22.0 <7.0.0",
+      "from": "babel-plugin-transform-es2015-block-scoped-functions@https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
       "dev": true
     },
     "babel-plugin-transform-es2015-block-scoping": {
       "version": "6.26.0",
-      "from": "babel-plugin-transform-es2015-block-scoping@>=6.24.1 <7.0.0",
+      "from": "babel-plugin-transform-es2015-block-scoping@https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
       "dev": true
     },
     "babel-plugin-transform-es2015-classes": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-classes@>=6.24.1 <7.0.0",
+      "from": "babel-plugin-transform-es2015-classes@https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
       "dev": true
     },
     "babel-plugin-transform-es2015-computed-properties": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-computed-properties@>=6.24.1 <7.0.0",
+      "from": "babel-plugin-transform-es2015-computed-properties@https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "dev": true
     },
     "babel-plugin-transform-es2015-destructuring": {
       "version": "6.23.0",
-      "from": "babel-plugin-transform-es2015-destructuring@>=6.22.0 <7.0.0",
+      "from": "babel-plugin-transform-es2015-destructuring@https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
       "dev": true
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-duplicate-keys@>=6.24.1 <7.0.0",
+      "from": "babel-plugin-transform-es2015-duplicate-keys@https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
       "dev": true
     },
     "babel-plugin-transform-es2015-for-of": {
       "version": "6.23.0",
-      "from": "babel-plugin-transform-es2015-for-of@>=6.22.0 <7.0.0",
+      "from": "babel-plugin-transform-es2015-for-of@https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
       "dev": true
     },
     "babel-plugin-transform-es2015-function-name": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-function-name@>=6.24.1 <7.0.0",
+      "from": "babel-plugin-transform-es2015-function-name@https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
       "dev": true
     },
     "babel-plugin-transform-es2015-literals": {
       "version": "6.22.0",
-      "from": "babel-plugin-transform-es2015-literals@>=6.22.0 <7.0.0",
+      "from": "babel-plugin-transform-es2015-literals@https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
       "dev": true
     },
     "babel-plugin-transform-es2015-modules-amd": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-modules-amd@>=6.24.1 <7.0.0",
+      "from": "babel-plugin-transform-es2015-modules-amd@https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
       "dev": true
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
       "version": "6.26.2",
-      "from": "babel-plugin-transform-es2015-modules-commonjs@>=6.24.1 <7.0.0",
+      "from": "babel-plugin-transform-es2015-modules-commonjs@https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
       "dev": true
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-modules-systemjs@>=6.24.1 <7.0.0",
+      "from": "babel-plugin-transform-es2015-modules-systemjs@https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
       "dev": true
     },
     "babel-plugin-transform-es2015-modules-umd": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-modules-umd@>=6.24.1 <7.0.0",
+      "from": "babel-plugin-transform-es2015-modules-umd@https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
       "dev": true
     },
     "babel-plugin-transform-es2015-object-super": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-object-super@>=6.24.1 <7.0.0",
+      "from": "babel-plugin-transform-es2015-object-super@https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
       "dev": true
     },
     "babel-plugin-transform-es2015-parameters": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-parameters@>=6.24.1 <7.0.0",
+      "from": "babel-plugin-transform-es2015-parameters@https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
       "dev": true
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-shorthand-properties@>=6.24.1 <7.0.0",
+      "from": "babel-plugin-transform-es2015-shorthand-properties@https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
       "dev": true
     },
     "babel-plugin-transform-es2015-spread": {
       "version": "6.22.0",
-      "from": "babel-plugin-transform-es2015-spread@>=6.22.0 <7.0.0",
+      "from": "babel-plugin-transform-es2015-spread@https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
       "dev": true
     },
     "babel-plugin-transform-es2015-sticky-regex": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-sticky-regex@>=6.24.1 <7.0.0",
+      "from": "babel-plugin-transform-es2015-sticky-regex@https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
       "dev": true
     },
     "babel-plugin-transform-es2015-template-literals": {
       "version": "6.22.0",
-      "from": "babel-plugin-transform-es2015-template-literals@>=6.22.0 <7.0.0",
+      "from": "babel-plugin-transform-es2015-template-literals@https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
       "dev": true
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
       "version": "6.23.0",
-      "from": "babel-plugin-transform-es2015-typeof-symbol@>=6.22.0 <7.0.0",
+      "from": "babel-plugin-transform-es2015-typeof-symbol@https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
       "dev": true
     },
     "babel-plugin-transform-es2015-unicode-regex": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-es2015-unicode-regex@>=6.24.1 <7.0.0",
+      "from": "babel-plugin-transform-es2015-unicode-regex@https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
       "dev": true
     },
     "babel-plugin-transform-regenerator": {
       "version": "6.26.0",
-      "from": "babel-plugin-transform-regenerator@>=6.24.1 <7.0.0",
+      "from": "babel-plugin-transform-regenerator@https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
       "dev": true
     },
     "babel-plugin-transform-strict-mode": {
       "version": "6.24.1",
-      "from": "babel-plugin-transform-strict-mode@>=6.24.1 <7.0.0",
+      "from": "babel-plugin-transform-strict-mode@https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "dev": true
     },
     "babel-preset-es2015": {
       "version": "6.24.1",
-      "from": "babel-preset-es2015@>=6.24.1 <7.0.0",
+      "from": "babel-preset-es2015@https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
       "resolved": "https://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
       "dev": true
     },
     "babel-register": {
       "version": "6.26.0",
-      "from": "babel-register@>=6.26.0 <7.0.0",
+      "from": "babel-register@https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
       "dev": true
     },
     "babel-runtime": {
       "version": "6.26.0",
-      "from": "babel-runtime@>=6.26.0 <7.0.0",
+      "from": "babel-runtime@https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "dev": true
     },
     "babel-template": {
       "version": "6.26.0",
-      "from": "babel-template@>=6.26.0 <7.0.0",
+      "from": "babel-template@https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
       "dev": true
     },
     "babel-traverse": {
       "version": "6.26.0",
-      "from": "babel-traverse@>=6.26.0 <7.0.0",
+      "from": "babel-traverse@https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "dev": true
     },
     "babel-types": {
       "version": "6.26.0",
-      "from": "babel-types@>=6.26.0 <7.0.0",
+      "from": "babel-types@https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "dev": true
     },
     "babylon": {
       "version": "6.18.0",
-      "from": "babylon@>=6.18.0 <7.0.0",
+      "from": "babylon@https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
       "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
-      "from": "balanced-match@>=1.0.0 <2.0.0",
+      "from": "balanced-match@https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "dev": true
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
-      "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
+      "from": "bcrypt-pbkdf@https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
       "dev": true,
       "optional": true
     },
     "binary": {
       "version": "0.3.0",
-      "from": "binary@>=0.3.0 <0.4.0",
+      "from": "binary@https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
       "dev": true
     },
     "binary-extensions": {
       "version": "1.11.0",
-      "from": "binary-extensions@>=1.0.0 <2.0.0",
+      "from": "binary-extensions@https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",
       "dev": true
     },
+    "bindings": {
+      "version": "1.3.0",
+      "from": "bindings@https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
+      "optional": true
+    },
     "block-stream": {
       "version": "0.0.9",
-      "from": "block-stream@*",
+      "from": "block-stream@https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
       "dev": true
     },
     "bluebird": {
       "version": "3.5.1",
-      "from": "bluebird@>=3.0.5 <4.0.0",
+      "from": "bluebird@https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
       "dev": true
     },
     "body": {
       "version": "5.1.0",
-      "from": "body@>=5.1.0 <6.0.0",
+      "from": "body@https://registry.npmjs.org/body/-/body-5.1.0.tgz",
       "resolved": "https://registry.npmjs.org/body/-/body-5.1.0.tgz",
       "dev": true
     },
     "boom": {
       "version": "2.10.1",
-      "from": "boom@>=2.0.0 <3.0.0",
+      "from": "boom@https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "from": "brace-expansion@>=1.1.7 <2.0.0",
+      "from": "brace-expansion@https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "dev": true
     },
     "braces": {
       "version": "1.8.5",
-      "from": "braces@>=1.8.2 <2.0.0",
+      "from": "braces@https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "dev": true
     },
     "browser-stdout": {
       "version": "1.3.1",
-      "from": "browser-stdout@1.3.1",
+      "from": "browser-stdout@https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "dev": true
     },
     "buffer-from": {
       "version": "1.1.0",
-      "from": "buffer-from@>=1.0.0 <2.0.0",
+      "from": "buffer-from@https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
       "dev": true
     },
     "buffers": {
       "version": "0.1.1",
-      "from": "buffers@>=0.1.1 <0.2.0",
+      "from": "buffers@https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
       "dev": true
     },
     "builtin-modules": {
       "version": "1.1.1",
-      "from": "builtin-modules@>=1.0.0 <2.0.0",
+      "from": "builtin-modules@https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "dev": true
     },
     "bytes": {
       "version": "1.0.0",
-      "from": "bytes@>=1.0.0 <2.0.0",
+      "from": "bytes@https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
       "dev": true
     },
     "caller-path": {
       "version": "0.1.0",
-      "from": "caller-path@>=0.1.0 <0.2.0",
+      "from": "caller-path@https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "dev": true
     },
     "callsites": {
       "version": "0.2.0",
-      "from": "callsites@>=0.2.0 <0.3.0",
+      "from": "callsites@https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
       "dev": true
     },
     "camelcase": {
       "version": "3.0.0",
-      "from": "camelcase@>=3.0.0 <4.0.0",
+      "from": "camelcase@https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
       "dev": true
     },
     "camelcase-keys": {
       "version": "2.1.0",
-      "from": "camelcase-keys@>=2.0.0 <3.0.0",
+      "from": "camelcase-keys@https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "dev": true,
       "dependencies": {
         "camelcase": {
           "version": "2.1.1",
-          "from": "camelcase@>=2.0.0 <3.0.0",
+          "from": "camelcase@https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
           "dev": true
         }
@@ -721,55 +727,55 @@
     },
     "caseless": {
       "version": "0.12.0",
-      "from": "caseless@>=0.12.0 <0.13.0",
+      "from": "caseless@https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "dev": true
     },
     "chainsaw": {
       "version": "0.1.0",
-      "from": "chainsaw@>=0.1.0 <0.2.0",
+      "from": "chainsaw@https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
       "dev": true
     },
     "chalk": {
       "version": "1.1.3",
-      "from": "chalk@>=1.1.3 <2.0.0",
+      "from": "chalk@https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "dev": true
     },
     "chardet": {
       "version": "0.4.2",
-      "from": "chardet@>=0.4.0 <0.5.0",
+      "from": "chardet@https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
       "dev": true
     },
     "chokidar": {
       "version": "1.0.6",
-      "from": "chokidar@>=1.0.0 <1.1.0",
+      "from": "chokidar@https://registry.npmjs.org/chokidar/-/chokidar-1.0.6.tgz",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.0.6.tgz",
       "dev": true
     },
     "chromium-pickle-js": {
       "version": "0.2.0",
-      "from": "chromium-pickle-js@>=0.2.0 <0.3.0",
+      "from": "chromium-pickle-js@https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
       "dev": true
     },
     "circular-json": {
       "version": "0.3.3",
-      "from": "circular-json@>=0.3.1 <0.4.0",
+      "from": "circular-json@https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
       "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
       "dev": true
     },
     "cli": {
       "version": "1.0.1",
-      "from": "cli@>=1.0.0 <1.1.0",
+      "from": "cli@https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
       "dev": true,
       "dependencies": {
         "glob": {
           "version": "7.1.2",
-          "from": "glob@>=7.1.1 <8.0.0",
+          "from": "glob@https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "dev": true
         }
@@ -777,103 +783,103 @@
     },
     "cli-cursor": {
       "version": "2.1.0",
-      "from": "cli-cursor@>=2.1.0 <3.0.0",
+      "from": "cli-cursor@https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "dev": true
     },
     "cli-spinners": {
       "version": "1.3.1",
-      "from": "cli-spinners@>=1.0.1 <2.0.0",
+      "from": "cli-spinners@https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.3.1.tgz",
       "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-1.3.1.tgz",
       "dev": true
     },
     "cli-width": {
       "version": "2.2.0",
-      "from": "cli-width@>=2.0.0 <3.0.0",
+      "from": "cli-width@https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "dev": true
     },
     "cliui": {
       "version": "3.2.0",
-      "from": "cliui@>=3.2.0 <4.0.0",
+      "from": "cliui@https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
       "dev": true
     },
     "co": {
       "version": "4.6.0",
-      "from": "co@>=4.6.0 <5.0.0",
+      "from": "co@https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "dev": true
     },
     "code-point-at": {
       "version": "1.1.0",
-      "from": "code-point-at@>=1.0.0 <2.0.0",
+      "from": "code-point-at@https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
       "dev": true
     },
     "coffeescript": {
       "version": "1.10.0",
-      "from": "coffeescript@>=1.10.0 <1.11.0",
+      "from": "coffeescript@https://registry.npmjs.org/coffeescript/-/coffeescript-1.10.0.tgz",
       "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.10.0.tgz",
       "dev": true
     },
     "color-convert": {
       "version": "1.9.2",
-      "from": "color-convert@>=1.9.0 <2.0.0",
+      "from": "color-convert@https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
       "dev": true
     },
     "color-name": {
       "version": "1.1.1",
-      "from": "color-name@1.1.1",
+      "from": "color-name@https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
       "dev": true
     },
     "colors": {
       "version": "1.3.0",
-      "from": "colors@>=1.2.0 <2.0.0",
+      "from": "colors@https://registry.npmjs.org/colors/-/colors-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.0.tgz",
       "dev": true
     },
     "combined-stream": {
       "version": "1.0.6",
-      "from": "combined-stream@>=1.0.5 <1.1.0",
+      "from": "combined-stream@https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "dev": true
     },
     "commander": {
       "version": "2.16.0",
-      "from": "commander@>=2.9.0 <3.0.0",
+      "from": "commander@https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
       "dev": true
     },
     "concat-map": {
       "version": "0.0.1",
-      "from": "concat-map@0.0.1",
+      "from": "concat-map@https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "dev": true
     },
     "concat-stream": {
       "version": "1.6.2",
-      "from": "concat-stream@>=1.6.0 <2.0.0",
+      "from": "concat-stream@https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "dev": true,
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
-          "from": "isarray@>=1.0.0 <1.1.0",
+          "from": "isarray@https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "dev": true
         },
         "readable-stream": {
           "version": "2.3.6",
-          "from": "readable-stream@>=2.2.2 <3.0.0",
+          "from": "readable-stream@https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "dev": true
         },
         "string_decoder": {
           "version": "1.1.1",
-          "from": "string_decoder@>=1.1.1 <1.2.0",
+          "from": "string_decoder@https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "dev": true
         }
@@ -881,55 +887,55 @@
     },
     "config-chain": {
       "version": "1.1.11",
-      "from": "config-chain@>=1.1.5 <1.2.0",
+      "from": "config-chain@https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
       "dev": true
     },
     "console-browserify": {
       "version": "1.1.0",
-      "from": "console-browserify@>=1.1.0 <1.2.0",
+      "from": "console-browserify@https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "dev": true
     },
     "console-control-strings": {
       "version": "1.1.0",
-      "from": "console-control-strings@>=1.1.0 <1.2.0",
+      "from": "console-control-strings@https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "dev": true
     },
     "continuable-cache": {
       "version": "0.3.1",
-      "from": "continuable-cache@>=0.3.1 <0.4.0",
+      "from": "continuable-cache@https://registry.npmjs.org/continuable-cache/-/continuable-cache-0.3.1.tgz",
       "resolved": "https://registry.npmjs.org/continuable-cache/-/continuable-cache-0.3.1.tgz",
       "dev": true
     },
     "convert-source-map": {
       "version": "1.5.1",
-      "from": "convert-source-map@>=1.5.1 <2.0.0",
+      "from": "convert-source-map@https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
       "dev": true
     },
     "core-js": {
       "version": "2.5.7",
-      "from": "core-js@>=2.4.0 <3.0.0",
+      "from": "core-js@https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
       "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
-      "from": "core-util-is@>=1.0.0 <1.1.0",
+      "from": "core-util-is@https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "dev": true
     },
     "cross-spawn": {
       "version": "5.1.0",
-      "from": "cross-spawn@>=5.1.0 <6.0.0",
+      "from": "cross-spawn@https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "dev": true,
       "dependencies": {
         "lru-cache": {
           "version": "4.1.3",
-          "from": "lru-cache@>=4.0.1 <5.0.0",
+          "from": "lru-cache@https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
           "dev": true
         }
@@ -937,25 +943,25 @@
     },
     "cryptiles": {
       "version": "2.0.5",
-      "from": "cryptiles@>=2.0.0 <3.0.0",
+      "from": "cryptiles@https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
       "dev": true
     },
     "csproj2ts": {
       "version": "0.0.7",
-      "from": "csproj2ts@0.0.7",
+      "from": "csproj2ts@https://registry.npmjs.org/csproj2ts/-/csproj2ts-0.0.7.tgz",
       "resolved": "https://registry.npmjs.org/csproj2ts/-/csproj2ts-0.0.7.tgz",
       "dev": true,
       "dependencies": {
         "es6-promise": {
           "version": "2.3.0",
-          "from": "es6-promise@>=2.0.1 <3.0.0",
+          "from": "es6-promise@https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
           "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-2.3.0.tgz",
           "dev": true
         },
         "lodash": {
           "version": "3.10.1",
-          "from": "lodash@>=3.3.1 <4.0.0",
+          "from": "lodash@https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
           "dev": true
         }
@@ -963,121 +969,121 @@
     },
     "cuint": {
       "version": "0.2.2",
-      "from": "cuint@>=0.2.1 <0.3.0",
+      "from": "cuint@https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
       "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
       "dev": true
     },
     "currently-unhandled": {
       "version": "0.4.1",
-      "from": "currently-unhandled@>=0.4.1 <0.5.0",
+      "from": "currently-unhandled@https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "dev": true
     },
     "dashdash": {
       "version": "1.14.1",
-      "from": "dashdash@>=1.12.0 <2.0.0",
+      "from": "dashdash@https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "dev": true
     },
     "date-now": {
       "version": "0.1.4",
-      "from": "date-now@>=0.1.4 <0.2.0",
+      "from": "date-now@https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
       "dev": true
     },
     "dateformat": {
       "version": "1.0.12",
-      "from": "dateformat@>=1.0.12 <1.1.0",
+      "from": "dateformat@https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
       "dev": true
     },
     "debug": {
       "version": "2.6.9",
-      "from": "debug@>=2.6.9 <3.0.0",
+      "from": "debug@https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "dev": true
     },
     "decamelize": {
       "version": "1.2.0",
-      "from": "decamelize@>=1.1.1 <2.0.0",
+      "from": "decamelize@https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "dev": true
     },
     "decompress-zip": {
       "version": "0.3.0",
-      "from": "decompress-zip@0.3.0",
+      "from": "decompress-zip@https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.3.0.tgz",
       "dev": true
     },
     "deep-extend": {
       "version": "0.6.0",
-      "from": "deep-extend@>=0.6.0 <0.7.0",
+      "from": "deep-extend@https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "dev": true
     },
     "deep-is": {
       "version": "0.1.3",
-      "from": "deep-is@>=0.1.3 <0.2.0",
+      "from": "deep-is@https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "dev": true
     },
     "del": {
       "version": "2.2.2",
-      "from": "del@>=2.0.2 <3.0.0",
+      "from": "del@https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "dev": true
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "from": "delayed-stream@>=1.0.0 <1.1.0",
+      "from": "delayed-stream@https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "dev": true
     },
     "delegates": {
       "version": "1.0.0",
-      "from": "delegates@>=1.0.0 <2.0.0",
+      "from": "delegates@https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "dev": true
     },
     "detect-indent": {
       "version": "4.0.0",
-      "from": "detect-indent@>=4.0.0 <5.0.0",
+      "from": "detect-indent@https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "dev": true
     },
     "detect-libc": {
       "version": "1.0.3",
-      "from": "detect-libc@>=1.0.3 <2.0.0",
+      "from": "detect-libc@https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "dev": true
     },
     "diff": {
       "version": "3.5.0",
-      "from": "diff@3.5.0",
+      "from": "diff@https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "dev": true
     },
     "doctrine": {
       "version": "2.1.0",
-      "from": "doctrine@>=2.1.0 <3.0.0",
+      "from": "doctrine@https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
       "dev": true
     },
     "dom-serializer": {
       "version": "0.1.0",
-      "from": "dom-serializer@>=0.0.0 <1.0.0",
+      "from": "dom-serializer@https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "dev": true,
       "dependencies": {
         "domelementtype": {
           "version": "1.1.3",
-          "from": "domelementtype@>=1.1.1 <1.2.0",
+          "from": "domelementtype@https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
           "dev": true
         },
         "entities": {
           "version": "1.1.1",
-          "from": "entities@>=1.1.1 <1.2.0",
+          "from": "entities@https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
           "dev": true
         }
@@ -1085,50 +1091,50 @@
     },
     "domelementtype": {
       "version": "1.3.0",
-      "from": "domelementtype@>=1.0.0 <2.0.0",
+      "from": "domelementtype@https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
       "dev": true
     },
     "domhandler": {
       "version": "2.3.0",
-      "from": "domhandler@>=2.3.0 <2.4.0",
+      "from": "domhandler@https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
       "dev": true
     },
     "domutils": {
       "version": "1.5.1",
-      "from": "domutils@>=1.5.0 <1.6.0",
+      "from": "domutils@https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "dev": true
     },
     "ecc-jsbn": {
       "version": "0.1.1",
-      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+      "from": "ecc-jsbn@https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "dev": true,
       "optional": true
     },
     "editorconfig": {
       "version": "0.13.3",
-      "from": "editorconfig@>=0.13.2 <0.14.0",
+      "from": "editorconfig@https://registry.npmjs.org/editorconfig/-/editorconfig-0.13.3.tgz",
       "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.13.3.tgz",
       "dev": true
     },
     "electron-rebuild": {
       "version": "1.8.1",
-      "from": "electron-rebuild@>=1.8.1 <2.0.0",
+      "from": "electron-rebuild@https://registry.npmjs.org/electron-rebuild/-/electron-rebuild-1.8.1.tgz",
       "resolved": "https://registry.npmjs.org/electron-rebuild/-/electron-rebuild-1.8.1.tgz",
       "dev": true,
       "dependencies": {
         "fs-extra": {
           "version": "3.0.1",
-          "from": "fs-extra@>=3.0.1 <4.0.0",
+          "from": "fs-extra@https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
           "dev": true
         },
         "jsonfile": {
           "version": "3.0.1",
-          "from": "jsonfile@>=3.0.0 <4.0.0",
+          "from": "jsonfile@https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
           "dev": true
         }
@@ -1136,103 +1142,103 @@
     },
     "entities": {
       "version": "1.0.0",
-      "from": "entities@>=1.0.0 <1.1.0",
+      "from": "entities@https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
       "dev": true
     },
     "error": {
       "version": "7.0.2",
-      "from": "error@>=7.0.0 <8.0.0",
+      "from": "error@https://registry.npmjs.org/error/-/error-7.0.2.tgz",
       "resolved": "https://registry.npmjs.org/error/-/error-7.0.2.tgz",
       "dev": true
     },
     "error-ex": {
       "version": "1.3.2",
-      "from": "error-ex@>=1.2.0 <2.0.0",
+      "from": "error-ex@https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
       "dev": true
     },
     "es6-promise": {
       "version": "0.1.2",
-      "from": "es6-promise@>=0.1.1 <0.2.0",
+      "from": "es6-promise@https://registry.npmjs.org/es6-promise/-/es6-promise-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-0.1.2.tgz",
       "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
-      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+      "from": "escape-string-regexp@https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "dev": true
     },
     "eslint": {
       "version": "4.19.1",
-      "from": "eslint@>=4.19.1 <5.0.0",
+      "from": "eslint@https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
       "dev": true,
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "from": "ansi-regex@>=3.0.0 <4.0.0",
+          "from": "ansi-regex@https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "from": "ansi-styles@>=3.2.1 <4.0.0",
+          "from": "ansi-styles@https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "dev": true
         },
         "chalk": {
           "version": "2.4.1",
-          "from": "chalk@>=2.1.0 <3.0.0",
+          "from": "chalk@https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "dev": true
         },
         "debug": {
           "version": "3.1.0",
-          "from": "debug@>=3.1.0 <4.0.0",
+          "from": "debug@https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "dev": true
         },
         "esprima": {
           "version": "4.0.1",
-          "from": "esprima@>=4.0.0 <5.0.0",
+          "from": "esprima@https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
           "dev": true
         },
         "glob": {
           "version": "7.1.2",
-          "from": "glob@>=7.1.2 <8.0.0",
+          "from": "glob@https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "dev": true
         },
         "globals": {
           "version": "11.7.0",
-          "from": "globals@>=11.0.1 <12.0.0",
+          "from": "globals@https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
           "resolved": "https://registry.npmjs.org/globals/-/globals-11.7.0.tgz",
           "dev": true
         },
         "js-yaml": {
           "version": "3.12.0",
-          "from": "js-yaml@>=3.9.1 <4.0.0",
+          "from": "js-yaml@https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
           "dev": true
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "from": "strip-ansi@>=4.0.0 <5.0.0",
+          "from": "strip-ansi@https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "dev": true
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "from": "strip-json-comments@>=2.0.1 <2.1.0",
+          "from": "strip-json-comments@https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "dev": true
         },
         "supports-color": {
           "version": "5.4.0",
-          "from": "supports-color@>=5.3.0 <6.0.0",
+          "from": "supports-color@https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "dev": true
         }
@@ -1240,91 +1246,91 @@
     },
     "eslint-scope": {
       "version": "3.7.3",
-      "from": "eslint-scope@>=3.7.1 <4.0.0",
+      "from": "eslint-scope@https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.3.tgz",
       "dev": true
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",
-      "from": "eslint-visitor-keys@>=1.0.0 <2.0.0",
+      "from": "eslint-visitor-keys@https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
       "dev": true
     },
     "espree": {
       "version": "3.5.4",
-      "from": "espree@>=3.5.4 <4.0.0",
+      "from": "espree@https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
       "dev": true
     },
     "esprima": {
       "version": "2.7.3",
-      "from": "esprima@>=2.6.0 <3.0.0",
+      "from": "esprima@https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
       "dev": true
     },
     "esquery": {
       "version": "1.0.1",
-      "from": "esquery@>=1.0.0 <2.0.0",
+      "from": "esquery@https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
       "dev": true
     },
     "esrecurse": {
       "version": "4.2.1",
-      "from": "esrecurse@>=4.1.0 <5.0.0",
+      "from": "esrecurse@https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
       "dev": true
     },
     "estraverse": {
       "version": "4.2.0",
-      "from": "estraverse@>=4.1.1 <5.0.0",
+      "from": "estraverse@https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
       "dev": true
     },
     "esutils": {
       "version": "2.0.2",
-      "from": "esutils@>=2.0.2 <3.0.0",
+      "from": "esutils@https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
       "dev": true
     },
     "eventemitter2": {
       "version": "0.4.14",
-      "from": "eventemitter2@>=0.4.13 <0.5.0",
+      "from": "eventemitter2@https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz",
       "dev": true
     },
     "exit": {
       "version": "0.1.2",
-      "from": "exit@>=0.1.1 <0.2.0",
+      "from": "exit@https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "dev": true
     },
     "expand-brackets": {
       "version": "0.1.5",
-      "from": "expand-brackets@>=0.1.4 <0.2.0",
+      "from": "expand-brackets@https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "dev": true
     },
     "expand-range": {
       "version": "1.8.2",
-      "from": "expand-range@>=1.8.1 <2.0.0",
+      "from": "expand-range@https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "dev": true
     },
     "extend": {
       "version": "3.0.2",
-      "from": "extend@>=3.0.1 <3.1.0",
+      "from": "extend@https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "dev": true
     },
     "external-editor": {
       "version": "2.2.0",
-      "from": "external-editor@>=2.0.4 <3.0.0",
+      "from": "external-editor@https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
       "dev": true,
       "dependencies": {
         "tmp": {
           "version": "0.0.33",
-          "from": "tmp@>=0.0.33 <0.0.34",
+          "from": "tmp@https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
           "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
           "dev": true
         }
@@ -1332,85 +1338,85 @@
     },
     "extglob": {
       "version": "0.3.2",
-      "from": "extglob@>=0.3.1 <0.4.0",
+      "from": "extglob@https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "dev": true
     },
     "extsprintf": {
       "version": "1.3.0",
-      "from": "extsprintf@1.3.0",
+      "from": "extsprintf@https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "dev": true
     },
     "fast-deep-equal": {
       "version": "1.1.0",
-      "from": "fast-deep-equal@>=1.0.0 <2.0.0",
+      "from": "fast-deep-equal@https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
       "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
-      "from": "fast-json-stable-stringify@>=2.0.0 <3.0.0",
+      "from": "fast-json-stable-stringify@https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
-      "from": "fast-levenshtein@>=2.0.4 <2.1.0",
+      "from": "fast-levenshtein@https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "dev": true
     },
     "faye-websocket": {
       "version": "0.10.0",
-      "from": "faye-websocket@>=0.10.0 <0.11.0",
+      "from": "faye-websocket@https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
       "dev": true
     },
     "figures": {
       "version": "2.0.0",
-      "from": "figures@>=2.0.0 <3.0.0",
+      "from": "figures@https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "dev": true
     },
     "file-entry-cache": {
       "version": "2.0.0",
-      "from": "file-entry-cache@>=2.0.0 <3.0.0",
+      "from": "file-entry-cache@https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "dev": true
     },
     "file-sync-cmp": {
       "version": "0.1.1",
-      "from": "file-sync-cmp@>=0.1.0 <0.2.0",
+      "from": "file-sync-cmp@https://registry.npmjs.org/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/file-sync-cmp/-/file-sync-cmp-0.1.1.tgz",
       "dev": true
     },
     "filename-regex": {
       "version": "2.0.1",
-      "from": "filename-regex@>=2.0.0 <3.0.0",
+      "from": "filename-regex@https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
       "dev": true
     },
     "fill-range": {
       "version": "2.2.4",
-      "from": "fill-range@>=2.1.0 <3.0.0",
+      "from": "fill-range@https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
       "dev": true
     },
     "find-up": {
       "version": "1.1.2",
-      "from": "find-up@>=1.0.0 <2.0.0",
+      "from": "find-up@https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
       "dev": true
     },
     "findup-sync": {
       "version": "0.3.0",
-      "from": "findup-sync@>=0.3.0 <0.4.0",
+      "from": "findup-sync@https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
       "dev": true,
       "dependencies": {
         "glob": {
           "version": "5.0.15",
-          "from": "glob@>=5.0.0 <5.1.0",
+          "from": "glob@https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "dev": true
         }
@@ -1418,115 +1424,122 @@
     },
     "flat-cache": {
       "version": "1.3.0",
-      "from": "flat-cache@>=1.2.1 <2.0.0",
+      "from": "flat-cache@https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
       "dev": true
     },
     "for-in": {
       "version": "1.0.2",
-      "from": "for-in@>=1.0.1 <2.0.0",
+      "from": "for-in@https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "dev": true
     },
     "for-own": {
       "version": "0.1.5",
-      "from": "for-own@>=0.1.4 <0.2.0",
+      "from": "for-own@https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
-      "from": "forever-agent@>=0.6.1 <0.7.0",
+      "from": "forever-agent@https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "dev": true
     },
     "form-data": {
       "version": "2.3.2",
-      "from": "form-data@>=2.3.1 <2.4.0",
+      "from": "form-data@https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "dev": true
     },
     "fs-extra": {
       "version": "0.26.7",
-      "from": "fs-extra@0.26.7",
+      "from": "fs-extra@https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
       "dev": true
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "from": "fs.realpath@>=1.0.0 <2.0.0",
+      "from": "fs.realpath@https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "dev": true
     },
+    "fsevents": {
+      "version": "0.3.8",
+      "from": "fsevents@https://registry.npmjs.org/fsevents/-/fsevents-0.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-0.3.8.tgz",
+      "dev": true,
+      "optional": true
+    },
     "fstream": {
       "version": "1.0.11",
-      "from": "fstream@>=1.0.0 <2.0.0",
+      "from": "fstream@https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
       "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
       "dev": true
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
-      "from": "functional-red-black-tree@>=1.0.1 <2.0.0",
+      "from": "functional-red-black-tree@https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "dev": true
     },
     "gauge": {
       "version": "2.7.4",
-      "from": "gauge@>=2.7.3 <2.8.0",
+      "from": "gauge@https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "dev": true
     },
     "gaze": {
       "version": "1.1.3",
-      "from": "gaze@>=1.1.0 <2.0.0",
+      "from": "gaze@https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
       "dev": true
     },
     "get-caller-file": {
       "version": "1.0.3",
-      "from": "get-caller-file@>=1.0.1 <2.0.0",
+      "from": "get-caller-file@https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
       "dev": true
     },
     "get-stdin": {
       "version": "4.0.1",
-      "from": "get-stdin@>=4.0.1 <5.0.0",
+      "from": "get-stdin@https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
       "dev": true
     },
     "getobject": {
       "version": "0.1.0",
-      "from": "getobject@>=0.1.0 <0.2.0",
+      "from": "getobject@https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/getobject/-/getobject-0.1.0.tgz",
       "dev": true
     },
     "getpass": {
       "version": "0.1.7",
-      "from": "getpass@>=0.1.1 <0.2.0",
+      "from": "getpass@https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "dev": true
     },
     "glob": {
       "version": "6.0.4",
-      "from": "glob@>=6.0.4 <7.0.0",
+      "from": "glob@https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
       "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
       "dev": true
     },
     "glob-base": {
       "version": "0.3.0",
-      "from": "glob-base@>=0.3.0 <0.4.0",
+      "from": "glob-base@https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "dev": true,
       "dependencies": {
         "glob-parent": {
           "version": "2.0.0",
-          "from": "glob-parent@>=2.0.0 <3.0.0",
+          "from": "glob-parent@https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
           "dev": true
         },
         "is-glob": {
           "version": "2.0.1",
-          "from": "is-glob@>=2.0.0 <3.0.0",
+          "from": "is-glob@https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "dev": true
         }
@@ -1534,13 +1547,13 @@
     },
     "glob-parent": {
       "version": "1.3.0",
-      "from": "glob-parent@>=1.0.0 <2.0.0",
+      "from": "glob-parent@https://registry.npmjs.org/glob-parent/-/glob-parent-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-1.3.0.tgz",
       "dev": true,
       "dependencies": {
         "is-glob": {
           "version": "2.0.1",
-          "from": "is-glob@>=2.0.0 <3.0.0",
+          "from": "is-glob@https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "dev": true
         }
@@ -1548,19 +1561,19 @@
     },
     "globals": {
       "version": "9.18.0",
-      "from": "globals@>=9.18.0 <10.0.0",
+      "from": "globals@https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
       "dev": true
     },
     "globby": {
       "version": "5.0.0",
-      "from": "globby@>=5.0.0 <6.0.0",
+      "from": "globby@https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "dev": true,
       "dependencies": {
         "glob": {
           "version": "7.1.2",
-          "from": "glob@>=7.0.3 <8.0.0",
+          "from": "glob@https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "dev": true
         }
@@ -1568,13 +1581,13 @@
     },
     "globule": {
       "version": "1.2.1",
-      "from": "globule@>=1.0.0 <2.0.0",
+      "from": "globule@https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
       "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
       "dev": true,
       "dependencies": {
         "glob": {
           "version": "7.1.2",
-          "from": "glob@>=7.1.1 <7.2.0",
+          "from": "glob@https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "dev": true
         }
@@ -1582,25 +1595,25 @@
     },
     "graceful-fs": {
       "version": "4.1.11",
-      "from": "graceful-fs@>=4.1.3 <5.0.0",
+      "from": "graceful-fs@https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
       "dev": true
     },
     "growl": {
       "version": "1.10.5",
-      "from": "growl@1.10.5",
+      "from": "growl@https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
       "dev": true
     },
     "grunt": {
       "version": "1.0.3",
-      "from": "grunt@>=1.0.3 <2.0.0",
+      "from": "grunt@https://registry.npmjs.org/grunt/-/grunt-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.0.3.tgz",
       "dev": true,
       "dependencies": {
         "glob": {
           "version": "7.0.6",
-          "from": "glob@>=7.0.0 <7.1.0",
+          "from": "glob@https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
           "dev": true
         }
@@ -1608,37 +1621,37 @@
     },
     "grunt-babel": {
       "version": "7.0.0",
-      "from": "grunt-babel@>=7.0.0 <8.0.0",
+      "from": "grunt-babel@https://registry.npmjs.org/grunt-babel/-/grunt-babel-7.0.0.tgz",
       "resolved": "https://registry.npmjs.org/grunt-babel/-/grunt-babel-7.0.0.tgz",
       "dev": true
     },
     "grunt-cli": {
       "version": "1.2.0",
-      "from": "grunt-cli@>=1.2.0 <2.0.0",
+      "from": "grunt-cli@https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.2.0.tgz",
       "dev": true
     },
     "grunt-contrib-copy": {
       "version": "1.0.0",
-      "from": "grunt-contrib-copy@>=1.0.0 <2.0.0",
+      "from": "grunt-contrib-copy@https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-1.0.0.tgz",
       "dev": true
     },
     "grunt-contrib-jshint": {
       "version": "1.1.0",
-      "from": "grunt-contrib-jshint@>=1.1.0 <2.0.0",
+      "from": "grunt-contrib-jshint@https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-1.1.0.tgz",
       "dev": true
     },
     "grunt-contrib-watch": {
       "version": "1.1.0",
-      "from": "grunt-contrib-watch@>=1.1.0 <2.0.0",
+      "from": "grunt-contrib-watch@https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-1.1.0.tgz",
       "dev": true,
       "dependencies": {
         "async": {
           "version": "2.6.1",
-          "from": "async@>=2.6.0 <3.0.0",
+          "from": "async@https://registry.npmjs.org/async/-/async-2.6.1.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
           "dev": true
         }
@@ -1646,13 +1659,13 @@
     },
     "grunt-jsbeautifier": {
       "version": "0.2.13",
-      "from": "grunt-jsbeautifier@>=0.2.13 <0.3.0",
+      "from": "grunt-jsbeautifier@https://registry.npmjs.org/grunt-jsbeautifier/-/grunt-jsbeautifier-0.2.13.tgz",
       "resolved": "https://registry.npmjs.org/grunt-jsbeautifier/-/grunt-jsbeautifier-0.2.13.tgz",
       "dev": true,
       "dependencies": {
         "async": {
           "version": "2.6.1",
-          "from": "async@>=2.0.0-rc.3 <3.0.0",
+          "from": "async@https://registry.npmjs.org/async/-/async-2.6.1.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
           "dev": true
         }
@@ -1660,19 +1673,19 @@
     },
     "grunt-known-options": {
       "version": "1.1.0",
-      "from": "grunt-known-options@>=1.1.0 <1.2.0",
+      "from": "grunt-known-options@https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/grunt-known-options/-/grunt-known-options-1.1.0.tgz",
       "dev": true
     },
     "grunt-legacy-log": {
       "version": "2.0.0",
-      "from": "grunt-legacy-log@>=2.0.0 <2.1.0",
+      "from": "grunt-legacy-log@https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-2.0.0.tgz",
       "dev": true,
       "dependencies": {
         "colors": {
           "version": "1.1.2",
-          "from": "colors@>=1.1.2 <1.2.0",
+          "from": "colors@https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
           "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
           "dev": true
         }
@@ -1680,25 +1693,25 @@
     },
     "grunt-legacy-log-utils": {
       "version": "2.0.1",
-      "from": "grunt-legacy-log-utils@>=2.0.0 <2.1.0",
+      "from": "grunt-legacy-log-utils@https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-2.0.1.tgz",
       "dev": true,
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "from": "ansi-styles@>=3.2.1 <4.0.0",
+          "from": "ansi-styles@https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "dev": true
         },
         "chalk": {
           "version": "2.4.1",
-          "from": "chalk@>=2.4.1 <2.5.0",
+          "from": "chalk@https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "dev": true
         },
         "supports-color": {
           "version": "5.4.0",
-          "from": "supports-color@>=5.3.0 <6.0.0",
+          "from": "supports-color@https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "dev": true
         }
@@ -1706,49 +1719,49 @@
     },
     "grunt-legacy-util": {
       "version": "1.1.1",
-      "from": "grunt-legacy-util@>=1.1.1 <1.2.0",
+      "from": "grunt-legacy-util@https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-1.1.1.tgz",
       "dev": true
     },
     "grunt-mocha-test": {
       "version": "0.13.3",
-      "from": "grunt-mocha-test@>=0.13.3 <0.14.0",
+      "from": "grunt-mocha-test@https://registry.npmjs.org/grunt-mocha-test/-/grunt-mocha-test-0.13.3.tgz",
       "resolved": "https://registry.npmjs.org/grunt-mocha-test/-/grunt-mocha-test-0.13.3.tgz",
       "dev": true
     },
     "grunt-ts": {
       "version": "5.5.1",
-      "from": "grunt-ts@>=5.5.1 <6.0.0",
+      "from": "grunt-ts@https://registry.npmjs.org/grunt-ts/-/grunt-ts-5.5.1.tgz",
       "resolved": "https://registry.npmjs.org/grunt-ts/-/grunt-ts-5.5.1.tgz",
       "dev": true,
       "dependencies": {
         "lodash": {
           "version": "2.4.1",
-          "from": "lodash@2.4.1",
+          "from": "lodash@https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
           "dev": true
         },
         "rimraf": {
           "version": "2.2.6",
-          "from": "rimraf@2.2.6",
+          "from": "rimraf@https://registry.npmjs.org/rimraf/-/rimraf-2.2.6.tgz",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.6.tgz",
           "dev": true
         },
         "typescript": {
           "version": "1.8.9",
-          "from": "typescript@1.8.9",
+          "from": "typescript@https://registry.npmjs.org/typescript/-/typescript-1.8.9.tgz",
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-1.8.9.tgz",
           "dev": true
         },
         "underscore": {
           "version": "1.5.1",
-          "from": "underscore@1.5.1",
+          "from": "underscore@https://registry.npmjs.org/underscore/-/underscore-1.5.1.tgz",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.5.1.tgz",
           "dev": true
         },
         "underscore.string": {
           "version": "2.3.3",
-          "from": "underscore.string@2.3.3",
+          "from": "underscore.string@https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
           "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
           "dev": true
         }
@@ -1756,186 +1769,193 @@
     },
     "grunt-tslint": {
       "version": "5.0.2",
-      "from": "grunt-tslint@>=5.0.2 <6.0.0",
+      "from": "grunt-tslint@https://registry.npmjs.org/grunt-tslint/-/grunt-tslint-5.0.2.tgz",
       "resolved": "https://registry.npmjs.org/grunt-tslint/-/grunt-tslint-5.0.2.tgz",
       "dev": true
     },
     "hadouken-js-adapter": {
-      "version": "0.32.1-alpha.5",
-      "from": "hadouken-js-adapter@0.32.1-alpha.5",
-      "resolved": "https://registry.npmjs.org/hadouken-js-adapter/-/hadouken-js-adapter-0.32.1-alpha.5.tgz"
+      "version": "0.34.1-alpha.2",
+      "from": "hadouken-js-adapter@0.34.1-alpha.2",
+      "resolved": "https://registry.npmjs.org/hadouken-js-adapter/-/hadouken-js-adapter-0.34.1-alpha.2.tgz",
+      "dependencies": {
+        "@types/node": {
+          "version": "9.6.24",
+          "from": "@types/node@>=9.4.6 <10.0.0",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.24.tgz"
+        }
+      }
     },
     "har-schema": {
       "version": "2.0.0",
-      "from": "har-schema@>=2.0.0 <3.0.0",
+      "from": "har-schema@https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
       "dev": true
     },
     "har-validator": {
       "version": "5.0.3",
-      "from": "har-validator@>=5.0.3 <5.1.0",
+      "from": "har-validator@https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "dev": true
     },
     "has-ansi": {
       "version": "2.0.0",
-      "from": "has-ansi@>=2.0.0 <3.0.0",
+      "from": "has-ansi@https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "dev": true
     },
     "has-flag": {
       "version": "3.0.0",
-      "from": "has-flag@>=3.0.0 <4.0.0",
+      "from": "has-flag@https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "dev": true
     },
     "has-unicode": {
       "version": "2.0.1",
-      "from": "has-unicode@>=2.0.0 <3.0.0",
+      "from": "has-unicode@https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "dev": true
     },
     "hawk": {
       "version": "3.1.3",
-      "from": "hawk@>=3.1.3 <3.2.0",
+      "from": "hawk@https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
       "dev": true
     },
     "he": {
       "version": "1.1.1",
-      "from": "he@1.1.1",
+      "from": "he@https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
       "dev": true
     },
     "hoek": {
       "version": "2.16.3",
-      "from": "hoek@>=2.0.0 <3.0.0",
+      "from": "hoek@https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "dev": true
     },
     "home-or-tmp": {
       "version": "2.0.0",
-      "from": "home-or-tmp@>=2.0.0 <3.0.0",
+      "from": "home-or-tmp@https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "dev": true
     },
     "hooker": {
       "version": "0.2.3",
-      "from": "hooker@>=0.2.3 <0.3.0",
+      "from": "hooker@https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
       "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz",
       "dev": true
     },
     "hosted-git-info": {
       "version": "2.7.1",
-      "from": "hosted-git-info@>=2.1.4 <3.0.0",
+      "from": "hosted-git-info@https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.7.1.tgz",
       "dev": true
     },
     "htmlparser2": {
       "version": "3.8.3",
-      "from": "htmlparser2@>=3.8.0 <3.9.0",
+      "from": "htmlparser2@https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
       "dev": true
     },
     "http-parser-js": {
       "version": "0.4.13",
-      "from": "http-parser-js@>=0.4.0",
+      "from": "http-parser-js@https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.13.tgz",
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.13.tgz",
       "dev": true
     },
     "http-signature": {
       "version": "1.2.0",
-      "from": "http-signature@>=1.2.0 <1.3.0",
+      "from": "http-signature@https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "dev": true
     },
     "iconv-lite": {
       "version": "0.4.23",
-      "from": "iconv-lite@>=0.4.13 <0.5.0",
+      "from": "iconv-lite@https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
       "dev": true
     },
     "ignore": {
       "version": "3.3.10",
-      "from": "ignore@>=3.3.3 <4.0.0",
+      "from": "ignore@https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
       "dev": true
     },
     "imurmurhash": {
       "version": "0.1.4",
-      "from": "imurmurhash@>=0.1.4 <0.2.0",
+      "from": "imurmurhash@https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "dev": true
     },
     "indent-string": {
       "version": "2.1.0",
-      "from": "indent-string@>=2.1.0 <3.0.0",
+      "from": "indent-string@https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "dev": true
     },
     "inflight": {
       "version": "1.0.6",
-      "from": "inflight@>=1.0.4 <2.0.0",
+      "from": "inflight@https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "dev": true
     },
     "inherits": {
       "version": "2.0.3",
-      "from": "inherits@>=2.0.0 <3.0.0",
+      "from": "inherits@https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "dev": true
     },
     "ini": {
       "version": "1.3.5",
-      "from": "ini@>=1.3.4 <2.0.0",
+      "from": "ini@https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "dev": true
     },
     "inquirer": {
       "version": "3.3.0",
-      "from": "inquirer@>=3.0.6 <4.0.0",
+      "from": "inquirer@https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
       "dev": true,
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "from": "ansi-regex@>=3.0.0 <4.0.0",
+          "from": "ansi-regex@https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "from": "ansi-styles@>=3.2.1 <4.0.0",
+          "from": "ansi-styles@https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "dev": true
         },
         "chalk": {
           "version": "2.4.1",
-          "from": "chalk@>=2.0.0 <3.0.0",
+          "from": "chalk@https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "from": "is-fullwidth-code-point@>=2.0.0 <3.0.0",
+          "from": "is-fullwidth-code-point@https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "dev": true
         },
         "string-width": {
           "version": "2.1.1",
-          "from": "string-width@>=2.1.0 <3.0.0",
+          "from": "string-width@https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "dev": true
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "from": "strip-ansi@>=4.0.0 <5.0.0",
+          "from": "strip-ansi@https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "dev": true
         },
         "supports-color": {
           "version": "5.4.0",
-          "from": "supports-color@>=5.3.0 <6.0.0",
+          "from": "supports-color@https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "dev": true
         }
@@ -1943,163 +1963,163 @@
     },
     "invariant": {
       "version": "2.2.4",
-      "from": "invariant@>=2.2.2 <3.0.0",
+      "from": "invariant@https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
       "dev": true
     },
     "invert-kv": {
       "version": "1.0.0",
-      "from": "invert-kv@>=1.0.0 <2.0.0",
+      "from": "invert-kv@https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "dev": true
     },
     "is-arrayish": {
       "version": "0.2.1",
-      "from": "is-arrayish@>=0.2.1 <0.3.0",
+      "from": "is-arrayish@https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "dev": true
     },
     "is-binary-path": {
       "version": "1.0.1",
-      "from": "is-binary-path@>=1.0.0 <2.0.0",
+      "from": "is-binary-path@https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "dev": true
     },
     "is-buffer": {
       "version": "1.1.6",
-      "from": "is-buffer@>=1.1.5 <2.0.0",
+      "from": "is-buffer@https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "dev": true
     },
     "is-builtin-module": {
       "version": "1.0.0",
-      "from": "is-builtin-module@>=1.0.0 <2.0.0",
+      "from": "is-builtin-module@https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "dev": true
     },
     "is-dotfile": {
       "version": "1.0.3",
-      "from": "is-dotfile@>=1.0.0 <2.0.0",
+      "from": "is-dotfile@https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
       "dev": true
     },
     "is-equal-shallow": {
       "version": "0.1.3",
-      "from": "is-equal-shallow@>=0.1.3 <0.2.0",
+      "from": "is-equal-shallow@https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "dev": true
     },
     "is-extendable": {
       "version": "0.1.1",
-      "from": "is-extendable@>=0.1.1 <0.2.0",
+      "from": "is-extendable@https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
       "dev": true
     },
     "is-extglob": {
       "version": "1.0.0",
-      "from": "is-extglob@>=1.0.0 <2.0.0",
+      "from": "is-extglob@https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
       "dev": true
     },
     "is-finite": {
       "version": "1.0.2",
-      "from": "is-finite@>=1.0.0 <2.0.0",
+      "from": "is-finite@https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
-      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+      "from": "is-fullwidth-code-point@https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "dev": true
     },
     "is-glob": {
       "version": "1.1.3",
-      "from": "is-glob@>=1.1.3 <2.0.0",
+      "from": "is-glob@https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-1.1.3.tgz",
       "dev": true
     },
     "is-number": {
       "version": "2.1.0",
-      "from": "is-number@>=2.1.0 <3.0.0",
+      "from": "is-number@https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "dev": true
     },
     "is-path-cwd": {
       "version": "1.0.0",
-      "from": "is-path-cwd@>=1.0.0 <2.0.0",
+      "from": "is-path-cwd@https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
       "dev": true
     },
     "is-path-in-cwd": {
       "version": "1.0.1",
-      "from": "is-path-in-cwd@>=1.0.0 <2.0.0",
+      "from": "is-path-in-cwd@https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
       "dev": true
     },
     "is-path-inside": {
       "version": "1.0.1",
-      "from": "is-path-inside@>=1.0.0 <2.0.0",
+      "from": "is-path-inside@https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
       "dev": true
     },
     "is-posix-bracket": {
       "version": "0.1.1",
-      "from": "is-posix-bracket@>=0.1.0 <0.2.0",
+      "from": "is-posix-bracket@https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
       "dev": true
     },
     "is-primitive": {
       "version": "2.0.0",
-      "from": "is-primitive@>=2.0.0 <3.0.0",
+      "from": "is-primitive@https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
       "dev": true
     },
     "is-promise": {
       "version": "2.1.0",
-      "from": "is-promise@>=2.1.0 <3.0.0",
+      "from": "is-promise@https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "dev": true
     },
     "is-resolvable": {
       "version": "1.1.0",
-      "from": "is-resolvable@>=1.0.0 <2.0.0",
+      "from": "is-resolvable@https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
       "dev": true
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "from": "is-typedarray@>=1.0.0 <1.1.0",
+      "from": "is-typedarray@https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "dev": true
     },
     "is-utf8": {
       "version": "0.2.1",
-      "from": "is-utf8@>=0.2.0 <0.3.0",
+      "from": "is-utf8@https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "dev": true
     },
     "isarray": {
       "version": "0.0.1",
-      "from": "isarray@0.0.1",
+      "from": "isarray@https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "dev": true
     },
     "isexe": {
       "version": "2.0.0",
-      "from": "isexe@>=2.0.0 <3.0.0",
+      "from": "isexe@https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "dev": true
     },
     "isobject": {
       "version": "2.1.0",
-      "from": "isobject@>=2.0.0 <3.0.0",
+      "from": "isobject@https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "dev": true,
       "dependencies": {
         "isarray": {
           "version": "1.0.0",
-          "from": "isarray@1.0.0",
+          "from": "isarray@https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "dev": true
         }
@@ -2107,50 +2127,50 @@
     },
     "isstream": {
       "version": "0.1.2",
-      "from": "isstream@>=0.1.2 <0.2.0",
+      "from": "isstream@https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "dev": true
     },
     "js-beautify": {
       "version": "1.7.5",
-      "from": "js-beautify@>=1.4.2",
+      "from": "js-beautify@https://registry.npmjs.org/js-beautify/-/js-beautify-1.7.5.tgz",
       "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.7.5.tgz",
       "dev": true
     },
     "js-tokens": {
       "version": "3.0.2",
-      "from": "js-tokens@>=3.0.2 <4.0.0",
+      "from": "js-tokens@https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
       "dev": true
     },
     "js-yaml": {
       "version": "3.5.5",
-      "from": "js-yaml@>=3.5.2 <3.6.0",
+      "from": "js-yaml@https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.5.tgz",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.5.tgz",
       "dev": true
     },
     "jsbn": {
       "version": "0.1.1",
-      "from": "jsbn@>=0.1.0 <0.2.0",
+      "from": "jsbn@https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "dev": true,
       "optional": true
     },
     "jsesc": {
       "version": "1.3.0",
-      "from": "jsesc@>=1.3.0 <2.0.0",
+      "from": "jsesc@https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
       "dev": true
     },
     "jshint": {
       "version": "2.9.5",
-      "from": "jshint@>=2.9.4 <2.10.0",
+      "from": "jshint@https://registry.npmjs.org/jshint/-/jshint-2.9.5.tgz",
       "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.5.tgz",
       "dev": true,
       "dependencies": {
         "lodash": {
           "version": "3.7.0",
-          "from": "lodash@>=3.7.0 <3.8.0",
+          "from": "lodash@https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
           "dev": true
         }
@@ -2158,115 +2178,115 @@
     },
     "json-schema": {
       "version": "0.2.3",
-      "from": "json-schema@0.2.3",
+      "from": "json-schema@https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
       "dev": true
     },
     "json-schema-traverse": {
       "version": "0.3.1",
-      "from": "json-schema-traverse@>=0.3.0 <0.4.0",
+      "from": "json-schema-traverse@https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
       "dev": true
     },
     "json-stable-stringify": {
       "version": "1.0.1",
-      "from": "json-stable-stringify@>=1.0.1 <2.0.0",
+      "from": "json-stable-stringify@https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
       "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
-      "from": "json-stable-stringify-without-jsonify@>=1.0.1 <2.0.0",
+      "from": "json-stable-stringify-without-jsonify@https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+      "from": "json-stringify-safe@https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "dev": true
     },
     "json5": {
       "version": "0.5.1",
-      "from": "json5@>=0.5.1 <0.6.0",
+      "from": "json5@https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "dev": true
     },
     "jsonfile": {
       "version": "2.4.0",
-      "from": "jsonfile@>=2.1.0 <3.0.0",
+      "from": "jsonfile@https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "dev": true
     },
     "jsonify": {
       "version": "0.0.0",
-      "from": "jsonify@>=0.0.0 <0.1.0",
+      "from": "jsonify@https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
       "dev": true
     },
     "jsprim": {
       "version": "1.4.1",
-      "from": "jsprim@>=1.2.2 <2.0.0",
+      "from": "jsprim@https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "dev": true
     },
     "just-extend": {
       "version": "1.1.27",
-      "from": "just-extend@>=1.1.27 <2.0.0",
+      "from": "just-extend@https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
       "dev": true
     },
     "kind-of": {
       "version": "3.2.2",
-      "from": "kind-of@>=3.0.2 <4.0.0",
+      "from": "kind-of@https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "dev": true
     },
     "klaw": {
       "version": "1.3.1",
-      "from": "klaw@>=1.0.0 <2.0.0",
+      "from": "klaw@https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "dev": true
     },
     "lcid": {
       "version": "1.0.0",
-      "from": "lcid@>=1.0.0 <2.0.0",
+      "from": "lcid@https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "dev": true
     },
     "levn": {
       "version": "0.3.0",
-      "from": "levn@>=0.3.0 <0.4.0",
+      "from": "levn@https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "dev": true
     },
     "livereload-js": {
       "version": "2.3.0",
-      "from": "livereload-js@>=2.3.0 <3.0.0",
+      "from": "livereload-js@https://registry.npmjs.org/livereload-js/-/livereload-js-2.3.0.tgz",
       "resolved": "https://registry.npmjs.org/livereload-js/-/livereload-js-2.3.0.tgz",
       "dev": true
     },
     "load-grunt-tasks": {
       "version": "4.0.0",
-      "from": "load-grunt-tasks@>=4.0.0 <5.0.0",
+      "from": "load-grunt-tasks@https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-4.0.0.tgz",
       "resolved": "https://registry.npmjs.org/load-grunt-tasks/-/load-grunt-tasks-4.0.0.tgz",
       "dev": true
     },
     "load-json-file": {
       "version": "1.1.0",
-      "from": "load-json-file@>=1.0.0 <2.0.0",
+      "from": "load-json-file@https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
       "dev": true
     },
     "locate-path": {
       "version": "2.0.0",
-      "from": "locate-path@>=2.0.0 <3.0.0",
+      "from": "locate-path@https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "dev": true,
       "dependencies": {
         "path-exists": {
           "version": "3.0.0",
-          "from": "path-exists@>=3.0.0 <4.0.0",
+          "from": "path-exists@https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
           "dev": true
         }
@@ -2274,43 +2294,43 @@
     },
     "lodash": {
       "version": "4.17.10",
-      "from": "lodash@>=4.17.4 <5.0.0",
+      "from": "lodash@https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
       "dev": true
     },
     "lodash.assign": {
       "version": "4.2.0",
-      "from": "lodash.assign@>=4.2.0 <5.0.0",
+      "from": "lodash.assign@https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
       "dev": true
     },
     "lodash.get": {
       "version": "4.4.2",
-      "from": "lodash.get@>=4.4.2 <5.0.0",
+      "from": "lodash.get@https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "dev": true
     },
     "log-symbols": {
       "version": "2.2.0",
-      "from": "log-symbols@>=2.1.0 <3.0.0",
+      "from": "log-symbols@https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
       "dev": true,
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "from": "ansi-styles@>=3.2.1 <4.0.0",
+          "from": "ansi-styles@https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "dev": true
         },
         "chalk": {
           "version": "2.4.1",
-          "from": "chalk@>=2.0.1 <3.0.0",
+          "from": "chalk@https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "dev": true
         },
         "supports-color": {
           "version": "5.4.0",
-          "from": "supports-color@>=5.3.0 <6.0.0",
+          "from": "supports-color@https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "dev": true
         }
@@ -2318,55 +2338,55 @@
     },
     "lolex": {
       "version": "2.7.1",
-      "from": "lolex@>=2.4.2 <3.0.0",
+      "from": "lolex@https://registry.npmjs.org/lolex/-/lolex-2.7.1.tgz",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.1.tgz",
       "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",
-      "from": "loose-envify@>=1.0.0 <2.0.0",
+      "from": "loose-envify@https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "dev": true
     },
     "loud-rejection": {
       "version": "1.6.0",
-      "from": "loud-rejection@>=1.0.0 <2.0.0",
+      "from": "loud-rejection@https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "dev": true
     },
     "lru-cache": {
       "version": "3.2.0",
-      "from": "lru-cache@>=3.2.0 <4.0.0",
+      "from": "lru-cache@https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
       "dev": true
     },
     "map-obj": {
       "version": "1.0.1",
-      "from": "map-obj@>=1.0.1 <2.0.0",
+      "from": "map-obj@https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
       "dev": true
     },
     "math-random": {
       "version": "1.0.1",
-      "from": "math-random@>=1.0.1 <2.0.0",
+      "from": "math-random@https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
       "dev": true
     },
     "meow": {
       "version": "3.7.0",
-      "from": "meow@>=3.3.0 <4.0.0",
+      "from": "meow@https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "dev": true
     },
     "micromatch": {
       "version": "2.3.11",
-      "from": "micromatch@>=2.1.5 <3.0.0",
+      "from": "micromatch@https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "dev": true,
       "dependencies": {
         "is-glob": {
           "version": "2.0.1",
-          "from": "is-glob@>=2.0.1 <3.0.0",
+          "from": "is-glob@https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "dev": true
         }
@@ -2374,42 +2394,42 @@
     },
     "mime-db": {
       "version": "1.35.0",
-      "from": "mime-db@>=1.35.0 <1.36.0",
+      "from": "mime-db@https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.35.0.tgz",
       "dev": true
     },
     "mime-types": {
       "version": "2.1.19",
-      "from": "mime-types@>=2.1.17 <2.2.0",
+      "from": "mime-types@https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.19.tgz",
       "dev": true
     },
     "mimic-fn": {
       "version": "1.2.0",
-      "from": "mimic-fn@>=1.0.0 <2.0.0",
+      "from": "mimic-fn@https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
       "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
-      "from": "minimatch@>=3.0.3 <4.0.0",
+      "from": "minimatch@https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "dev": true
     },
     "minimist": {
       "version": "1.2.0",
-      "from": "minimist@>=1.2.0 <2.0.0",
+      "from": "minimist@https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
     },
     "mkdirp": {
       "version": "0.5.1",
-      "from": "mkdirp@>=0.5.0 <0.6.0",
+      "from": "mkdirp@https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "dev": true,
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
-          "from": "minimist@0.0.8",
+          "from": "minimist@https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "dev": true
         }
@@ -2417,43 +2437,43 @@
     },
     "mkpath": {
       "version": "0.1.0",
-      "from": "mkpath@>=0.1.0 <0.2.0",
+      "from": "mkpath@https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
       "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
       "dev": true
     },
     "mksnapshot": {
       "version": "0.3.1",
-      "from": "mksnapshot@>=0.3.0 <0.4.0",
+      "from": "mksnapshot@https://registry.npmjs.org/mksnapshot/-/mksnapshot-0.3.1.tgz",
       "resolved": "https://registry.npmjs.org/mksnapshot/-/mksnapshot-0.3.1.tgz",
       "dev": true
     },
     "mocha": {
       "version": "5.2.0",
-      "from": "mocha@>=5.2.0 <6.0.0",
+      "from": "mocha@https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
       "dev": true,
       "dependencies": {
         "commander": {
           "version": "2.15.1",
-          "from": "commander@2.15.1",
+          "from": "commander@https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
           "dev": true
         },
         "debug": {
           "version": "3.1.0",
-          "from": "debug@3.1.0",
+          "from": "debug@https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "dev": true
         },
         "glob": {
           "version": "7.1.2",
-          "from": "glob@7.1.2",
+          "from": "glob@https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "dev": true
         },
         "supports-color": {
           "version": "5.4.0",
-          "from": "supports-color@5.4.0",
+          "from": "supports-color@https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "dev": true
         }
@@ -2461,127 +2481,133 @@
     },
     "mockery": {
       "version": "2.1.0",
-      "from": "mockery@>=2.1.0 <3.0.0",
+      "from": "mockery@https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
       "dev": true
     },
     "ms": {
       "version": "2.0.0",
-      "from": "ms@2.0.0",
+      "from": "ms@https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "dev": true
     },
     "multimatch": {
       "version": "2.1.0",
-      "from": "multimatch@>=2.0.0 <3.0.0",
+      "from": "multimatch@https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-2.1.0.tgz",
       "dev": true
     },
     "mute-stream": {
       "version": "0.0.7",
-      "from": "mute-stream@0.0.7",
+      "from": "mute-stream@https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "dev": true
     },
+    "nan": {
+      "version": "2.10.0",
+      "from": "nan@https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "optional": true
+    },
     "natural-compare": {
       "version": "1.4.0",
-      "from": "natural-compare@>=1.4.0 <2.0.0",
+      "from": "natural-compare@https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "dev": true
     },
     "ncp": {
       "version": "0.5.1",
-      "from": "ncp@0.5.1",
+      "from": "ncp@https://registry.npmjs.org/ncp/-/ncp-0.5.1.tgz",
       "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.5.1.tgz",
       "dev": true
     },
     "nise": {
       "version": "1.4.2",
-      "from": "nise@>=1.3.3 <2.0.0",
+      "from": "nise@https://registry.npmjs.org/nise/-/nise-1.4.2.tgz",
       "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.2.tgz",
       "dev": true
     },
     "node-abi": {
       "version": "2.4.3",
-      "from": "node-abi@>=2.0.0 <3.0.0",
+      "from": "node-abi@https://registry.npmjs.org/node-abi/-/node-abi-2.4.3.tgz",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.4.3.tgz",
       "dev": true
     },
     "node-gyp": {
       "version": "3.7.0",
-      "from": "node-gyp@>=3.6.0 <4.0.0",
+      "from": "node-gyp@https://registry.npmjs.org/node-gyp/-/node-gyp-3.7.0.tgz",
       "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.7.0.tgz",
       "dev": true,
       "dependencies": {
         "ajv": {
           "version": "4.11.8",
-          "from": "ajv@>=4.9.1 <5.0.0",
+          "from": "ajv@https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
           "dev": true
         },
         "assert-plus": {
           "version": "0.2.0",
-          "from": "assert-plus@>=0.2.0 <0.3.0",
+          "from": "assert-plus@https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
           "dev": true
         },
         "aws-sign2": {
           "version": "0.6.0",
-          "from": "aws-sign2@>=0.6.0 <0.7.0",
+          "from": "aws-sign2@https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
           "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
           "dev": true
         },
         "form-data": {
           "version": "2.1.4",
-          "from": "form-data@>=2.1.1 <2.2.0",
+          "from": "form-data@https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
           "dev": true
         },
         "glob": {
           "version": "7.1.2",
-          "from": "glob@>=7.0.3 <8.0.0",
+          "from": "glob@https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "dev": true
         },
         "har-schema": {
           "version": "1.0.5",
-          "from": "har-schema@>=1.0.5 <2.0.0",
+          "from": "har-schema@https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
           "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
           "dev": true
         },
         "har-validator": {
           "version": "4.2.1",
-          "from": "har-validator@>=4.2.1 <4.3.0",
+          "from": "har-validator@https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
           "dev": true
         },
         "http-signature": {
           "version": "1.1.1",
-          "from": "http-signature@>=1.1.0 <1.2.0",
+          "from": "http-signature@https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
           "dev": true
         },
         "performance-now": {
           "version": "0.2.0",
-          "from": "performance-now@>=0.2.0 <0.3.0",
+          "from": "performance-now@https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
           "dev": true
         },
         "qs": {
           "version": "6.4.0",
-          "from": "qs@>=6.4.0 <6.5.0",
+          "from": "qs@https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
           "dev": true
         },
         "request": {
           "version": "2.81.0",
-          "from": "request@>=2.9.0 <2.82.0",
+          "from": "request@https://registry.npmjs.org/request/-/request-2.81.0.tgz",
           "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
           "dev": true
         },
         "semver": {
           "version": "5.3.0",
-          "from": "semver@>=5.3.0 <5.4.0",
+          "from": "semver@https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
           "dev": true
         }
@@ -2589,61 +2615,61 @@
     },
     "nopt": {
       "version": "3.0.6",
-      "from": "nopt@>=3.0.1 <4.0.0",
+      "from": "nopt@https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "dev": true
     },
     "normalize-package-data": {
       "version": "2.4.0",
-      "from": "normalize-package-data@>=2.3.2 <3.0.0",
+      "from": "normalize-package-data@https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "dev": true
     },
     "normalize-path": {
       "version": "2.1.1",
-      "from": "normalize-path@>=2.0.0 <3.0.0",
+      "from": "normalize-path@https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "dev": true
     },
     "npmlog": {
       "version": "4.1.2",
-      "from": "npmlog@>=0.0.0 <1.0.0||>=1.0.0 <2.0.0||>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0",
+      "from": "npmlog@https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "dev": true
     },
     "number-is-nan": {
       "version": "1.0.1",
-      "from": "number-is-nan@>=1.0.0 <2.0.0",
+      "from": "number-is-nan@https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "dev": true
     },
     "oauth-sign": {
       "version": "0.8.2",
-      "from": "oauth-sign@>=0.8.2 <0.9.0",
+      "from": "oauth-sign@https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
       "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
-      "from": "object-assign@>=4.1.0 <5.0.0",
+      "from": "object-assign@https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "dev": true
     },
     "object.omit": {
       "version": "2.0.1",
-      "from": "object.omit@>=2.0.0 <3.0.0",
+      "from": "object.omit@https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "dev": true
     },
     "once": {
       "version": "1.4.0",
-      "from": "once@>=1.3.0 <2.0.0",
+      "from": "once@https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "dev": true
     },
     "onetime": {
       "version": "2.0.1",
-      "from": "onetime@>=2.0.0 <3.0.0",
+      "from": "onetime@https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "dev": true
     },
@@ -2655,36 +2681,36 @@
     },
     "optionator": {
       "version": "0.8.2",
-      "from": "optionator@>=0.8.2 <0.9.0",
+      "from": "optionator@https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "dev": true
     },
     "options": {
       "version": "0.0.6",
-      "from": "options@0.0.6",
+      "from": "options@https://registry.npmjs.org/options/-/options-0.0.6.tgz",
       "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz"
     },
     "ora": {
       "version": "1.4.0",
-      "from": "ora@>=1.2.0 <2.0.0",
+      "from": "ora@https://registry.npmjs.org/ora/-/ora-1.4.0.tgz",
       "resolved": "https://registry.npmjs.org/ora/-/ora-1.4.0.tgz",
       "dev": true,
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "from": "ansi-styles@>=3.2.1 <4.0.0",
+          "from": "ansi-styles@https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "dev": true
         },
         "chalk": {
           "version": "2.4.1",
-          "from": "chalk@>=2.1.0 <3.0.0",
+          "from": "chalk@https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "dev": true
         },
         "supports-color": {
           "version": "5.4.0",
-          "from": "supports-color@>=5.3.0 <6.0.0",
+          "from": "supports-color@https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "dev": true
         }
@@ -2692,55 +2718,55 @@
     },
     "os-homedir": {
       "version": "1.0.2",
-      "from": "os-homedir@>=1.0.0 <2.0.0",
+      "from": "os-homedir@https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
       "dev": true
     },
     "os-locale": {
       "version": "1.4.0",
-      "from": "os-locale@>=1.4.0 <2.0.0",
+      "from": "os-locale@https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
       "dev": true
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "from": "os-tmpdir@>=1.0.1 <1.1.0",
+      "from": "os-tmpdir@https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "dev": true
     },
     "osenv": {
       "version": "0.1.5",
-      "from": "osenv@>=0.0.0 <1.0.0",
+      "from": "osenv@https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
       "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
       "dev": true
     },
     "p-limit": {
       "version": "1.3.0",
-      "from": "p-limit@>=1.1.0 <2.0.0",
+      "from": "p-limit@https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
       "dev": true
     },
     "p-locate": {
       "version": "2.0.0",
-      "from": "p-locate@>=2.0.0 <3.0.0",
+      "from": "p-locate@https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "dev": true
     },
     "p-try": {
       "version": "1.0.0",
-      "from": "p-try@>=1.0.0 <2.0.0",
+      "from": "p-try@https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
       "dev": true
     },
     "parse-glob": {
       "version": "3.0.4",
-      "from": "parse-glob@>=3.0.4 <4.0.0",
+      "from": "parse-glob@https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "dev": true,
       "dependencies": {
         "is-glob": {
           "version": "2.0.1",
-          "from": "is-glob@>=2.0.0 <3.0.0",
+          "from": "is-glob@https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
           "dev": true
         }
@@ -2748,79 +2774,79 @@
     },
     "parse-json": {
       "version": "2.2.0",
-      "from": "parse-json@>=2.2.0 <3.0.0",
+      "from": "parse-json@https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
       "dev": true
     },
     "path-exists": {
       "version": "2.1.0",
-      "from": "path-exists@>=2.0.0 <3.0.0",
+      "from": "path-exists@https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
       "dev": true
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+      "from": "path-is-absolute@https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
-      "from": "path-is-inside@>=1.0.2 <2.0.0",
+      "from": "path-is-inside@https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "dev": true
     },
     "path-parse": {
       "version": "1.0.5",
-      "from": "path-parse@>=1.0.5 <2.0.0",
+      "from": "path-parse@https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
       "dev": true
     },
     "path-to-regexp": {
       "version": "1.7.0",
-      "from": "path-to-regexp@>=1.7.0 <2.0.0",
+      "from": "path-to-regexp@https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
       "dev": true
     },
     "path-type": {
       "version": "1.1.0",
-      "from": "path-type@>=1.0.0 <2.0.0",
+      "from": "path-type@https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
       "dev": true
     },
     "performance-now": {
       "version": "2.1.0",
-      "from": "performance-now@>=2.1.0 <3.0.0",
+      "from": "performance-now@https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "dev": true
     },
     "pify": {
       "version": "2.3.0",
-      "from": "pify@>=2.0.0 <3.0.0",
+      "from": "pify@https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "dev": true
     },
     "pinkie": {
       "version": "2.0.4",
-      "from": "pinkie@>=2.0.0 <3.0.0",
+      "from": "pinkie@https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
       "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
       "dev": true
     },
     "pinkie-promise": {
       "version": "2.0.1",
-      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+      "from": "pinkie-promise@https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "dev": true
     },
     "pkg-up": {
       "version": "2.0.0",
-      "from": "pkg-up@>=2.0.0 <3.0.0",
+      "from": "pkg-up@https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
       "dev": true,
       "dependencies": {
         "find-up": {
           "version": "2.1.0",
-          "from": "find-up@>=2.1.0 <3.0.0",
+          "from": "find-up@https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "dev": true
         }
@@ -2828,85 +2854,85 @@
     },
     "pluralize": {
       "version": "7.0.0",
-      "from": "pluralize@>=7.0.0 <8.0.0",
+      "from": "pluralize@https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
       "dev": true
     },
     "prelude-ls": {
       "version": "1.1.2",
-      "from": "prelude-ls@>=1.1.2 <1.2.0",
+      "from": "prelude-ls@https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "dev": true
     },
     "preserve": {
       "version": "0.2.0",
-      "from": "preserve@>=0.2.0 <0.3.0",
+      "from": "preserve@https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "dev": true
     },
     "private": {
       "version": "0.1.8",
-      "from": "private@>=0.1.8 <0.2.0",
+      "from": "private@https://registry.npmjs.org/private/-/private-0.1.8.tgz",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
       "dev": true
     },
     "process-nextick-args": {
       "version": "2.0.0",
-      "from": "process-nextick-args@>=2.0.0 <2.1.0",
+      "from": "process-nextick-args@https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "dev": true
     },
     "progress": {
       "version": "2.0.0",
-      "from": "progress@>=2.0.0 <3.0.0",
+      "from": "progress@https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
       "dev": true
     },
     "proto-list": {
       "version": "1.2.4",
-      "from": "proto-list@>=1.2.1 <1.3.0",
+      "from": "proto-list@https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
       "dev": true
     },
     "pseudomap": {
       "version": "1.0.2",
-      "from": "pseudomap@>=1.0.1 <2.0.0",
+      "from": "pseudomap@https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "dev": true
     },
     "punycode": {
       "version": "1.4.1",
-      "from": "punycode@>=1.4.1 <2.0.0",
+      "from": "punycode@https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
       "dev": true
     },
     "q": {
       "version": "1.5.1",
-      "from": "q@>=1.1.2 <2.0.0",
+      "from": "q@https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
       "dev": true
     },
     "qs": {
       "version": "6.5.2",
-      "from": "qs@>=6.5.1 <6.6.0",
+      "from": "qs@https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "dev": true
     },
     "randomatic": {
       "version": "3.0.0",
-      "from": "randomatic@>=3.0.0 <4.0.0",
+      "from": "randomatic@https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
       "dev": true,
       "dependencies": {
         "is-number": {
           "version": "4.0.0",
-          "from": "is-number@>=4.0.0 <5.0.0",
+          "from": "is-number@https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
           "dev": true
         },
         "kind-of": {
           "version": "6.0.2",
-          "from": "kind-of@>=6.0.0 <7.0.0",
+          "from": "kind-of@https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
           "dev": true
         }
@@ -2914,19 +2940,19 @@
     },
     "raw-body": {
       "version": "1.1.7",
-      "from": "raw-body@>=1.1.0 <1.2.0",
+      "from": "raw-body@https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
       "dev": true
     },
     "rc": {
       "version": "1.2.8",
-      "from": "rc@>=0.5.5",
+      "from": "rc@https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "dev": true,
       "dependencies": {
         "strip-json-comments": {
           "version": "2.0.1",
-          "from": "strip-json-comments@>=2.0.1 <2.1.0",
+          "from": "strip-json-comments@https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "dev": true
         }
@@ -2934,43 +2960,43 @@
     },
     "read-pkg": {
       "version": "1.1.0",
-      "from": "read-pkg@>=1.0.0 <2.0.0",
+      "from": "read-pkg@https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
       "dev": true
     },
     "read-pkg-up": {
       "version": "1.0.1",
-      "from": "read-pkg-up@>=1.0.1 <2.0.0",
+      "from": "read-pkg-up@https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
       "dev": true
     },
     "readable-stream": {
       "version": "1.1.14",
-      "from": "readable-stream@>=1.1.8 <2.0.0",
+      "from": "readable-stream@https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
       "dev": true
     },
     "readdirp": {
       "version": "1.4.0",
-      "from": "readdirp@>=1.3.0 <2.0.0",
+      "from": "readdirp@https://registry.npmjs.org/readdirp/-/readdirp-1.4.0.tgz",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-1.4.0.tgz",
       "dev": true,
       "dependencies": {
         "lru-cache": {
           "version": "2.7.3",
-          "from": "lru-cache@>=2.0.0 <3.0.0",
+          "from": "lru-cache@https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
           "dev": true
         },
         "minimatch": {
           "version": "0.2.14",
-          "from": "minimatch@>=0.2.12 <0.3.0",
+          "from": "minimatch@https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
           "dev": true
         },
         "readable-stream": {
           "version": "1.0.34",
-          "from": "readable-stream@>=1.0.26-2 <1.1.0",
+          "from": "readable-stream@https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "dev": true
         }
@@ -2978,61 +3004,61 @@
     },
     "redent": {
       "version": "1.0.0",
-      "from": "redent@>=1.0.0 <2.0.0",
+      "from": "redent@https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "dev": true
     },
     "regenerate": {
       "version": "1.4.0",
-      "from": "regenerate@>=1.2.1 <2.0.0",
+      "from": "regenerate@https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
       "dev": true
     },
     "regenerator-runtime": {
       "version": "0.11.1",
-      "from": "regenerator-runtime@>=0.11.0 <0.12.0",
+      "from": "regenerator-runtime@https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
       "dev": true
     },
     "regenerator-transform": {
       "version": "0.10.1",
-      "from": "regenerator-transform@>=0.10.0 <0.11.0",
+      "from": "regenerator-transform@https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
       "dev": true
     },
     "regex-cache": {
       "version": "0.4.4",
-      "from": "regex-cache@>=0.4.2 <0.5.0",
+      "from": "regex-cache@https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
       "dev": true
     },
     "regexpp": {
       "version": "1.1.0",
-      "from": "regexpp@>=1.0.1 <2.0.0",
+      "from": "regexpp@https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
       "dev": true
     },
     "regexpu-core": {
       "version": "2.0.0",
-      "from": "regexpu-core@>=2.0.0 <3.0.0",
+      "from": "regexpu-core@https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "dev": true
     },
     "regjsgen": {
       "version": "0.2.0",
-      "from": "regjsgen@>=0.2.0 <0.3.0",
+      "from": "regjsgen@https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
       "dev": true
     },
     "regjsparser": {
       "version": "0.1.5",
-      "from": "regjsparser@>=0.1.4 <0.2.0",
+      "from": "regjsparser@https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "dev": true,
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
-          "from": "jsesc@>=0.5.0 <0.6.0",
+          "from": "jsesc@https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
           "dev": true
         }
@@ -3040,55 +3066,55 @@
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
-      "from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+      "from": "remove-trailing-separator@https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "dev": true
     },
     "repeat-element": {
       "version": "1.1.2",
-      "from": "repeat-element@>=1.1.2 <2.0.0",
+      "from": "repeat-element@https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
       "dev": true
     },
     "repeat-string": {
       "version": "1.6.1",
-      "from": "repeat-string@>=1.5.2 <2.0.0",
+      "from": "repeat-string@https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "dev": true
     },
     "repeating": {
       "version": "2.0.1",
-      "from": "repeating@>=2.0.0 <3.0.0",
+      "from": "repeating@https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "dev": true
     },
     "request": {
       "version": "2.87.0",
-      "from": "request@>=2.79.0 <3.0.0",
+      "from": "request@https://registry.npmjs.org/request/-/request-2.87.0.tgz",
       "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
       "dev": true
     },
     "require-directory": {
       "version": "2.1.1",
-      "from": "require-directory@>=2.1.1 <3.0.0",
+      "from": "require-directory@https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "dev": true
     },
     "require-main-filename": {
       "version": "1.0.1",
-      "from": "require-main-filename@>=1.0.1 <2.0.0",
+      "from": "require-main-filename@https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "dev": true
     },
     "require-uncached": {
       "version": "1.0.3",
-      "from": "require-uncached@>=1.0.3 <2.0.0",
+      "from": "require-uncached@https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "dev": true,
       "dependencies": {
         "resolve-from": {
           "version": "1.0.1",
-          "from": "resolve-from@>=1.0.0 <2.0.0",
+          "from": "resolve-from@https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
           "dev": true
         }
@@ -3096,43 +3122,43 @@
     },
     "resolve": {
       "version": "1.1.7",
-      "from": "resolve@>=1.1.0 <1.2.0",
+      "from": "resolve@https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
       "dev": true
     },
     "resolve-from": {
       "version": "2.0.0",
-      "from": "resolve-from@>=2.0.0 <3.0.0",
+      "from": "resolve-from@https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
       "dev": true
     },
     "resolve-pkg": {
       "version": "1.0.0",
-      "from": "resolve-pkg@>=1.0.0 <2.0.0",
+      "from": "resolve-pkg@https://registry.npmjs.org/resolve-pkg/-/resolve-pkg-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/resolve-pkg/-/resolve-pkg-1.0.0.tgz",
       "dev": true
     },
     "restore-cursor": {
       "version": "2.0.0",
-      "from": "restore-cursor@>=2.0.0 <3.0.0",
+      "from": "restore-cursor@https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "dev": true
     },
     "rewire": {
       "version": "4.0.1",
-      "from": "rewire@>=4.0.1 <5.0.0",
+      "from": "rewire@https://registry.npmjs.org/rewire/-/rewire-4.0.1.tgz",
       "resolved": "https://registry.npmjs.org/rewire/-/rewire-4.0.1.tgz",
       "dev": true
     },
     "rimraf": {
       "version": "2.6.2",
-      "from": "rimraf@>=2.2.8 <3.0.0",
+      "from": "rimraf@https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "dev": true,
       "dependencies": {
         "glob": {
           "version": "7.1.2",
-          "from": "glob@>=7.0.5 <8.0.0",
+          "from": "glob@https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "dev": true
         }
@@ -3140,156 +3166,156 @@
     },
     "run-async": {
       "version": "2.3.0",
-      "from": "run-async@>=2.2.0 <3.0.0",
+      "from": "run-async@https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
       "dev": true
     },
     "rx": {
       "version": "4.1.0",
-      "from": "rx@>=4.1.0 <5.0.0",
+      "from": "rx@https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
       "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz"
     },
     "rx-lite": {
       "version": "4.0.8",
-      "from": "rx-lite@>=4.0.8 <5.0.0",
+      "from": "rx-lite@https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
       "dev": true
     },
     "rx-lite-aggregates": {
       "version": "4.0.8",
-      "from": "rx-lite-aggregates@>=4.0.8 <5.0.0",
+      "from": "rx-lite-aggregates@https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
       "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
       "dev": true
     },
     "rxjs": {
       "version": "5.5.11",
-      "from": "rxjs@>=5.1.1 <6.0.0",
+      "from": "rxjs@https://registry.npmjs.org/rxjs/-/rxjs-5.5.11.tgz",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.11.tgz",
       "dev": true
     },
     "safe-buffer": {
       "version": "5.1.2",
-      "from": "safe-buffer@>=5.1.1 <6.0.0",
+      "from": "safe-buffer@https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "dev": true
     },
     "safe-json-parse": {
       "version": "1.0.1",
-      "from": "safe-json-parse@>=1.0.1 <1.1.0",
+      "from": "safe-json-parse@https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-1.0.1.tgz",
       "dev": true
     },
     "safer-buffer": {
       "version": "2.1.2",
-      "from": "safer-buffer@>=2.0.2 <3.0.0",
+      "from": "safer-buffer@https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "dev": true
     },
     "samsam": {
       "version": "1.3.0",
-      "from": "samsam@1.3.0",
+      "from": "samsam@https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
       "dev": true
     },
     "sax": {
       "version": "1.2.4",
-      "from": "sax@>=0.6.0",
+      "from": "sax@https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "dev": true
     },
     "semver": {
       "version": "5.5.0",
-      "from": "semver@>=5.4.1 <6.0.0",
+      "from": "semver@https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
       "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",
-      "from": "set-blocking@>=2.0.0 <2.1.0",
+      "from": "set-blocking@https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",
-      "from": "shebang-command@>=1.2.0 <2.0.0",
+      "from": "shebang-command@https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "dev": true
     },
     "shebang-regex": {
       "version": "1.0.0",
-      "from": "shebang-regex@>=1.0.0 <2.0.0",
+      "from": "shebang-regex@https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "dev": true
     },
     "shelljs": {
       "version": "0.3.0",
-      "from": "shelljs@>=0.3.0 <0.4.0",
+      "from": "shelljs@https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
       "dev": true
     },
     "should": {
       "version": "13.2.1",
-      "from": "should@>=13.2.1 <14.0.0",
+      "from": "should@https://registry.npmjs.org/should/-/should-13.2.1.tgz",
       "resolved": "https://registry.npmjs.org/should/-/should-13.2.1.tgz",
       "dev": true
     },
     "should-equal": {
       "version": "2.0.0",
-      "from": "should-equal@>=2.0.0 <3.0.0",
+      "from": "should-equal@https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-2.0.0.tgz",
       "dev": true
     },
     "should-format": {
       "version": "3.0.3",
-      "from": "should-format@>=3.0.3 <4.0.0",
+      "from": "should-format@https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
       "resolved": "https://registry.npmjs.org/should-format/-/should-format-3.0.3.tgz",
       "dev": true
     },
     "should-sinon": {
       "version": "0.0.6",
-      "from": "should-sinon@0.0.6",
+      "from": "should-sinon@https://registry.npmjs.org/should-sinon/-/should-sinon-0.0.6.tgz",
       "resolved": "https://registry.npmjs.org/should-sinon/-/should-sinon-0.0.6.tgz",
       "dev": true
     },
     "should-type": {
       "version": "1.4.0",
-      "from": "should-type@>=1.4.0 <2.0.0",
+      "from": "should-type@https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
       "resolved": "https://registry.npmjs.org/should-type/-/should-type-1.4.0.tgz",
       "dev": true
     },
     "should-type-adaptors": {
       "version": "1.1.0",
-      "from": "should-type-adaptors@>=1.0.1 <2.0.0",
+      "from": "should-type-adaptors@https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
       "resolved": "https://registry.npmjs.org/should-type-adaptors/-/should-type-adaptors-1.1.0.tgz",
       "dev": true
     },
     "should-util": {
       "version": "1.0.0",
-      "from": "should-util@>=1.0.0 <2.0.0",
+      "from": "should-util@https://registry.npmjs.org/should-util/-/should-util-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/should-util/-/should-util-1.0.0.tgz",
       "dev": true
     },
     "sigmund": {
       "version": "1.0.1",
-      "from": "sigmund@>=1.0.1 <2.0.0",
+      "from": "sigmund@https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
       "dev": true
     },
     "signal-exit": {
       "version": "3.0.2",
-      "from": "signal-exit@>=3.0.0 <4.0.0",
+      "from": "signal-exit@https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "dev": true
     },
     "sinon": {
       "version": "6.1.3",
-      "from": "sinon@>=6.1.3 <7.0.0",
+      "from": "sinon@https://registry.npmjs.org/sinon/-/sinon-6.1.3.tgz",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-6.1.3.tgz",
       "dev": true,
       "dependencies": {
         "supports-color": {
           "version": "5.4.0",
-          "from": "supports-color@>=5.4.0 <6.0.0",
+          "from": "supports-color@https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "dev": true
         }
@@ -3297,19 +3323,19 @@
     },
     "slash": {
       "version": "1.0.0",
-      "from": "slash@>=1.0.0 <2.0.0",
+      "from": "slash@https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
       "dev": true
     },
     "slice-ansi": {
       "version": "1.0.0",
-      "from": "slice-ansi@1.0.0",
+      "from": "slice-ansi@https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
       "dev": true,
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "from": "is-fullwidth-code-point@>=2.0.0 <3.0.0",
+          "from": "is-fullwidth-code-point@https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "dev": true
         }
@@ -3317,169 +3343,169 @@
     },
     "sntp": {
       "version": "1.0.9",
-      "from": "sntp@>=1.0.0 <2.0.0",
+      "from": "sntp@https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
       "dev": true
     },
     "source-map": {
       "version": "0.5.7",
-      "from": "source-map@>=0.5.7 <0.6.0",
+      "from": "source-map@https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "dev": true
     },
     "source-map-support": {
       "version": "0.4.18",
-      "from": "source-map-support@>=0.4.15 <0.5.0",
+      "from": "source-map-support@https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
       "dev": true
     },
     "spawn-rx": {
       "version": "2.0.12",
-      "from": "spawn-rx@>=2.0.10 <3.0.0",
+      "from": "spawn-rx@https://registry.npmjs.org/spawn-rx/-/spawn-rx-2.0.12.tgz",
       "resolved": "https://registry.npmjs.org/spawn-rx/-/spawn-rx-2.0.12.tgz",
       "dev": true
     },
     "spdx-correct": {
       "version": "3.0.0",
-      "from": "spdx-correct@>=3.0.0 <4.0.0",
+      "from": "spdx-correct@https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
       "dev": true
     },
     "spdx-exceptions": {
       "version": "2.1.0",
-      "from": "spdx-exceptions@>=2.1.0 <3.0.0",
+      "from": "spdx-exceptions@https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
       "dev": true
     },
     "spdx-expression-parse": {
       "version": "3.0.0",
-      "from": "spdx-expression-parse@>=3.0.0 <4.0.0",
+      "from": "spdx-expression-parse@https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
       "dev": true
     },
     "spdx-license-ids": {
       "version": "3.0.0",
-      "from": "spdx-license-ids@>=3.0.0 <4.0.0",
+      "from": "spdx-license-ids@https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
       "dev": true
     },
     "sprintf-js": {
       "version": "1.1.1",
-      "from": "sprintf-js@>=1.0.3 <2.0.0",
+      "from": "sprintf-js@https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
       "dev": true
     },
     "sshpk": {
       "version": "1.14.2",
-      "from": "sshpk@>=1.7.0 <2.0.0",
+      "from": "sshpk@https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
       "dev": true
     },
     "string_decoder": {
       "version": "0.10.31",
-      "from": "string_decoder@>=0.10.0 <0.11.0",
+      "from": "string_decoder@https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "dev": true
     },
     "string-template": {
       "version": "0.2.1",
-      "from": "string-template@>=0.2.1 <0.3.0",
+      "from": "string-template@https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
       "dev": true
     },
     "string-width": {
       "version": "1.0.2",
-      "from": "string-width@>=1.0.1 <2.0.0",
+      "from": "string-width@https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "dev": true
     },
     "stringstream": {
       "version": "0.0.6",
-      "from": "stringstream@>=0.0.4 <0.1.0",
+      "from": "stringstream@https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
       "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "from": "strip-ansi@>=3.0.0 <4.0.0",
+      "from": "strip-ansi@https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "dev": true
     },
     "strip-bom": {
       "version": "2.0.0",
-      "from": "strip-bom@>=2.0.0 <3.0.0",
+      "from": "strip-bom@https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
       "dev": true
     },
     "strip-indent": {
       "version": "1.0.1",
-      "from": "strip-indent@>=1.0.1 <2.0.0",
+      "from": "strip-indent@https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "dev": true
     },
     "strip-json-comments": {
       "version": "1.0.4",
-      "from": "strip-json-comments@>=1.0.0 <1.1.0",
+      "from": "strip-json-comments@https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
       "dev": true
     },
     "supports-color": {
       "version": "2.0.0",
-      "from": "supports-color@>=2.0.0 <3.0.0",
+      "from": "supports-color@https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
       "dev": true
     },
     "symbol-observable": {
       "version": "1.0.1",
-      "from": "symbol-observable@1.0.1",
+      "from": "symbol-observable@https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
       "dev": true
     },
     "table": {
       "version": "4.0.2",
-      "from": "table@4.0.2",
+      "from": "table@https://registry.npmjs.org/table/-/table-4.0.2.tgz",
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
       "dev": true,
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
-          "from": "ansi-regex@>=3.0.0 <4.0.0",
+          "from": "ansi-regex@https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "from": "ansi-styles@>=3.2.1 <4.0.0",
+          "from": "ansi-styles@https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "dev": true
         },
         "chalk": {
           "version": "2.4.1",
-          "from": "chalk@>=2.1.0 <3.0.0",
+          "from": "chalk@https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "from": "is-fullwidth-code-point@>=2.0.0 <3.0.0",
+          "from": "is-fullwidth-code-point@https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "dev": true
         },
         "string-width": {
           "version": "2.1.1",
-          "from": "string-width@>=2.1.1 <3.0.0",
+          "from": "string-width@https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "dev": true
         },
         "strip-ansi": {
           "version": "4.0.0",
-          "from": "strip-ansi@>=4.0.0 <5.0.0",
+          "from": "strip-ansi@https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "dev": true
         },
         "supports-color": {
           "version": "5.4.0",
-          "from": "supports-color@>=5.3.0 <6.0.0",
+          "from": "supports-color@https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "dev": true
         }
@@ -3487,37 +3513,37 @@
     },
     "tar": {
       "version": "2.2.1",
-      "from": "tar@>=2.0.0 <3.0.0",
+      "from": "tar@https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
       "dev": true
     },
     "text-encoding": {
       "version": "0.6.4",
-      "from": "text-encoding@>=0.6.4 <0.7.0",
+      "from": "text-encoding@https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "dev": true
     },
     "text-table": {
       "version": "0.2.0",
-      "from": "text-table@>=0.2.0 <0.3.0",
+      "from": "text-table@https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "dev": true
     },
     "through": {
       "version": "2.3.8",
-      "from": "through@>=2.3.6 <3.0.0",
+      "from": "through@https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "dev": true
     },
     "tiny-lr": {
       "version": "1.1.1",
-      "from": "tiny-lr@>=1.1.1 <2.0.0",
+      "from": "tiny-lr@https://registry.npmjs.org/tiny-lr/-/tiny-lr-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-1.1.1.tgz",
       "dev": true,
       "dependencies": {
         "debug": {
           "version": "3.1.0",
-          "from": "debug@>=3.1.0 <4.0.0",
+          "from": "debug@https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "dev": true
         }
@@ -3525,25 +3551,25 @@
     },
     "tmp": {
       "version": "0.0.28",
-      "from": "tmp@0.0.28",
+      "from": "tmp@https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
       "dev": true
     },
     "to-fast-properties": {
       "version": "1.0.3",
-      "from": "to-fast-properties@>=1.0.3 <2.0.0",
+      "from": "to-fast-properties@https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
       "dev": true
     },
     "touch": {
       "version": "0.0.3",
-      "from": "touch@0.0.3",
+      "from": "touch@https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
       "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
       "dev": true,
       "dependencies": {
         "nopt": {
           "version": "1.0.10",
-          "from": "nopt@>=1.0.10 <1.1.0",
+          "from": "nopt@https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "dev": true
         }
@@ -3551,79 +3577,79 @@
     },
     "tough-cookie": {
       "version": "2.3.4",
-      "from": "tough-cookie@>=2.3.3 <2.4.0",
+      "from": "tough-cookie@https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "dev": true
     },
     "traverse": {
       "version": "0.3.9",
-      "from": "traverse@>=0.3.0 <0.4.0",
+      "from": "traverse@https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
       "dev": true
     },
     "trim-newlines": {
       "version": "1.0.0",
-      "from": "trim-newlines@>=1.0.0 <2.0.0",
+      "from": "trim-newlines@https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
       "dev": true
     },
     "trim-right": {
       "version": "1.0.1",
-      "from": "trim-right@>=1.0.1 <2.0.0",
+      "from": "trim-right@https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "dev": true
     },
     "tslib": {
       "version": "1.9.3",
-      "from": "tslib@>=1.8.0 <2.0.0",
+      "from": "tslib@https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
       "dev": true
     },
     "tslint": {
       "version": "5.11.0",
-      "from": "tslint@>=5.11.0 <6.0.0",
+      "from": "tslint@https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
       "dev": true,
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
-          "from": "ansi-styles@>=3.2.1 <4.0.0",
+          "from": "ansi-styles@https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "dev": true
         },
         "chalk": {
           "version": "2.4.1",
-          "from": "chalk@>=2.3.0 <3.0.0",
+          "from": "chalk@https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
           "dev": true
         },
         "esprima": {
           "version": "4.0.1",
-          "from": "esprima@>=4.0.0 <5.0.0",
+          "from": "esprima@https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
           "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
           "dev": true
         },
         "glob": {
           "version": "7.1.2",
-          "from": "glob@>=7.1.1 <8.0.0",
+          "from": "glob@https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "dev": true
         },
         "js-yaml": {
           "version": "3.12.0",
-          "from": "js-yaml@>=3.7.0 <4.0.0",
+          "from": "js-yaml@https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
           "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
           "dev": true
         },
         "resolve": {
           "version": "1.8.1",
-          "from": "resolve@>=1.3.2 <2.0.0",
+          "from": "resolve@https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
           "dev": true
         },
         "supports-color": {
           "version": "5.4.0",
-          "from": "supports-color@>=5.3.0 <6.0.0",
+          "from": "supports-color@https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
           "dev": true
         }
@@ -3631,210 +3657,216 @@
     },
     "tslint-microsoft-contrib": {
       "version": "5.1.0",
-      "from": "tslint-microsoft-contrib@>=5.0.3 <6.0.0",
+      "from": "tslint-microsoft-contrib@https://registry.npmjs.org/tslint-microsoft-contrib/-/tslint-microsoft-contrib-5.1.0.tgz",
       "resolved": "https://registry.npmjs.org/tslint-microsoft-contrib/-/tslint-microsoft-contrib-5.1.0.tgz",
       "dev": true
     },
     "tsutils": {
       "version": "2.28.0",
-      "from": "tsutils@>=2.27.2 <3.0.0",
+      "from": "tsutils@https://registry.npmjs.org/tsutils/-/tsutils-2.28.0.tgz",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.28.0.tgz",
       "dev": true
     },
     "tunnel-agent": {
       "version": "0.6.0",
-      "from": "tunnel-agent@>=0.6.0 <0.7.0",
+      "from": "tunnel-agent@https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "dev": true
     },
     "tweetnacl": {
       "version": "0.14.5",
-      "from": "tweetnacl@>=0.14.0 <0.15.0",
+      "from": "tweetnacl@https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "dev": true,
       "optional": true
     },
     "type-check": {
       "version": "0.3.2",
-      "from": "type-check@>=0.3.2 <0.4.0",
+      "from": "type-check@https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "dev": true
     },
     "type-detect": {
       "version": "4.0.8",
-      "from": "type-detect@>=4.0.8 <5.0.0",
+      "from": "type-detect@https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "dev": true
     },
     "typedarray": {
       "version": "0.0.6",
-      "from": "typedarray@>=0.0.6 <0.0.7",
+      "from": "typedarray@https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "dev": true
     },
     "typescript": {
       "version": "2.9.2",
-      "from": "typescript@>=2.9.2 <3.0.0",
+      "from": "typescript@https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
       "dev": true
     },
     "ultron": {
       "version": "1.1.1",
-      "from": "ultron@>=1.0.2 <2.0.0",
+      "from": "ultron@https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz"
     },
     "underscore": {
       "version": "1.9.1",
-      "from": "underscore@>=1.8.3 <2.0.0",
+      "from": "underscore@https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz"
     },
     "underscore.string": {
       "version": "3.3.4",
-      "from": "underscore.string@>=3.3.4 <3.4.0",
+      "from": "underscore.string@https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
       "dev": true
     },
     "universalify": {
       "version": "0.1.2",
-      "from": "universalify@>=0.1.0 <0.2.0",
+      "from": "universalify@https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "dev": true
     },
+    "unix-dgram": {
+      "version": "2.0.2",
+      "from": "unix-dgram@https://registry.npmjs.org/unix-dgram/-/unix-dgram-2.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/unix-dgram/-/unix-dgram-2.0.2.tgz",
+      "optional": true
+    },
     "util-deprecate": {
       "version": "1.0.2",
-      "from": "util-deprecate@>=1.0.1 <1.1.0",
+      "from": "util-deprecate@https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "dev": true
     },
     "uuid": {
       "version": "3.3.2",
-      "from": "uuid@>=3.1.0 <4.0.0",
+      "from": "uuid@https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
       "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.3",
-      "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+      "from": "validate-npm-package-license@https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
       "dev": true
     },
     "verror": {
       "version": "1.10.0",
-      "from": "verror@1.10.0",
+      "from": "verror@https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "dev": true
     },
     "websocket-driver": {
       "version": "0.7.0",
-      "from": "websocket-driver@>=0.5.1",
+      "from": "websocket-driver@https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
       "dev": true
     },
     "websocket-extensions": {
       "version": "0.1.3",
-      "from": "websocket-extensions@>=0.1.1",
+      "from": "websocket-extensions@https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
       "dev": true
     },
     "which": {
       "version": "1.3.1",
-      "from": "which@>=1.0.0 <2.0.0",
+      "from": "which@https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "dev": true
     },
     "which-module": {
       "version": "1.0.0",
-      "from": "which-module@>=1.0.0 <2.0.0",
+      "from": "which-module@https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
       "dev": true
     },
     "wide-align": {
       "version": "1.1.3",
-      "from": "wide-align@>=1.1.0 <2.0.0",
+      "from": "wide-align@https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "dev": true
     },
     "wordwrap": {
       "version": "1.0.0",
-      "from": "wordwrap@>=1.0.0 <1.1.0",
+      "from": "wordwrap@https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "dev": true
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "from": "wrap-ansi@>=2.0.0 <3.0.0",
+      "from": "wrap-ansi@https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "dev": true
     },
     "wrappy": {
       "version": "1.0.2",
-      "from": "wrappy@>=1.0.0 <2.0.0",
+      "from": "wrappy@https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "dev": true
     },
     "wrench": {
       "version": "1.5.9",
-      "from": "wrench@>=1.5.9 <2.0.0",
+      "from": "wrench@https://registry.npmjs.org/wrench/-/wrench-1.5.9.tgz",
       "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.5.9.tgz",
       "dev": true
     },
     "write": {
       "version": "0.2.1",
-      "from": "write@>=0.2.1 <0.3.0",
+      "from": "write@https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "dev": true
     },
     "ws": {
       "version": "1.1.1",
-      "from": "ws@1.1.1",
+      "from": "ws@https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
       "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.1.tgz",
       "dependencies": {
         "ultron": {
           "version": "1.0.2",
-          "from": "ultron@>=1.0.0 <1.1.0",
+          "from": "ultron@https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
           "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz"
         }
       }
     },
     "xml2js": {
       "version": "0.4.19",
-      "from": "xml2js@>=0.4.5 <0.5.0",
+      "from": "xml2js@https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
       "dev": true
     },
     "xmlbuilder": {
       "version": "9.0.7",
-      "from": "xmlbuilder@>=9.0.1 <9.1.0",
+      "from": "xmlbuilder@https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "dev": true
     },
     "xtend": {
       "version": "4.0.1",
-      "from": "xtend@>=4.0.0 <4.1.0",
+      "from": "xtend@https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
       "dev": true
     },
     "y18n": {
       "version": "3.2.1",
-      "from": "y18n@>=3.2.1 <4.0.0",
+      "from": "y18n@https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "dev": true
     },
     "yallist": {
       "version": "2.1.2",
-      "from": "yallist@>=2.1.2 <3.0.0",
+      "from": "yallist@https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "dev": true
     },
     "yargs": {
       "version": "7.1.0",
-      "from": "yargs@>=7.0.2 <8.0.0",
+      "from": "yargs@https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
       "dev": true
     },
     "yargs-parser": {
       "version": "5.0.0",
-      "from": "yargs-parser@>=5.0.0 <6.0.0",
+      "from": "yargs-parser@https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
       "dev": true
     }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "wrench": "^1.5.9"
   },
   "dependencies": {
-    "hadouken-js-adapter": "0.32.1-alpha.5",
+    "hadouken-js-adapter": "0.34.1-alpha.2",
     "minimist": "^1.2.0",
     "options": "0.0.6",
     "rx": "^4.1.0",


### PR DESCRIPTION
Bump to js adapter. Pulls in may fixes and is needed for the service -> iab cut over

[Windows 10 (64-bit)](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b5b971854b21953031f3841) all pass
[Windows 7 (64-bit)](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b5b961e54b21953031f3840) all pass

