### PR TITLE
RUN-4717: Support devtools and reload as window options

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -144,9 +144,17 @@ function genWindowKey(identity) {
 */
 let optionSetters = {
     contextMenu: function(newVal, browserWin) {
+        // so old API still works
         let contextMenuBool = !!newVal;
-
-        setOptOnBrowserWin('contextMenu', contextMenuBool, browserWin);
+        optionSetters['contextMenuSettings']({ enable: contextMenuBool }, browserWin);
+    },
+    contextMenuSettings: function(newVal, browserWin) {
+        if (!newVal || typeof newVal.enable !== 'boolean') {
+            return;
+        }
+        const val = Object.assign({}, getOptFromBrowserWin('contextMenuSettings', browserWin),
+            newVal);
+        setOptOnBrowserWin('contextMenuSettings', val, browserWin);
         browserWin.setMenu(null);
     },
     customData: function(newVal, browserWin) {
@@ -1340,8 +1348,7 @@ Window.getSnapshot = (opts) => {
             return browserWindow.capturePage(callback);
         }
 
-        if (
-            !area ||
+        if (!area ||
             typeof area !== 'object' ||
             typeof area.x !== 'number' ||
             typeof area.y !== 'number' ||

--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -24,6 +24,13 @@ import {
 } from '../shapes';
 const TRANSPARENT_WHITE = '#0FFF'; // format #ARGB
 
+// contextMenuSettings is not updateable for enable_chromium
+const contextMenuSettings = {
+    'enable': true,
+    'devtools': true, // enable_chromium only
+    'reload': true, // enable_chromium only
+};
+
 const iframeBaseSettings = {
     'crossOriginInjection': false,
     'sameOriginInjection': true,
@@ -59,7 +66,7 @@ function five0BaseOptions() {
         'aspectRatio': 0,
         'autoShow': false,
         'backgroundThrottling': false,
-        'contextMenu': true,
+        'contextMenuSettings': contextMenuSettings,
         'cornerRounding': {
             'height': 0,
             'width': 0
@@ -81,7 +88,6 @@ function five0BaseOptions() {
                 'breadcrumbs': false,
                 'iframe': iframeBaseSettings
             },
-            'chromeContextMenu': false,
             'disableInitialReload': false,
             'node': false,
             'v2Api': true
@@ -253,12 +259,16 @@ module.exports = {
             newOptions.api.iframe = newOptions.experimental.api.iframe;
         }
 
+        if (_.has(options, 'contextMenu')) { // backwards compatible
+            newOptions.contextMenuSettings.enable = options.contextMenu;
+        }
+
         // Electron BrowserWindow options
         newOptions.enableLargerThanScreen = true;
         newOptions['enable-plugins'] = true;
         newOptions.webPreferences = {
             api: newOptions.experimental.api,
-            chromeContextMenu: newOptions.experimental.chromeContextMenu,
+            contextMenuSettings: newOptions.contextMenuSettings,
             disableInitialReload: newOptions.experimental.disableInitialReload,
             nodeIntegration: false,
             plugins: newOptions.plugins,

--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -24,7 +24,7 @@ import {
 } from '../shapes';
 const TRANSPARENT_WHITE = '#0FFF'; // format #ARGB
 
-// contextMenuSettings is not updateable for enable_chromium
+// contextMenuSettings is not updateable for enable_chromium.  RUN-4721
 const contextMenuSettings = {
     'enable': true,
     'devtools': true, // enable_chromium only

--- a/src/browser/core_state.ts
+++ b/src/browser/core_state.ts
@@ -17,7 +17,7 @@ import * as Shapes from '../shapes';
 import { writeToLog } from './log';
 import { FrameInfo } from './api/frame';
 import * as electronIPC from './transports/electron_ipc';
-import { getIdentityFromObject } from '../common/main';
+import { getIdentityFromObject, isEnableChromiumBuild } from '../common/main';
 
 interface ProxySettingsArgs {
     proxyAddress?: string;
@@ -802,11 +802,13 @@ export function getWindowInitialOptionSet(windowId: number): Shapes.WindowInitia
         channels: electronIPC.channels
     };
     const socketServerState = <PortInfo>getSocketServerState();
+    const enableChromiumBuild = isEnableChromiumBuild();
 
     return {
         options,
         entityInfo,
         elIPCConfig,
+        enableChromiumBuild,
         socketServerState,
         frames: Array.from(ofWin.frames.values())
     };

--- a/src/common/main.ts
+++ b/src/common/main.ts
@@ -22,3 +22,8 @@ export const getIdentityFromObject = (obj: any): Identity => {
     const { uuid, name } = obj;
     return { uuid, name };
 };
+
+export function isEnableChromiumBuild(): boolean {
+    const { buildFlags } = <any> process;
+    return buildFlags && buildFlags.enableChromium;
+}

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -28,6 +28,7 @@
 
     const {
         elIPCConfig,
+        enableChromiumBuild,
         options: initialOptions,
         options: { api: { iframe: { enableDeprecatedSharedName } } },
         socketServerState,
@@ -175,7 +176,7 @@
     }
 
     function wireUpMenu(global) {
-        if (initialOptions.experimental.chromeContextMenu) {
+        if (enableChromiumBuild) {
             return;
         }
         global.addEventListener('contextmenu', e => {
@@ -185,7 +186,7 @@
                 const identity = entityInfo.entityType === 'iframe' ? entityInfo.parent : entityInfo;
 
                 fin.desktop.Window.getCurrent().getOptions(options => {
-                    if (options.contextMenu) {
+                    if (options.contextMenuSettings.enable) {
                         syncApiCall('show-menu', {
                             uuid: identity.uuid,
                             name: identity.name,

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -156,6 +156,11 @@ export interface WindowOptions {
         blacklist?: string[];
     };
     contextMenu?: boolean;
+    contextMenuSettings?: {
+        enable: boolean,
+        devtools?: boolean,
+        reload?: boolean
+    };
     cornerRounding?: {
         height: number;
         width: number;
@@ -313,6 +318,7 @@ export interface ElectronIpcChannels {
 export interface WindowInitialOptionSet {
     options: WindowOptions;
     entityInfo: FrameInfo;
+    enableChromiumBuild: boolean;
     socketServerState: PortInfo;
     frames: ChildFrameInfo[];
     elIPCConfig: {


### PR DESCRIPTION
[Runtime](https://github.com/openfin/runtime/pull/1218)

Tests
[W7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5bcf3595cb360141a7dfd133)
[W10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5bcf3705cb360141a7dfd134)
[Test with enable_chromium build of Runtime](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5bcfc4bdcb360141a7dfd144)

Tests of context menu failed because contextMenu has been replaced with contextMenuSettings

Also, contextMenuSettings can not be updated in enable_chromium build of Runtime, for now.
 