### PR TITLE
RUN-4346 window-end-load event is being emitted twice

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -685,11 +685,6 @@ Window.create = function(id, opts) {
                 isMain,
                 documentName
             });
-
-            ofEvents.emit(route.application('window-end-load'), {
-                name,
-                uuid
-            });
         };
         let documentLoadedString = 'document-loaded';
         webContents.on(documentLoadedString, documentLoadedSubscribe);


### PR DESCRIPTION
Removed the second emit.

Tests:
[Win 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b5f546754b21953031f385e)
[Win 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b5f557a54b21953031f385f)