### PR TITLE
RUN-4654: calling app.exit during delegated launch

### DIFF
--- a/index.js
+++ b/index.js
@@ -226,7 +226,7 @@ app.on('chrome-browser-process-created', function() {
 
         app.commandLine.appendArgument('noerrdialogs');
         process.argv.push('--noerrdialogs');
-        app.quit();
+        app.exit(0);
 
         return;
     }


### PR DESCRIPTION

For enable_chromium, if otherInstanceRunning is true, app.quit tries to shut down Chromium components that are not initialized yet and can cause crash of 2nd instance.  app.exit just exits.

Tests
[W10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5bc78e22cb360141a7dfd0de)
[W8](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5bc78c90cb360141a7dfd0db)