### PR TITLE
RUN-4202 RUN-3435 Name iframes as default

### DIFF
--- a/src/browser/api_protocol/transport_strategy/elipc_strategy.ts
+++ b/src/browser/api_protocol/transport_strategy/elipc_strategy.ts
@@ -100,10 +100,10 @@ export class ElipcStrategy extends ApiTransportBase<MessagePackage> {
 
             const entityType = e.sender.getEntityType(e.frameRoutingId);
             const isWindow  = ! e.sender.isIframe(e.frameRoutingId);
-            const { api: { iframe: { enableDepricatedSharedName } } } = opts;
+            const { api: { iframe: { enableDeprecatedSharedName } } } = opts;
             let subFrameName;
 
-            if (isWindow || enableDepricatedSharedName) {
+            if (isWindow || enableDeprecatedSharedName) {
                 subFrameName = opts.name;
             } else {
                 subFrameName = e.sender.getFrameName(e.frameRoutingId);

--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -27,7 +27,7 @@ const TRANSPARENT_WHITE = '#0FFF'; // format #ARGB
 const iframeBaseSettings = {
     'crossOriginInjection': false,
     'sameOriginInjection': true,
-    'enableDepricatedSharedName': false
+    'enableDeprecatedSharedName': false
 };
 
 // this is the 5.0 base to be sure that we are only extending what is already expected

--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -26,7 +26,8 @@ const TRANSPARENT_WHITE = '#0FFF'; // format #ARGB
 
 const iframeBaseSettings = {
     'crossOriginInjection': false,
-    'sameOriginInjection': true
+    'sameOriginInjection': true,
+    'enableDepricatedSharedName': false
 };
 
 // this is the 5.0 base to be sure that we are only extending what is already expected

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -29,7 +29,7 @@
     const {
         elIPCConfig,
         options: initialOptions,
-        options: { api: { iframe: { enableDepricatedSharedName } } },
+        options: { api: { iframe: { enableDeprecatedSharedName } } },
         socketServerState,
         runtimeArguments,
         frames
@@ -41,7 +41,7 @@
     // The following will check whether it is an iframe and update
     // entity information accordingly
     const frameInfo = frames.find(e => e.frameRoutingId === renderFrameId);
-    const entityInfo = isMainFrame || enableDepricatedSharedName ? glbl.__startOptions.entityInfo : frameInfo;
+    const entityInfo = isMainFrame || enableDeprecatedSharedName ? glbl.__startOptions.entityInfo : frameInfo;
     const decorateOpen = !runtimeArguments.includes('--native-window-open');
 
     let getOpenerSuccessCallbackCalled = () => {

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -29,6 +29,7 @@
     const {
         elIPCConfig,
         options: initialOptions,
+        options: { api: { iframe: { enableDepricatedSharedName } } },
         socketServerState,
         runtimeArguments,
         frames
@@ -40,7 +41,7 @@
     // The following will check whether it is an iframe and update
     // entity information accordingly
     const frameInfo = frames.find(e => e.frameRoutingId === renderFrameId);
-    const entityInfo = isMainFrame ? glbl.__startOptions.entityInfo : frameInfo;
+    const entityInfo = isMainFrame || enableDepricatedSharedName ? glbl.__startOptions.entityInfo : frameInfo;
     const decorateOpen = !runtimeArguments.includes('--native-window-open');
 
     let getOpenerSuccessCallbackCalled = () => {


### PR DESCRIPTION
IFrames will now get their own names by default allowing them to
act as discrete endpoints on the IAB. If a user wants to opt into
the old frameConnect style behavior it can be opted into via
api.frame.enableDepricatedSharedName being set to true.

This removes the need for `--frameStragety=frames` and it will now
be ignored. 

Requires [this](https://github.com/openfin/javascript-adapter/pull/490) adapter pr

Tests well
[win 7 64](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b88019f6107b45e6d1ebbdf)
[win 10 32](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b88035d6107b45e6d1ebbe1)
[win 10 64](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b8803246107b45e6d1ebbe0)