### PR TITLE
RUN-4392 fixed raiseEvent

### DIFF
--- a/src/browser/api_protocol/api_handlers/system.ts
+++ b/src/browser/api_protocol/api_handlers/system.ts
@@ -173,7 +173,7 @@ function getDeviceUserId(identity: Identity, message: APIMessage, ack: Acker): v
 }
 
 function raiseEvent(identity: Identity, message: APIMessage, ack: Acker): void {
-    const { eventName, payload: { eventArgs } } = message;
+    const { payload: { eventName, eventArgs } } = message;
 
     System.raiseEvent(eventName, eventArgs);
     ack(successAck);


### PR DESCRIPTION
Fixed object destructuring in `raiseEvent`

🚥 **Automated test results**
[Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b74872c6107b45e6d1eba03)
[Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b74883e6107b45e6d1eba04)