### PR TITLE
RUN-4397 fixed createFromManifest timing problem

### DIFF
--- a/src/browser/runtime_p2p/peer_connection_manager.ts
+++ b/src/browser/runtime_p2p/peer_connection_manager.ts
@@ -142,7 +142,7 @@ export class PeerConnectionManager extends EventEmitter {
                         resolve(identityAddress);
                     }).catch((err: Error) => {
                         failures++;
-                        if (failures === this._runtimeMap.size) {
+                        if (failures >= this._runtimeMap.size) {
                             reject(err);
                         }
                     });


### PR DESCRIPTION
ℹ️ **About**
Believe it or not, this 2-character change took me 3-4 days and Pierre 2-3 days of investigation. This is a very nasty timing issue, hard to reproduce on command, but been showing up consistently lately in our test results. Apparently, the number of failures can exceed the number of runtimes in the map during another runtime shutdown.

👍 However, on the plus side, this long investigation also yielded **positive results**:
1. Discovered and fixed an improper promise resolution in the test runner
2. Found 7 automated tests had uncaught exceptions
3. Found 4 tests that purposely crash apps and windows linger around throughout the whole test suite, which is okay, but not ideal
4. Came up with an idea or two on how to improve test runner's logging
5. And last but not least, fixed this nasty bug that could've caused much more trouble in the future

🍾 Cheers!

🚥 **Automated test results**
⚠️ Notice: again, 0 failed tests!
✅ [Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b7ef26c6107b45e6d1ebb4a)
✅ [Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b7ef3d56107b45e6d1ebb4d)