### PR TITLE
RUN-4466 Core controls console messages in the debug.log

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -851,6 +851,18 @@ Window.create = function(id, opts) {
     };
 
     const prepareConsoleMessageForRVM = (event, level, message, lineNo, sourceId) => {
+        /*
+            INFO:      0
+            WARNING:   1
+            ERROR:     2
+            FATAL:     3
+        */
+        if (level === /* INFO */ 0 ||
+            level === /* WARNING */ 1) {
+            // Prevent INFO and WARNING messages from writing to debug.log
+            event.preventDefault();
+        }
+
         const app = coreState.getAppByUuid(identity.uuid);
         if (!app) {
             electronApp.vlog(2, `Error: could not get app object for app with uuid: ${identity.uuid}`);


### PR DESCRIPTION
The runtime was hardcoded to prevent _INFO_ and _WARN_ console messages from being written into the _debug.log_

This change
1. Relies on removing the hardcoding from the runtime [PR](https://github.com/openfin/runtime/pull/1135)
2. Allows the core to designate what gets written to the debug.log

[Test Results](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b859bcb6107b45e6d1ebbaf)