### PR TITLE
RUN-4670/Forward error message rather than error

### DIFF
--- a/src/browser/api_protocol/api_handlers/mesh_middleware.ts
+++ b/src/browser/api_protocol/api_handlers/mesh_middleware.ts
@@ -98,7 +98,7 @@ function sendMessageMiddleware(msg: MessagePackage, next: () => void) {
             .then((id: any) => {
                 id.runtime.fin.System.executeOnRemote(identity, data)
                 .then(ack)
-                .catch(nack);
+                .catch((e: Error) => nack(e.message));
             }).catch((e: Error) => {
                 //Uuid was not found in the mesh, let local logic go its course
                 next();
@@ -140,7 +140,7 @@ function ferryActionMiddleware(msg: MessagePackage, next: () => void) {
                     }
                 })
                 .then(ack)
-                .catch(nack);
+                .catch((e: Error) => nack(e.message));
             }).catch((e: Error) => {
                 //Uuid was not found in the mesh, let local logic go its course
                 next();
@@ -186,7 +186,7 @@ function aggregateFromExternalRuntime(msg: MessagePackage, next: (locals?: objec
                 const locals = { aggregate: externalRuntimeData };
                 next(locals);
             })
-            .catch(nack);
+            .catch((e: Error) => nack(e.message));
         } else {
             next();
         }

--- a/src/browser/api_protocol/api_handlers/mesh_middleware.ts
+++ b/src/browser/api_protocol/api_handlers/mesh_middleware.ts
@@ -98,7 +98,7 @@ function sendMessageMiddleware(msg: MessagePackage, next: () => void) {
             .then((id: any) => {
                 id.runtime.fin.System.executeOnRemote(identity, data)
                 .then(ack)
-                .catch((e: Error) => nack(e.message));
+                .catch(nack);
             }).catch((e: Error) => {
                 //Uuid was not found in the mesh, let local logic go its course
                 next();
@@ -140,7 +140,7 @@ function ferryActionMiddleware(msg: MessagePackage, next: () => void) {
                     }
                 })
                 .then(ack)
-                .catch((e: Error) => nack(e.message));
+                .catch(nack);
             }).catch((e: Error) => {
                 //Uuid was not found in the mesh, let local logic go its course
                 next();
@@ -186,7 +186,7 @@ function aggregateFromExternalRuntime(msg: MessagePackage, next: (locals?: objec
                 const locals = { aggregate: externalRuntimeData };
                 next(locals);
             })
-            .catch((e: Error) => nack(e.message));
+            .catch(nack);
         } else {
             next();
         }

--- a/src/browser/api_protocol/transport_strategy/ack.ts
+++ b/src/browser/api_protocol/transport_strategy/ack.ts
@@ -52,7 +52,7 @@ export class NackPayload {
             this.reason = error;
         } else {
             const errorObject = errors.errorToPOJO(error);
-            this.reason = errorObject.toString();
+            this.reason = error.message;
             this.error = errorObject;
         }
     }


### PR DESCRIPTION
Changes multi-runtime error messages from `RuntimeError: Error: **error message**` to `RuntimeError: **error message**`
Test results
[Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5bb38008cb360141a7dfcfef) (Failed one test which passed multiple times otherwise)
[Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5bb3811fcb360141a7dfcff0)