### PR TITLE
RUN-4671 Fail on duplicate run calls

### DIFF
--- a/src/browser/api_protocol/api_handlers/application.js
+++ b/src/browser/api_protocol/api_handlers/application.js
@@ -315,6 +315,12 @@ function runApplication(identity, message, ack, nack) {
         className: 'window',
         eventName: 'fire-constructor-callback'
     };
+    
+    if (coreState.getAppRunningState(uuid)) {
+        Application.emitRunRequested(appIdentity);
+        nack(`Application with specified UUID is already running: ${uuid}`);
+        return;
+    }
 
     ofEvents.once(route.window('fire-constructor-callback', uuid, uuid), loadInfo => {
         if (loadInfo.success) {


### PR DESCRIPTION
Nack when .run is called instead of hanging.

Tests:
[Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5bb294afcb360141a7dfcfde)
[Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5bb2936acb360141a7dfcfdb)