### PR TITLE
RUN-4566 - getAppAssetInfo always returns the error: "Cannot set property 'srcUrl' of undefined"

### DIFF
--- a/src/browser/api_protocol/api_handlers/system.ts
+++ b/src/browser/api_protocol/api_handlers/system.ts
@@ -156,7 +156,7 @@ function getCrashReporterState(identity: Identity, message: APIMessage, ack: Ack
 }
 
 function getAppAssetInfo(identity: Identity, message: APIMessage, ack: Acker, nack: Nacker): void {
-    const { options } = message;
+    const options = message.payload;
 
     System.getAppAssetInfo(identity, options, (data: any) => {
         const dataAck = Object.assign({}, successAck);


### PR DESCRIPTION
Tests:
[Win 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b996f736107b45e6d1ebc7d)
[Win 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b9970f86107b45e6d1ebc7e)
