### PR TITLE
RUN-4564: Use process object for build flag logs

### DIFF
--- a/index.js
+++ b/index.js
@@ -249,8 +249,8 @@ app.on('ready', function() {
     app.registerNamedCallback('getWindowOptionsById', coreState.getWindowOptionsById);
 
     if (process.platform === 'win32') {
-        log.writeToLog('info', `group-policy build: ${app.isGroupPolicyBuild()}`);
-        log.writeToLog('info', `enable-chromium build: ${app.isEnableChromiumBuild()}`);
+        log.writeToLog('info', `group-policy build: ${process.buildFlags.groupPolicy}`);
+        log.writeToLog('info', `enable-chromium build: ${process.buildFlags.enableChromium}`);
     }
     log.writeToLog('info', `build architecture: ${process.arch}`);
     app.vlog(1, 'process.versions: ' + JSON.stringify(process.versions, null, 2));

--- a/index.js
+++ b/index.js
@@ -250,6 +250,7 @@ app.on('ready', function() {
 
     if (process.platform === 'win32') {
         log.writeToLog('info', `group-policy build: ${app.isGroupPolicyBuild()}`);
+        log.writeToLog('info', `enable-chromium build: ${app.isEnableChromiumBuild()}`);
     }
     log.writeToLog('info', `build architecture: ${process.arch}`);
     app.vlog(1, 'process.versions: ' + JSON.stringify(process.versions, null, 2));


### PR DESCRIPTION
ain't gonna work w/o https://github.com/openfin/runtime/pull/1162

this includes:
- using process.buildFlags.enableChromium
- moving app.isGroupPolicyBuild() to process.buildFlags.groupPolicy