### PR TITLE
RUN-4525: refine grouped window move on MAC

### DIFF
--- a/src/browser/bounds_changed_state_tracker.ts
+++ b/src/browser/bounds_changed_state_tracker.ts
@@ -452,11 +452,14 @@ export default class BoundsChangedStateTracker {
                             const [w, h] = [width, height];
                             wt.setWindowPos(hwnd, { x, y, w, h, flags });
                         } else {
-                            if (win.browserWindow.isMaximized()) {
+                            if (win.browserWindow.isFullScreen()) {
+                                win.browserWindow.setFullScreen(false);
+                            } else if (win.browserWindow.isMaximized()) {
                                 win.browserWindow.unmaximize();
+                            } else {
+                                // no need to call clipBounds here because called earlier
+                                win.browserWindow.setBounds({ x, y, width, height });
                             }
-                            // no need to call clipBounds here because called earlier
-                            win.browserWindow.setBounds({ x, y, width, height });
                         }
                     });
 

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -100,8 +100,10 @@ declare module 'electron' {
         bringToFront(): any;
         isDestroyed(): boolean;
         isMaximized(): boolean;
+        isFullScreen(): boolean;
         isMinimized(): boolean;
         unmaximize(): any;
+        setFullScreen(fullscreen: boolean): any;
         emit(routeString: string, ...args: any[]): void;
         getBounds(): Rectangle;
         setBounds(bounds: Rectangle): void;

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -103,7 +103,7 @@ declare module 'electron' {
         isFullScreen(): boolean;
         isMinimized(): boolean;
         unmaximize(): any;
-        setFullScreen(fullscreen: boolean): any;
+        setFullScreen(fullscreen: boolean): void;
         emit(routeString: string, ...args: any[]): void;
         getBounds(): Rectangle;
         setBounds(bounds: Rectangle): void;


### PR DESCRIPTION
1: for full screen window, set to normal mode first.
2: No need to restore cached bounds on mac cause we hasn't [store the window's bounds before max or fullscreen](https://github.com/openfin/runtime/blob/d8f3a2aa275bf085d12716f89ea86573dd7d0bba/atom/browser/native_window_views.h#L393).