### PR TITLE
Bump electron rebuild to use 2.0.7

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -262,7 +262,7 @@ module.exports = (grunt) => {
 
         electronRebuild.rebuild({
             buildPath: __dirname,
-            electronVersion: '2.0.2'
+            electronVersion: '2.0.7'
         }).then(() => {
             grunt.log.writeln('Rebuild successful!');
             done();


### PR DESCRIPTION
No underlying NodeJS change, just bumping this number.

✅ [Win 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b9c21b06107b45e6d1ebcbe)
✅ [Win 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5b9c20796107b45e6d1ebcbc)