### PR TITLE
RUN-4636 fix for subscribeToAllRuntimes

### DIFF
--- a/src/browser/remote_subscriptions.ts
+++ b/src/browser/remote_subscriptions.ts
@@ -230,7 +230,7 @@ export function applyAllRemoteSubscriptions(runtime: PeerRuntime) {
 export function subscribeToAllRuntimes(subscriptionProps: RemoteSubscriptionProps|RemoteSubscription): Promise<() => void> {
     return new Promise(resolve => {
         if (systemEventsToIgnore[subscriptionProps.eventName]) {
-            resolve();
+            return resolve();
         }
 
         const clonedProps = JSON.parse(JSON.stringify(subscriptionProps));


### PR DESCRIPTION
This function was leaking remote subscriptions.

✅ Automated tests
[Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5bc73fcfcb360141a7dfd0ca)
[Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5bc74108cb360141a7dfd0cb)