### PR TITLE
Run4712 Added API to associate app log with custom username

### DIFF
--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -777,6 +777,27 @@ Application.setShortcuts = function(identity, config, callback, errorCallback) {
     }
 };
 
+Application.setAppLogUsername = function(identity, username, callback, errorCallback) {
+    let app = Application.wrap(identity.uuid);
+
+    if (app) {
+        // Only apps started from a manifest can retrieve shortcut configuration
+        const options = {
+            topic: 'application',
+            action: 'application-log-username',
+            sourceUrl: app._configUrl,
+            data: {
+                userName: username
+            }
+        };
+        sendToRVM(options)
+            .then(callback, errorCallback)
+            .catch(errorCallback);
+    } else {
+        errorCallback(new Error('Application uuid not valid.'));
+    }
+};
+
 
 Application.setTrayIcon = function(identity, iconUrl, callback, errorCallback) {
     let { uuid } = identity;

--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -779,9 +779,7 @@ Application.setShortcuts = function(identity, config, callback, errorCallback) {
 
 Application.setAppLogUsername = function(identity, username, callback, errorCallback) {
     let app = Application.wrap(identity.uuid);
-
     if (app) {
-        // Only apps started from a manifest can retrieve shortcut configuration
         const options = {
             topic: 'application',
             action: 'application-log-username',

--- a/src/browser/api_protocol/api_handlers/application.js
+++ b/src/browser/api_protocol/api_handlers/application.js
@@ -66,6 +66,7 @@ module.exports.applicationApiMap = {
     'restart-application': restartApplication,
     'run-application': runApplication,
     'set-shortcuts': { apiFunc: setShortcuts, apiPath: '.setShortcuts' },
+    'set-app-log-username': setAppLogUsername,
     'set-tray-icon': setTrayIcon,
     'set-application-zoom-level': setApplicationZoomLevel,
     'terminate-application': terminateApplication,
@@ -263,6 +264,17 @@ function setShortcuts(identity, message, ack, nack) {
     const appIdentity = apiProtocolBase.getTargetApplicationIdentity(payload);
 
     Application.setShortcuts(appIdentity, payload.data, response => {
+        dataAck.data = response;
+        ack(dataAck);
+    }, nack);
+}
+
+function setAppLogUsername(identity, message, ack, nack) {
+    const payload = message.payload;
+    const dataAck = _.clone(successAck);
+    const appIdentity = apiProtocolBase.getTargetApplicationIdentity(payload);
+
+    Application.setAppLogUsername(appIdentity, payload.data, response => {
         dataAck.data = response;
         ack(dataAck);
     }, nack);


### PR DESCRIPTION
Added a Core API with (action: "application-log-username"). Sends a message over the RVM bus that updates App Log username when uploaded.

Ex)
var app = fin.desktop.Application.getCurrent();
app.setAppLogUsername(username, callback, errorCallback);

