### PR TITLE
RUN-2986: Implement getDeviceId() for non-Windows systems

### DIFF
--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -251,19 +251,15 @@ exports.System = {
         if (process.platform === 'win32') {
             return electronApp.getHostToken();
         } else {
-            try {
-                const hash = crypto.createHash('sha256');
+            const hash = crypto.createHash('sha256');
 
-                let macAddress = os.networkInterfaces().en0[0].mac;
-                if (!macAddress) {
-                    throw new Error(`MAC address (${macAddress}) not defined`);
-                }
-
-                hash.update(macAddress);
-                return hash.digest('hex');
-            } catch (e) {
-                return e;
+            const macAddress = os.networkInterfaces().en0[0].mac;
+            if (!macAddress) {
+                throw new Error(`MAC address (${macAddress}) not defined`);
             }
+
+            hash.update(macAddress);
+            return hash.digest('hex');
         }
     },
     getEntityInfo: function(identity) {

--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -251,16 +251,19 @@ exports.System = {
         if (process.platform === 'win32') {
             return electronApp.getHostToken();
         } else {
-            const hash = crypto.createHash('sha256');
+            try {
+                const hash = crypto.createHash('sha256');
 
-            let macAddress = os.networkInterfaces().en0[0].mac;
+                let macAddress = os.networkInterfaces().en0[0].mac;
+                if (!macAddress) {
+                    throw new Error(`MAC address (${macAddress}) not defined`);
+                }
 
-            if (!macAddress) {
-                throw new Error(`MAC address (${macAddress}) not defined`);
+                hash.update(macAddress);
+                return hash.digest('hex');
+            } catch (e) {
+                return e;
             }
-
-            hash.update(macAddress);
-            return hash.digest('hex');
         }
     },
     getEntityInfo: function(identity) {

--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -248,7 +248,20 @@ exports.System = {
         return hash.digest('hex');
     },
     getDeviceId: function() {
-        return electronApp.getHostToken();
+        if (process.platform === 'win32') {
+            return electronApp.getHostToken();
+        } else {
+            const hash = crypto.createHash('sha256');
+
+            let macAddress = os.networkInterfaces().en0[0].mac;
+
+            if (!macAddress) {
+                throw new Error(`MAC address (${macAddress}) not defined`);
+            }
+
+            hash.update(macAddress);
+            return hash.digest('hex');
+        }
     },
     getEntityInfo: function(identity) {
         return coreState.getEntityInfo(identity);


### PR DESCRIPTION
This simply returns the SHA256 hash of the MAC address.

Note that incorrect behaviour in Windows is ignored; see RUN-4451.