### PR TITLE
RUN-4356 return string from remote apiWithOptions call

### DIFF
--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -54,10 +54,10 @@ module.exports.api = api;
 
 module.exports.apiWithOptions = (windowId) => {
     const initialOptions = coreState.getWindowInitialOptionSet(windowId);
-    return {
-        apiString: api(windowId, initialOptions),
 
-        // break the remote link
-        initialOptions: JSON.stringify(initialOptions)
-    };
+    // break the remote link
+    return JSON.stringify({
+        apiString: api(windowId, initialOptions),
+        initialOptions: initialOptions
+    });
 };

--- a/src/renderer/node-less.js
+++ b/src/renderer/node-less.js
@@ -28,7 +28,8 @@ process.versions.mainFrameRoutingId = electron.ipcRenderer.getFrameRoutingID();
 process.versions.cachePath = electron.remote.app.getPath('userData');
 
 const mainWindowId = electron.remote.getCurrentWindow(process.versions.mainFrameRoutingId).id;
-const { apiString, initialOptions } = electron.remote.require('./src/renderer/main').apiWithOptions(mainWindowId);
+const apiInfo = electron.remote.require('./src/renderer/main').apiWithOptions(mainWindowId);
+const { apiString, initialOptions } = JSON.parse(apiInfo);
 
 // let chromiumWindowAlertEnabled = electron.remote.app.getCommandLineArguments().includes('--enable-chromium-window-alert');
 
@@ -86,7 +87,7 @@ const registerAPI = (w, routingId, isMainFrame, isSameOriginIframe, isCrossOrigi
         w.isMainFrame = isMainFrame;
         // ===================================
 
-        const { options: { api: { iframe: { sameOriginInjection, crossOriginInjection } } } } = JSON.parse(initialOptions);
+        const { options: { api: { iframe: { sameOriginInjection, crossOriginInjection } } } } = initialOptions;
         let inboundMessageTopic = '';
 
         const apiInjectionAllowed = isMainFrame || isChildMainFrame ||


### PR DESCRIPTION
@StevenEBarbaro @HarsimranSingh @whyn07m3 

This fixes the memory leak, it was the remote module returning an object, even thought the render side goes away, the remote `_cache` was holding it in memory. 

~Tests in flight~
Tests well:
[Win 7 32 bit](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b64c12554b21953031f38c9)
[Win 7 64 bit](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b64c0ea54b21953031f38c8)