### PR TITLE
RUN-4342 Multi-Runtime channels

### DIFF
--- a/src/browser/api/channel.ts
+++ b/src/browser/api/channel.ts
@@ -48,10 +48,9 @@ const createChannelTeardown = (providerIdentity: ProviderIdentity): void => {
     // When channel exits, remove from channelMap
     const { uuid, name, isExternal, channelId } = providerIdentity;
     const closedEvent = isExternal ? route.externalApplication('closed', uuid) : route.window('closed', uuid, name);
-    const disconnectedEvent = isExternal ? route.channel('disconnected', uuid) : route.channel('disconnected', uuid, name);
     ofEvents.once(closedEvent, () => {
         channelMap.delete(channelId);
-        ofEvents.emit(disconnectedEvent, providerIdentity);
+        ofEvents.emit(route.channel('disconnected'), providerIdentity);
     });
 
     // For some reason this is captured sometimes when window closed is not
@@ -127,7 +126,7 @@ export module Channel {
         const connectedEvent = isExternal ? route.channel('connected', uuid) : route.channel('connected', uuid, name);
         ofEvents.emit(connectedEvent, providerIdentity);
         // Used internally by adapters for pending connections and onChannelConnect
-        ofEvents.emit(route.channel('internal-connected'), providerIdentity);
+        ofEvents.emit(route.channel('connected'), providerIdentity);
 
         return providerIdentity;
     }

--- a/src/browser/api/channel.ts
+++ b/src/browser/api/channel.ts
@@ -50,7 +50,7 @@ const createChannelTeardown = (providerIdentity: ProviderIdentity): void => {
     const closedEvent = isExternal ? route.externalApplication('closed', uuid) : route.window('closed', uuid, name);
     ofEvents.once(closedEvent, () => {
         channelMap.delete(channelId);
-        ofEvents.emit(route.channel('disconnected'), providerIdentity);
+        ofEvents.emit(route.channel('channel-disconnected'), providerIdentity);
     });
 
     // For some reason this is captured sometimes when window closed is not
@@ -122,11 +122,8 @@ export module Channel {
         channelMap.set(channelId, providerIdentity);
 
         createChannelTeardown(providerIdentity);
-
-        const connectedEvent = isExternal ? route.channel('connected', uuid) : route.channel('connected', uuid, name);
-        ofEvents.emit(connectedEvent, providerIdentity);
         // Used internally by adapters for pending connections and onChannelConnect
-        ofEvents.emit(route.channel('connected'), providerIdentity);
+        ofEvents.emit(route.channel('channel-connected'), providerIdentity);
 
         return providerIdentity;
     }

--- a/src/browser/api/channel.ts
+++ b/src/browser/api/channel.ts
@@ -119,6 +119,7 @@ export module Channel {
 
         const connectedEvent = isExternal ? route.channel('connected', uuid) : route.channel('connected', uuid, name);
         ofEvents.emit(connectedEvent, providerIdentity);
+        ofEvents.emit(route.channel('internal-connected'), providerIdentity);
 
         // execute requests to connect for channel that occured before channel registration. Timeout ensures registration concludes first.
         setTimeout(() => {
@@ -161,13 +162,10 @@ export module Channel {
                     payload: connectionPayload
                 }
             });
-        } else if (wait) {
-            // Channel not yet registered, hold connection request
-            const message = { identity, payload, messageId, ack, nack };
-            const channelId = getChannelId(uuid, name, channelName);
-            waitForChannelRegistration(channelId, message);
         } else {
-            nack('Channel connection not found.');
+            // Do not change this, checking for this in adapter
+            const interimNackMessage = 'internal-nack';
+            nack(interimNackMessage);
         }
         return providerIdentity;
     }

--- a/src/browser/api_protocol/api_handlers/event_listener.js
+++ b/src/browser/api_protocol/api_handlers/event_listener.js
@@ -164,7 +164,7 @@ function EventListenerApiHandler() {
                         addRemoteSubscription(subscription).then(unSubscribe => {
                             remoteUnSub = unSubscribe;
                         });
-                    } else if (type === 'internal-connected') {
+                    } else if (type === 'connected' || type === 'disconnected') {
                         const subscription = {
                             listenType: 'on',
                             className: 'channel',

--- a/src/browser/api_protocol/api_handlers/event_listener.js
+++ b/src/browser/api_protocol/api_handlers/event_listener.js
@@ -150,19 +150,31 @@ function EventListenerApiHandler() {
                 const islocalUuid = coreState.isLocalUuid(uuid);
                 const localUnsub = Channel.addEventListener(targetIdentity, type, cb);
                 let remoteUnSub;
-                const isExternalRuntime = ExternalApplication.isRuntimeClient(uuid);
+                const isExternalClient = ExternalApplication.isRuntimeClient(identity.uuid);
 
-                if (!islocalUuid && !isExternalRuntime) {
-                    const subscription = {
-                        uuid,
-                        listenType: 'on',
-                        className: 'channel',
-                        eventName: type
-                    };
+                if (!islocalUuid && !isExternalClient) {
+                    if (uuid) {
+                        const subscription = {
+                            uuid,
+                            listenType: 'on',
+                            className: 'channel',
+                            eventName: type
+                        };
 
-                    addRemoteSubscription(subscription).then(unSubscribe => {
-                        remoteUnSub = unSubscribe;
-                    });
+                        addRemoteSubscription(subscription).then(unSubscribe => {
+                            remoteUnSub = unSubscribe;
+                        });
+                    } else if (type === 'internal-connected') {
+                        const subscription = {
+                            listenType: 'on',
+                            className: 'channel',
+                            eventName: type
+                        };
+                        subscribeToAllRuntimes(subscription).then(unSubscribe => {
+                            remoteUnSub = unSubscribe;
+                        });
+                    }
+
                 }
 
                 return () => {
@@ -182,10 +194,14 @@ function EventListenerApiHandler() {
                     className: 'system',
                     eventName: type
                 };
+
                 let remoteUnSub;
-                subscribeToAllRuntimes(subscription).then(unSubscribe => {
-                    remoteUnSub = unSubscribe;
-                });
+                const isExternalClient = ExternalApplication.isRuntimeClient(identity.uuid);
+                if (!isExternalClient) {
+                    subscribeToAllRuntimes(subscription).then(unSubscribe => {
+                        remoteUnSub = unSubscribe;
+                    });
+                }
 
                 return () => {
                     localUnsub();

--- a/src/browser/api_protocol/api_handlers/event_listener.js
+++ b/src/browser/api_protocol/api_handlers/event_listener.js
@@ -164,7 +164,7 @@ function EventListenerApiHandler() {
                         addRemoteSubscription(subscription).then(unSubscribe => {
                             remoteUnSub = unSubscribe;
                         });
-                    } else if (type === 'connected' || type === 'disconnected') {
+                    } else if (type === 'channel-connected' || type === 'channel-disconnected') {
                         const subscription = {
                             listenType: 'on',
                             className: 'channel',

--- a/src/browser/api_protocol/api_handlers/event_listener.js
+++ b/src/browser/api_protocol/api_handlers/event_listener.js
@@ -145,12 +145,12 @@ function EventListenerApiHandler() {
         'channel': {
             name: 'channel',
             subscribe: function(identity, type, payload, cb) {
-                const targetIdentity = apiProtocolBase.getTargetApplicationIdentity(payload);
+                const targetIdentity = apiProtocolBase.getTargetWindowIdentity(payload);
                 const { uuid } = targetIdentity;
                 const islocalUuid = coreState.isLocalUuid(uuid);
                 const localUnsub = Channel.addEventListener(targetIdentity, type, cb);
                 let remoteUnSub;
-                const isExternalRuntime = ExternalApplication.isRuntimeClient(identity.uuid);
+                const isExternalRuntime = ExternalApplication.isRuntimeClient(uuid);
 
                 if (!islocalUuid && !isExternalRuntime) {
                     const subscription = {

--- a/src/browser/api_protocol/api_handlers/event_listener.js
+++ b/src/browser/api_protocol/api_handlers/event_listener.js
@@ -152,29 +152,15 @@ function EventListenerApiHandler() {
                 let remoteUnSub;
                 const isExternalClient = ExternalApplication.isRuntimeClient(identity.uuid);
 
-                if (!islocalUuid && !isExternalClient) {
-                    if (uuid) {
-                        const subscription = {
-                            uuid,
-                            listenType: 'on',
-                            className: 'channel',
-                            eventName: type
-                        };
-
-                        addRemoteSubscription(subscription).then(unSubscribe => {
-                            remoteUnSub = unSubscribe;
-                        });
-                    } else if (type === 'channel-connected' || type === 'channel-disconnected') {
-                        const subscription = {
-                            listenType: 'on',
-                            className: 'channel',
-                            eventName: type
-                        };
-                        subscribeToAllRuntimes(subscription).then(unSubscribe => {
-                            remoteUnSub = unSubscribe;
-                        });
-                    }
-
+                if (!islocalUuid && !isExternalClient && (type === 'channel-connected' || type === 'channel-disconnected')) {
+                    const subscription = {
+                        listenType: 'on',
+                        className: 'channel',
+                        eventName: type
+                    };
+                    subscribeToAllRuntimes(subscription).then(unSubscribe => {
+                        remoteUnSub = unSubscribe;
+                    });
                 }
 
                 return () => {

--- a/src/browser/remote_subscriptions.ts
+++ b/src/browser/remote_subscriptions.ts
@@ -293,7 +293,6 @@ function applySubscriptionToAllRuntimes(subscription: RemoteSubscription, runtim
         removeListener = runtime.fin.InterApplicationBus.Channel.removeListener;
     }
 
-
     // When runtime disconnects, remove the subscription for that runtime
     // It will be re-added from pending subscriptions if the runtime connects again
     const disconnectEventName = 'disconnected';
@@ -309,10 +308,10 @@ function applySubscriptionToAllRuntimes(subscription: RemoteSubscription, runtim
     }
 
     // Subscribe to an event on a remote runtime
-        subscription.unSubscriptions.get(runtimeKey).push(() => {
-            removeListener(eventName, listener);
-            runtime.fin.removeListener(disconnectEventName, unSubscribeListener);
-        });
+    subscription.unSubscriptions.get(runtimeKey).push(() => {
+        removeListener(eventName, listener);
+        // runtime.fin.removeListener(disconnectEventName, unSubscribeListener);
+    });
 
 }
 

--- a/src/browser/remote_subscriptions.ts
+++ b/src/browser/remote_subscriptions.ts
@@ -283,14 +283,11 @@ function applySubscriptionToAllRuntimes(subscription: RemoteSubscription, runtim
         }
     };
 
-    let removeListener: Function;
     // Subscribe to an event on a remote runtime
     if (className === 'system') {
         runtime.fin.System[listenType](eventName, listener);
-        removeListener = runtime.fin.System.removeListener;
     } else if (className === 'channel') {
         runtime.fin.InterApplicationBus.Channel[listenType](eventName, listener);
-        removeListener = runtime.fin.InterApplicationBus.Channel.removeListener;
     }
 
     // When runtime disconnects, remove the subscription for that runtime
@@ -308,11 +305,17 @@ function applySubscriptionToAllRuntimes(subscription: RemoteSubscription, runtim
     }
 
     // Subscribe to an event on a remote runtime
-    subscription.unSubscriptions.get(runtimeKey).push(() => {
-        removeListener(eventName, listener);
-        // runtime.fin.removeListener(disconnectEventName, unSubscribeListener);
-    });
-
+    if (className === 'system') {
+        subscription.unSubscriptions.get(runtimeKey).push(() => {
+            runtime.fin.System.removeListener(eventName, listener);
+            runtime.fin.removeListener(disconnectEventName, unSubscribeListener);
+        });
+    } else if (className === 'channel') {
+        subscription.unSubscriptions.get(runtimeKey).push(() => {
+            runtime.fin.InterApplicationBus.Channel.removeListener(eventName, listener);
+            runtime.fin.removeListener(disconnectEventName, unSubscribeListener);
+        });
+    }
 }
 
 /**

--- a/src/browser/remote_subscriptions.ts
+++ b/src/browser/remote_subscriptions.ts
@@ -219,7 +219,7 @@ export function applyAllRemoteSubscriptions(runtime: PeerRuntime) {
         if (!subscription.isSystemEvent) {
             applyRemoteSubscription(subscription, runtime);
         } else {
-            applySystemSubscription(subscription, runtime);
+            applySubscriptionToAllRuntimes(subscription, runtime);
         }
     });
 }
@@ -244,7 +244,7 @@ export function subscribeToAllRuntimes(subscriptionProps: RemoteSubscriptionProp
 
         // Subscribe in all connected runtimes
         if (connectionManager.connections.length) {
-            connectionManager.connections.forEach(runtime => applySystemSubscription(subscription, runtime));
+            connectionManager.connections.forEach(runtime => applySubscriptionToAllRuntimes(subscription, runtime));
         }
 
         // Add the subscription to pending to cover any runtimes launched in the future
@@ -271,7 +271,7 @@ function systemUnsubscribe(subscription: any) {
 /**
  * Subscribe to a system event in a remote runtime
  */
-function applySystemSubscription(subscription: RemoteSubscription, runtime: PeerRuntime) {
+function applySubscriptionToAllRuntimes(subscription: RemoteSubscription, runtime: PeerRuntime) {
     const { className, eventName, listenType } = subscription;
     const fullEventName = route(className, eventName);
     const runtimeKey = keyFromPortInfo(runtime.portInfo);

--- a/src/common/route.ts
+++ b/src/common/route.ts
@@ -85,7 +85,7 @@ route.frame = <WindowRoute>router.bind(HYPHEN, 'frame');
 route.window = <WindowRoute>router.bind(HYPHEN, 'window');
 route.externalWindow = route['external-window'] = <WindowRoute>router.bind(HYPHEN, 'external-window');
 
-route.channel = <SimpleRoute>router.bind(null, 'channel');
+route.channel = <WindowRoute>router.bind(HYPHEN, 'channel');
 route.system = <SimpleRoute>router.bind(null, 'system');
 route.rvmMessageBus = route['rvm-message-bus'] = <SimpleRoute>router.bind(null, 'rvm-message-bus');
 route.server = <SimpleRoute>router.bind(null, 'server');


### PR DESCRIPTION
This PR does two things that turned out to be intertwined:  

1.) Makes channels work correctly in multi-runtime
 - fixed some eventing stuff for channels, particularly remote subscriptions
 - put pending channels on renderer side
       * If channel does not yet exist, nack back to renderer with specific message.  Renderer then listens for connection event and will resend the connect message -where it can be routed to correct runtime via normal mesh middleware.  
       * better handles lifecycle of request
       * better to implement multi-runtime channel connection with eventing / existing middleware

2.) Make connection to a channel more flexible - can now use uuid only / identity (uuid and name) / and/or channelName (new construct)
 - still need to use UUID for multi-runtime to work but channelName only connection requests can be implemented in future
 - inclusion of channelName allows for more than one channel per identity

Eventing for channels will be addressed further in an upcoming PR.  

Depends on this [JS-adapter PR](https://github.com/HadoukenIO/js-adapter/pull/160) that has a new multi-runtime channels test.

Passed js-adapter tests.  Updated test-runner tests including new [two channels from same uuid test](https://testing-dashboard.openfin.co/#/app/tests/5b560f8f54b21953031f37a4/edit)

[Win7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b60f0a854b21953031f388d)
[Win10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b60f20a54b21953031f3891)