### PR TITLE
RUN-4519 API breadcrumbs

### DIFF
--- a/src/browser/api_protocol/transport_strategy/ack.ts
+++ b/src/browser/api_protocol/transport_strategy/ack.ts
@@ -3,6 +3,7 @@ const errors = require('../../../common/errors');
 
 export class AckMessage {
     public readonly action: string = 'ack';
+    public breadcrumbs: Array<any>;
     public correlationId: number;
     public payload: AckPayload | NackPayload;
 }

--- a/src/browser/api_protocol/transport_strategy/api_transport_base.ts
+++ b/src/browser/api_protocol/transport_strategy/api_transport_base.ts
@@ -38,7 +38,7 @@ export abstract class ApiTransportBase<T> {
 
     protected abstract onMessage(id: number, data: any): void;
 
-    protected abstract ackDecorator(id: number, messageId: number): AckFunc;
+    protected abstract ackDecorator(id: number, messageId: number, originalPayload: any): AckFunc;
 
     protected abstract ackDecoratorSync(e: any, messageId: number): AckFunc;
 

--- a/src/browser/api_protocol/transport_strategy/elipc_strategy.ts
+++ b/src/browser/api_protocol/transport_strategy/elipc_strategy.ts
@@ -99,7 +99,7 @@ export class ElipcStrategy extends ApiTransportBase<MessagePackage> {
 
         try {
             const data = JSON.parse(JSON.stringify(rawData));
-            const ack = !data.isSync ? this.ackDecorator(e, data.messageId) : this.ackDecoratorSync(e, data.messageId);
+            const ack = !data.isSync ? this.ackDecorator(e, data.messageId, data) : this.ackDecoratorSync(e, data.messageId);
             const nack = this.nackDecorator(ack);
             const browserWindow = e.sender.getOwnerBrowserWindow();
             const currWindow = browserWindow ? coreState.getWinById(browserWindow.id) : null;
@@ -151,9 +151,29 @@ export class ElipcStrategy extends ApiTransportBase<MessagePackage> {
         };
     }
 
-    protected ackDecorator(e: any, messageId: number): AckFunc {
+    private addBreadcrumb(message: any,  messageId: number, action: string, name: string): void {
+        if (message && message.breadcrumbs && message.breadcrumbs.length) {
+            message.breadcrumbs.push({
+                action,
+                messageId,
+                name,
+                time: Date.now()
+            });
+        }
+    }
+
+    protected ackDecorator(e: any, messageId: number, originalPayload: any): AckFunc {
         const ackObj = new AckMessage();
         ackObj.correlationId = messageId;
+
+        // It is inferred that breadcrumbs have been enabled for a window
+        // when the breadcrumb array is present in the original payload of the API request.
+        const usingBreadcrumbs = originalPayload.breadcrumbs && originalPayload.breadcrumbs.length;
+
+        if (usingBreadcrumbs) {
+            ackObj.breadcrumbs = originalPayload.breadcrumbs;
+            this.addBreadcrumb(ackObj, messageId, originalPayload.action, 'core/ackDecorator');
+        }
 
         return (payload: any): void => {
             ackObj.payload = payload;
@@ -167,6 +187,10 @@ export class ElipcStrategy extends ApiTransportBase<MessagePackage> {
             }
 
             if (!e.sender.isDestroyed()) {
+                if (usingBreadcrumbs) {
+                    this.addBreadcrumb(ackObj, messageId, originalPayload.action, 'core/ACK');
+                }
+
                 e.sender.sendToFrame(e.frameRoutingId, electronIpc.channels.CORE_MESSAGE, JSON.stringify(ackObj));
             }
         };

--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -68,6 +68,7 @@ function five0BaseOptions() {
         'exitOnClose': false,
         'experimental': {
             'api': {
+                'breadcrumbs': false,
                 'iframe': iframeBaseSettings
             },
             'disableInitialReload': false,


### PR DESCRIPTION
When breadcrumbs are enabled, the debug.log contains tracking of the API messages at each hop of the system.

This is a Window option that defaults to _false_
_experimental.api.breadcrumbs_

🌳 Requires this [adapter PR 493](https://github.com/openfin/javascript-adapter/pull/493)