### PR TITLE
Removed the need to specify any experimental flag in order to use the file download API

### DIFF
--- a/index.js
+++ b/index.js
@@ -368,12 +368,9 @@ app.on('ready', function() {
         electron.session.defaultSession.on('will-download', (event, item, webContents) => {
             try {
                 const { uuid, name } = webContents.browserWindowOptions;
-                const { experimental } = coreState.getAppObjByUuid(uuid)._options;
-                //Experimental flag for the download events.
-                if (experimental && experimental.api && experimental.api.fileDownloadApi) {
-                    const downloadListener = createWillDownloadEventListener({ uuid, name });
-                    downloadListener(event, item, webContents);
-                }
+
+                const downloadListener = createWillDownloadEventListener({ uuid, name });
+                downloadListener(event, item, webContents);
             } catch (err) {
                 log.writeToLog('info', 'Error while processing will-download event.');
                 log.writeToLog('info', err);

--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -79,7 +79,6 @@ function five0BaseOptions() {
                     'renderer': rendererBatchingBaseSettings
                 },
                 'breadcrumbs': false,
-                'fileDownloadApi': false,
                 'iframe': iframeBaseSettings
             },
             'disableInitialReload': false,


### PR DESCRIPTION
Removing experimental flag requirement for the download listener API.

Test results: 
[Win 7](https://testing-dashboard.openfin.co/#/app/sessions)
[Win 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5bad3a1ecb360141a7dfcfa6)