### PR TITLE
RUN-4332 move iframe out of experimental

### DIFF
--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -24,6 +24,11 @@ import {
 } from '../shapes';
 const TRANSPARENT_WHITE = '#0FFF'; // format #ARGB
 
+const iframeBaseSettings = {
+    'crossOriginInjection': false,
+    'sameOriginInjection': true
+};
+
 // this is the 5.0 base to be sure that we are only extending what is already expected
 function five0BaseOptions() {
     return {
@@ -40,6 +45,9 @@ function five0BaseOptions() {
         },
         'alwaysOnBottom': false,
         'alwaysOnTop': false,
+        'api': {
+            'iframe': iframeBaseSettings
+        },
         'applicationIcon': '',
         'autoShow': false,
         'backgroundThrottling': false,
@@ -59,10 +67,7 @@ function five0BaseOptions() {
         'exitOnClose': false,
         'experimental': {
             'api': {
-                'iframe': {
-                    'crossOriginInjection': false,
-                    'sameOriginInjection': true
-                }
+                'iframe': iframeBaseSettings
             },
             'disableInitialReload': false,
             'node': false,
@@ -184,6 +189,8 @@ module.exports = {
 
     convertToElectron: function(options, returnAsString) {
 
+        const usingIframe = !!(options.api && options.api.iframe);
+
         // build on top of the 5.0 base
         let newOptions = validateOptions(options);
 
@@ -224,6 +231,14 @@ module.exports = {
 
         const useNodeInRenderer = newOptions.experimental.node;
         const noNodePreload = path.join(__dirname, '..', 'renderer', 'node-less.js');
+
+        // Because we have communicated the experimental option, this allows us to
+        // respect that if its set but defaults to the proper passed in `iframe` key
+        if (usingIframe) {
+            Object.assign(newOptions.experimental.api.iframe, newOptions.api.iframe);
+        } else {
+            newOptions.api.iframe = newOptions.experimental.api.iframe;
+        }
 
         // Electron BrowserWindow options
         newOptions.enableLargerThanScreen = true;

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -33,8 +33,8 @@ const jsAdapterV2 = readAdapterFromSearchPaths(searchPathsV2Api, 'js-adapter.js'
 let me = fs.readFileSync(path.join(__dirname, 'api-decorator.js'), 'utf8');
 me = me.slice(13);
 
-module.exports.api = (windowId) => {
-    const windowOptionSet = coreState.getWindowInitialOptionSet(windowId);
+const api = (windowId, initialOptions) => {
+    const windowOptionSet = initialOptions || coreState.getWindowInitialOptionSet(windowId);
     const mainWindowOptions = windowOptionSet.options || {};
     const enableV2Api = (mainWindowOptions.experimental || {}).v2Api;
     const v2AdapterShim = (!enableV2Api ? '' : jsAdapterV2);
@@ -48,4 +48,16 @@ module.exports.api = (windowId) => {
         v2AdapterShim,
         `fin.__internal_.ipc = null`
     ].join(';');
+};
+
+module.exports.api = api;
+
+module.exports.apiWithOptions = (windowId) => {
+    const initialOptions = coreState.getWindowInitialOptionSet(windowId);
+    return {
+        apiString: api(windowId, initialOptions),
+
+        // break the remote link
+        initialOptions: JSON.stringify(initialOptions)
+    };
 };

--- a/src/renderer/node-less.js
+++ b/src/renderer/node-less.js
@@ -1,4 +1,4 @@
-/* global routingId, isMainFrame */
+/* global routingId, isMainFrame, isSameOriginIframe, isCrossOriginIframe, isChildMainFrame */
 
 const electron = require('electron');
 const resolvePromise = Promise.resolve.bind(Promise);
@@ -28,7 +28,7 @@ process.versions.mainFrameRoutingId = electron.ipcRenderer.getFrameRoutingID();
 process.versions.cachePath = electron.remote.app.getPath('userData');
 
 const mainWindowId = electron.remote.getCurrentWindow(process.versions.mainFrameRoutingId).id;
-const apiDecoratorAsString = electron.remote.require('./src/renderer/main').api(mainWindowId);
+const { apiString, initialOptions } = electron.remote.require('./src/renderer/main').apiWithOptions(mainWindowId);
 
 // let chromiumWindowAlertEnabled = electron.remote.app.getCommandLineArguments().includes('--enable-chromium-window-alert');
 
@@ -66,7 +66,8 @@ const hookWebFrame = (webFrame, renderFrameId) => {
 
 
 // Handle spin-up and tear-down
-const registerAPI = (w, routingId, isMainFrame) => {
+const registerAPI = (w, routingId, isMainFrame, isSameOriginIframe, isCrossOriginIframe, isChildMainFrame) => {
+
     const teardownHandlers = [];
     teardownHandlers.push(hookWebFrame(defaultWebFrame.createForRenderFrame(routingId), routingId));
 
@@ -75,42 +76,33 @@ const registerAPI = (w, routingId, isMainFrame) => {
             return;
         }
 
-        // w.debugMessages = w.debugMessages || [];
-        // w.debugMessages.push(`id is ${routingId}`);
-
         // Mock as a Node/Electron environment
         // ===================================
-        // let global = w;
         w.getFrameData = process.getFrameData;
-
         w.require = require;
-        // w.debugMessages.push('w.require = require;');
-        // w.module = module;
-        // w.debugMessages.push('w.module = module;');
         w.global = global;
-        // w.debugMessages.push('w.global = global;');
         w.process = process;
-        // w.debugMessages.push('w.process = process;');
         w.routingId = routingId || electron.ipcRenderer.getFrameRoutingID();
-        // w.debugMessages.push('w.routingId = routingId || electron.ipcRenderer.getFrameRoutingID();');
         w.isMainFrame = isMainFrame;
-
-        // v8Util.setHiddenValue(w, 'routingId', routingId)
-        // v8Util.setHiddenValue(w.global, 'ipc', electron.ipcRenderer)
-
-        // teardownHandlers.push(override(w, routingId, chromiumWindowAlertEnabled))
         // ===================================
 
-        w.process.eval(apiDecoratorAsString);
-
+        const { options: { api: { iframe: { sameOriginInjection, crossOriginInjection } } } } = JSON.parse(initialOptions);
         let inboundMessageTopic = '';
 
-        if (w.fin) {
-            inboundMessageTopic = `${w.fin.__internal_.ipcconfig.channels.CORE_MESSAGE}-${w.fin.__internal_.routingId}`;
-        }
+        const apiInjectionAllowed = isMainFrame || isChildMainFrame ||
+            (isSameOriginIframe && sameOriginInjection) ||
+            (isCrossOriginIframe && crossOriginInjection);
 
-        // w.debugMessages.push(`nodeIntegration ${nodeIntegration}`);
-        // w.debugMessages.push(`inboundMessageTopic ${inboundMessageTopic}`);
+        if (apiInjectionAllowed) {
+            w.process.eval(apiString);
+
+            if (w.fin) {
+                inboundMessageTopic = `${w.fin.__internal_.ipcconfig.channels.CORE_MESSAGE}-${w.fin.__internal_.routingId}`;
+
+            } else {
+                console.warn('failed to load OpenFin api');
+            }
+        }
 
         delete w.require;
         delete w.process;
@@ -159,4 +151,4 @@ const registerAPI = (w, routingId, isMainFrame) => {
     susbcribeForTeardown(routingId, teardownHandlers);
 };
 
-registerAPI(window, routingId, isMainFrame);
+registerAPI(window, routingId, isMainFrame, isSameOriginIframe, isCrossOriginIframe, isChildMainFrame, initialOptions);


### PR DESCRIPTION
This moves the experimental api.iframe api injection config into
startup_app.api.iframe. The idea of the outer api key is to provide
the option to manage injection to windows or apps in the future.
As is, you can now decide if iframes get the openfin api or no based
on their domain (cross origin or not). As is, this option is not
inherited.