### PR TITLE
Expose the Electron 'move' event

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -114,10 +114,11 @@ let browserWindowEventMap = {
     },
     'unmaximize': {
         topic: 'restored'
+    },
+    'move': {
+        topic: 'moving',
+        decorator: movingDecorator
     }
-    // 'move': {
-    //     topic: 'bounds-changing'
-    // }
 };
 
 let webContentsEventMap = {
@@ -2072,6 +2073,29 @@ function closeRequestedDecorator(payload) {
     payload.force = false;
 
     return propagate;
+}
+
+function movingDecorator(payload, args) {
+    let positionToBounds = (position) => {
+        return {
+            left: position.x + 7,
+            top: position.y,
+            right: position.x + position.width - 7,
+            bottom: position.y + position.height - 7,
+            height: position.height,
+            width: position.width
+        };
+    };
+    // stringify and parse to get rid of invalid values
+    let bounds = JSON.parse(JSON.stringify(args[0].sender.getBounds()));
+    if (Object.keys(bounds).length >= 4) {
+        let processedBounds = positionToBounds(bounds);
+        Object.keys(processedBounds).forEach((key) => {
+            payload[key] = processedBounds[key];
+        });
+        return true;
+    }
+    return false;
 }
 
 function boundsChangeDecorator(payload, args) {

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -2078,10 +2078,10 @@ function closeRequestedDecorator(payload) {
 function movingDecorator(payload, args) {
     let positionToBounds = (position) => {
         return {
-            left: position.x + 7,
+            left: position.x,
             top: position.y,
-            right: position.x + position.width - 7,
-            bottom: position.y + position.height - 7,
+            right: position.x + position.width,
+            bottom: position.y + position.height,
             height: position.height,
             width: position.width
         };


### PR DESCRIPTION
This PR exposes the Electron `move` event in the core API as `moving`, converting the payload into the accepted bounds format (left, top, width, height, etc).