### PR TITLE
RUN-4400: Call Unix binaries with full path

### DIFF
--- a/src/browser/transports/unix_domain_socket.ts
+++ b/src/browser/transports/unix_domain_socket.ts
@@ -75,7 +75,7 @@ class UnixDomainSocket extends BaseTransport {
 
     private getFileDescriptors(): Promise<FileDescriptor[]> {
         return new Promise<FileDescriptor[]>((resolve) => {
-            exec(`lsof -U | grep ${this.filenamePrefix}`, (error, stdout) => {
+            exec(`/usr/sbin/lsof -U | /usr/bin/grep ${this.filenamePrefix}`, (error, stdout) => {
                 if (error) {
                     log.writeToLog(1, '[unix domain socket] begin exec error', true);
                     log.writeToLog(1, error, true);


### PR DESCRIPTION
This fixes (most, but evidently not all) multi-runtime OS X tests.

It turns out that within the Node adapter test framework, there's a bunch of
layers that result losing track of the PATH environment variable.

Instead of trying to find out where, we could simply ignore the non-existent
PATH and call the binaries that we know are there.

This assumes a Unix system that's not _too_ far out of whack.

#1storypoint