### PR TITLE
RUN-4718 - Port Discovery Fix

### DIFF
--- a/src/browser/transports/chromium_ipc.ts
+++ b/src/browser/transports/chromium_ipc.ts
@@ -40,8 +40,8 @@ class ChromiumIPCTransport extends BaseTransport {
         if (this.connected) {
             this.ipc.send(JSON.stringify(data));
         } else {
-            this.connect();
             this.messageQueue.push(data);
+            this.connect();
         }
 
         return true;


### PR DESCRIPTION
Fixes issue where port discovery via chromeIPC (named pipe) was periodically failing due to garbage collection cleaning up the chromeIPCclient before the message was sent out.  We are now saving the client as a property on the instance (that can be overwritten if need be by a new chromeIPCclient).  

Also added try / catch protection around port discovery broadcast.

[Win7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5bcf6982cb360141a7dfd136)
[Win10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5bcf6b23cb360141a7dfd137)