### PR TITLE
RUN-4460: Fix/v10/version

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -262,7 +262,7 @@ module.exports = (grunt) => {
 
         electronRebuild.rebuild({
             buildPath: __dirname,
-            electronVersion: '2.0.7'
+            electronVersion: '3.0.0'
         }).then(() => {
             grunt.log.writeln('Rebuild successful!');
             done();

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -262,7 +262,7 @@ module.exports = (grunt) => {
 
         electronRebuild.rebuild({
             buildPath: __dirname,
-            electronVersion: '3.0.0'
+            electronVersion: '3.0.2'
         }).then(() => {
             grunt.log.writeln('Rebuild successful!');
             done();

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1677,7 +1677,7 @@
         "debug": "^2.6.3",
         "detect-libc": "^1.0.3",
         "fs-extra": "^3.0.1",
-        "node-abi": "^2.4.5",
+        "node-abi": "^2.0.0",
         "node-gyp": "^3.6.0",
         "ora": "^1.2.0",
         "rimraf": "^2.6.1",
@@ -3710,7 +3710,7 @@
       "integrity": "sha512-aa/UC6Nr3+tqhHGRsAuw/edz7/q9nnetBrKWxj6rpTtm+0X9T1qU7lIEHMS3yN9JwAbRiKUbRRFy1PLz/y3aaA==",
       "dev": true,
       "requires": {
-        "semver": "5.5.0"
+        "semver": "^5.4.1"
       }
     },
     "node-gyp": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1677,7 +1677,7 @@
         "debug": "^2.6.3",
         "detect-libc": "^1.0.3",
         "fs-extra": "^3.0.1",
-        "node-abi": "^2.0.0",
+        "node-abi": "^2.4.5",
         "node-gyp": "^3.6.0",
         "ora": "^1.2.0",
         "rimraf": "^2.6.1",
@@ -3705,12 +3705,12 @@
       }
     },
     "node-abi": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.4.3.tgz",
-      "integrity": "sha512-b656V5C0628gOOA2kwcpNA/bxdlqYF9FvxJ+qqVX0ctdXNVZpS8J6xEUYir3WAKc7U0BH/NRlSpNbGsy+azjeg==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.4.5.tgz",
+      "integrity": "sha512-aa/UC6Nr3+tqhHGRsAuw/edz7/q9nnetBrKWxj6rpTtm+0X9T1qU7lIEHMS3yN9JwAbRiKUbRRFy1PLz/y3aaA==",
       "dev": true,
       "requires": {
-        "semver": "^5.4.1"
+        "semver": "5.5.0"
       }
     },
     "node-gyp": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "load-grunt-tasks": "^4.0.0",
     "mocha": "^5.2.0",
     "mockery": "^2.1.0",
+    "node-abi": "^2.4.5",
     "openfin-sign": "openfin/openfin-sign.git#v1.0.0",
     "rewire": "^4.0.1",
     "should": "^13.2.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "load-grunt-tasks": "^4.0.0",
     "mocha": "^5.2.0",
     "mockery": "^2.1.0",
-    "node-abi": "^2.4.5",
     "openfin-sign": "openfin/openfin-sign.git#v1.0.0",
     "rewire": "^4.0.1",
     "should": "^13.2.1",


### PR DESCRIPTION
to enable v10 build on MAC.
To eliminate the warning for node-abi version complaint from bootstrap [using new electronVersion](https://github.com/electron/electron-rebuild/issues/251), add the latest 2.4.5 version to devDependencies. 