### PR TITLE
Run 4360 some fixes for our custom error boxes

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -578,7 +578,6 @@ Window.create = function(id, opts) {
                     `application with the UUID "${uuid}"`;
                 const title = ERROR_TITLE_RENDERER_CRASH;
                 const type = ERROR_BOX_TYPES.RENDERER_CRASH;
-                log.writeToLog('info', '==========> ' + type);
                 const args = { message, title, type };
                 showErrorBox(args);
             }

--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -65,6 +65,8 @@ export function initSafeErrors(argo: any): void {
     isInitSafeErrors = true;
 }
 
+const maxErrorBoxesQty = 10;
+let errorBoxesQty = 0;
 export function showErrorBox(data: ErrorBox): Promise<void> {
     return new Promise((resolve) => {
 
@@ -74,11 +76,19 @@ export function showErrorBox(data: ErrorBox): Promise<void> {
 
         const { error, message, title = '', type } = data;
         const uuid = `error-app-${app.generateGUID()}`;
+        const errorMessage = message || error.stack;
 
-        writeToLog('info', error);
+        writeToLog('info', errorMessage);
 
         if (argo.noerrdialogs) {
             return resolve();
+        }
+
+        if (errorBoxesQty >= maxErrorBoxesQty) {
+            writeToLog('info', `Not showing custom error box because the ` +
+                `quantity of active custom error boxes exceeded maximum ` +
+                `allowed of ${maxErrorBoxesQty}`);
+            return
         }
 
         try {
@@ -105,7 +115,7 @@ export function showErrorBox(data: ErrorBox): Promise<void> {
                         v2Api: true
                     },
                     customData: {
-                        error: message || error.stack,
+                        error: errorMessage,
                         title
                     }
                 }
@@ -115,10 +125,13 @@ export function showErrorBox(data: ErrorBox): Promise<void> {
 
             ofEvents.once(route.application('closed', uuid), () => {
                 deleteApp(uuid);
+                errorBoxesQty -= 1;
                 resolve();
             });
 
             Application.run({ uuid });
+
+            errorBoxesQty += 1;
 
         } catch (error) {
             writeToLog('info', error);

--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -85,10 +85,10 @@ export function showErrorBox(data: ErrorBox): Promise<void> {
         }
 
         if (errorBoxesQty >= maxErrorBoxesQty) {
-            writeToLog('info', `Not showing custom error box because the ` +
-                `quantity of active custom error boxes exceeded maximum ` +
+            writeToLog('info', 'Not showing custom error box because the ' +
+                'quantity of active custom error boxes exceeded maximum ' +
                 `allowed of ${maxErrorBoxesQty}`);
-            return
+            return;
         }
 
         try {

--- a/src/common/errors.ts
+++ b/src/common/errors.ts
@@ -107,7 +107,7 @@ export function showErrorBox(data: ErrorBox): Promise<void> {
                     autoShow: false, // shown later after resizing is done
                     alwaysOnTop: true,
                     resizable: false,
-                    contextMenu: true,
+                    contextMenu: false,
                     minimizable: false,
                     maximizable: false,
                     nonPersistent: true,


### PR DESCRIPTION
ℹ️ Minor fixes + limit active number of our custom error boxes to **10**

➕ New test (manual test apps PR): [Qty limit for custom error dialogs](https://github.com/openfin/test_apps/pull/46)

🚥 Automated tests results:
✅ [Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b9bd7cf6107b45e6d1ebc98) (same as vanilla)
✅ [Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b9bd8d86107b45e6d1ebc99) (same as vanilla)