### PR TITLE
RUN-2315 added support for taking a snapshot of an area in a window

### DIFF
--- a/src/browser/api_protocol/api_handlers/window.ts
+++ b/src/browser/api_protocol/api_handlers/window.ts
@@ -327,19 +327,10 @@ function getAllFrames(identity: Identity, message: APIMessage): FrameInfo[] {
     return Window.getAllFrames(windowIdentity);
 }
 
-function getWindowSnapshot(identity: Identity, message: APIMessage, ack: Acker): void {
+function getWindowSnapshot(identity: Identity, message: APIMessage): Promise<string> {
     const { payload } = message;
-    const dataAck = Object.assign({}, successAck);
     const windowIdentity = getTargetWindowIdentity(payload);
-
-    Window.getSnapshot(windowIdentity, (err: Error, image: string) => {
-        if (err) {
-            throw err; // TODO: this should probably nack - investigate
-        } else {
-            dataAck.data = image;
-            ack(dataAck);
-        }
-    });
+    return Window.getSnapshot({ identity: windowIdentity, payload });
 }
 
 function getWindowState(identity: Identity, message: APIMessage, ack: Acker): void {


### PR DESCRIPTION
ℹ️ **About**
This and related PRs add support for taking snapshots of an area of a window.

🔗 All linked PRs
1\. [core PR](https://github.com/HadoukenIO/core/pull/561)
2\. [javascript-adapter PR](https://github.com/openfin/javascript-adapter/pull/500)
3\. [js-adapter PR](https://github.com/HadoukenIO/js-adapter/pull/188)

➕ **New automated tests**
1\. [window.getSnapshot (specified area)](https://testing-dashboard.openfin.co/#/app/tests/5ba1497ad6d66a0ddf8e7253/edit)
2\. [window.getSnapshot (specified area) (V2 API)](https://testing-dashboard.openfin.co/#/app/tests/5baa700ecb360141a7dfcf5f/edit)

🚥 **Test results**
✅ [Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5baa75bbcb360141a7dfcf65)
✅ Node test results
![screen shot 2018-09-25 at 12 53 56 pm](https://user-images.githubusercontent.com/5790216/46083329-389acd80-c16f-11e8-971c-1f7fbc90d45c.png)
