### PR TITLE
A few build changes:

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,7 +24,7 @@ if (!Object.entries) {
     while (i--) {
       resArray[i] = [ownProps[i], obj[ownProps[i]]];
     }
-    
+
     return resArray;
   };
 }
@@ -40,14 +40,14 @@ function flattenDeep(arr1, usedModules) {
         // Add top level dependencies without duplicates
         if(!usedModules[val[0]]) {
             usedModules[val[0]] = true;
-            acc.push(`${val[0]}/**`); 
+            acc.push(`${val[0]}/**`);
         }
 
         // Handle nested dependencies
         const subDep = val[1].dependencies;
         if(typeof subDep === 'object') {
             acc = acc.concat(flattenDeep(Object.entries(subDep), usedModules));
-        } 
+        }
 
         return acc;
     }, []);
@@ -293,6 +293,9 @@ module.exports = (grunt) => {
     grunt.registerTask('package', 'Package in an asar', function() {
         const done = this.async();
 
+        //delete build/test related files before packaging.
+        grunt.file.delete('staging/core/Gruntfile.js');
+        wrench.rmdirSyncRecursive('staging/core/test', true);
         asar.createPackage('staging/core', 'out/app.asar', function() {
             grunt.log.ok('Finished packaging as asar.');
             wrench.rmdirSyncRecursive('staging', true);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,11 @@
 {
     "compilerOptions": {
+        "target": "es2017",
         "module": "commonjs",
         "noImplicitAny": true,
         "removeComments": true,
         "preserveConstEnums": true,
         "sourceMap": false,
-        "target": "es6",
         "outDir": "./staging/core/",
         "moduleResolution": "node",
         "allowJs": true


### PR DESCRIPTION
* Moved our typescript target to 2017
* Noticed our tests and gruntfile were making their way into packaged asar.

Tests: 
[Win10 x32](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b6def7054b21953031f3943)
[Win 10 x64](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b6def2d54b21953031f3942)
[Win7 x32](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b6dee1b54b21953031f3941)
[Win7 x64](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b6dee0d54b21953031f3940)