### PR TITLE
RUN-3525: Add aspect ratio as a window option

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -1100,6 +1100,16 @@ Window.enableFrame = function(identity) {
     browserWindow.setUserMovementEnabled(true);
 };
 
+Window.setAspectRatio = function(identity, ratio, extraWidth, extraHeight) {
+    let browserWindow = getElectronBrowserWindow(identity);
+
+    if (!browserWindow) {
+        return;
+    }
+
+    browserWindow.setAspectRatio(ratio, { width: extraWidth, height: extraHeight });
+};
+
 Window.executeJavascript = function(identity, code, callback = () => {}) {
     let browserWindow = getElectronBrowserWindow(identity);
 

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -351,6 +351,13 @@ let optionSetters = {
             setOptOnBrowserWin('resizeRegion', newVal, browserWin);
         }
     },
+    aspectRatio: function(newVal, browserWin) {
+        if (typeof(newVal) !== 'number') {
+            return;
+        }
+        browserWin.setAspectRatio(newVal);
+        setOptOnBrowserWin('aspectRatio', newVal, browserWin);
+    },
     hasLoaded: function(newVal, browserWin) {
         if (typeof(newVal) === 'boolean') {
             browserWin._options.hasLoaded = newVal;
@@ -1098,16 +1105,6 @@ Window.enableFrame = function(identity) {
     let dframeRefCount = disabledFrameRef.get(windowKey) || 0;
     disabledFrameRef.set(windowKey, --dframeRefCount);
     browserWindow.setUserMovementEnabled(true);
-};
-
-Window.setAspectRatio = function(identity, ratio, extraWidth, extraHeight) {
-    let browserWindow = getElectronBrowserWindow(identity);
-
-    if (!browserWindow) {
-        return;
-    }
-
-    browserWindow.setAspectRatio(ratio, { width: extraWidth, height: extraHeight });
 };
 
 Window.executeJavascript = function(identity, code, callback = () => {}) {
@@ -1993,6 +1990,11 @@ function applyAdditionalOptionsToWindow(browserWindow) {
                 browserWindow.setAlphaMask(options.alphaMask.red, options.alphaMask.green, options.alphaMask.blue);
             } else if (options.opacity < 1) {
                 browserWindow.setOpacity(options.opacity);
+            }
+
+            // set aspect ratio if present
+            if (options.aspectRatio > 0) {
+                browserWindow.setAspectRatio(options.aspectRatio);
             }
 
             // set minimized or maximized

--- a/src/browser/api_protocol/api_handlers/window.ts
+++ b/src/browser/api_protocol/api_handlers/window.ts
@@ -51,6 +51,7 @@ export const windowApiMap = {
     'navigate-window': navigateWindow,
     'navigate-window-back': navigateWindowBack,
     'navigate-window-forward': navigateWindowForward,
+    'set-aspect-ratio': setAspectRatio,
     'stop-window-navigation': stopWindowNavigation,
     'register-window-name': registerWindowName,
     'reload-window': reloadWindow,
@@ -468,6 +469,15 @@ function disableWindowFrame(identity: Identity, message: APIMessage, ack: Acker)
     const windowIdentity = getTargetWindowIdentity(payload);
 
     Window.disableFrame(identity, windowIdentity);
+    ack(successAck);
+}
+
+function setAspectRatio(identity: Identity, message: APIMessage, ack: Acker): void {
+    const { payload } = message;
+    const { ratio, extraWidth, extraHeight } = payload;
+    const windowIdentity = getTargetWindowIdentity(payload);
+
+    Window.setAspectRatio(windowIdentity, ratio, extraWidth, extraHeight);
     ack(successAck);
 }
 

--- a/src/browser/api_protocol/api_handlers/window.ts
+++ b/src/browser/api_protocol/api_handlers/window.ts
@@ -51,7 +51,6 @@ export const windowApiMap = {
     'navigate-window': navigateWindow,
     'navigate-window-back': navigateWindowBack,
     'navigate-window-forward': navigateWindowForward,
-    'set-aspect-ratio': setAspectRatio,
     'stop-window-navigation': stopWindowNavigation,
     'register-window-name': registerWindowName,
     'reload-window': reloadWindow,
@@ -469,15 +468,6 @@ function disableWindowFrame(identity: Identity, message: APIMessage, ack: Acker)
     const windowIdentity = getTargetWindowIdentity(payload);
 
     Window.disableFrame(identity, windowIdentity);
-    ack(successAck);
-}
-
-function setAspectRatio(identity: Identity, message: APIMessage, ack: Acker): void {
-    const { payload } = message;
-    const { ratio, extraWidth, extraHeight } = payload;
-    const windowIdentity = getTargetWindowIdentity(payload);
-
-    Window.setAspectRatio(windowIdentity, ratio, extraWidth, extraHeight);
     ack(successAck);
 }
 

--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -41,6 +41,7 @@ function five0BaseOptions() {
         'alwaysOnBottom': false,
         'alwaysOnTop': false,
         'applicationIcon': '',
+        'aspectRatio': 0,
         'autoShow': false,
         'backgroundThrottling': false,
         'contextMenu': true,

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -138,6 +138,7 @@ export interface WindowOptions {
     alwaysOnBottom?: boolean;
     alwaysOnTop?: boolean;
     applicationIcon?: string;
+    aspectRatio?: number;
     autoShow?: boolean;
     backgroundColor?: string;
     backgroundThrottling?: boolean;


### PR DESCRIPTION
see https://github.com/openfin/Internal-Wiki/issues/40

requires https://github.com/openfin/runtime/pull/1080 to be merged

A general note: the aspect ratio is only enforced when the window is resized. For example, if `startup_app.aspectRatio` is given as `1`, windows may initially be shown with a different aspect ratio, because the window has not yet been resized. I think this behaviour is correct, as otherwise unintuitive collisions might occur with other window options.