### PR TITLE
RUN-4715 Fix window has incorrect zoom level issue when reopen

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -2425,11 +2425,7 @@ function restoreWindowPosition(identity, cb) {
 
         // set zoom level
         const { zoomLevel } = savedBounds;
-        if (zoomLevel) {
-            const browserWindow = getElectronBrowserWindow(identity);
-            browserWindow.webContents.setZoomLevel(zoomLevel);
-        }
-
+        Window.setZoomLevel(identity, zoomLevel);
         cb();
     }, (err) => {
         //We care about errors but lets keep window creation going.

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -153,17 +153,7 @@
     }
     ////END.
 
-    function wireUpZoomEvents() {
-        // listen for zoom-in/out keyboard shortcut
-        // messages sent from the browser process
-        ipc.on(`zoom-${renderFrameId}`, (event, zoom) => {
-            if ('level' in zoom) {
-                webFrame.setZoomLevel(zoom.level);
-            } else if ('increment' in zoom) {
-                webFrame.setZoomLevel(zoom.increment ? Math.floor(webFrame.getZoomLevel()) + zoom.increment : 0);
-            }
-        });
-
+    function wireUpMouseWheelZoomEvents() {
         document.addEventListener('mousewheel', event => {
             if (!event.ctrlKey || !initialOptions.accelerator.zoom) {
                 return;
@@ -263,7 +253,7 @@
 
         wireUpMenu(glbl);
         disableModifiedClicks(glbl);
-        wireUpZoomEvents();
+        wireUpMouseWheelZoomEvents();
         raiseReadyEvents(entityInfo);
 
         //TODO:Notifications to be removed from this file.
@@ -528,6 +518,17 @@
 
         if (!isNotificationType(name)) {
             evalPreloadScripts(uuid, name);
+        }
+    });
+
+    /**
+     * zoom event: listen for zoom-in/out keyboard shortcut and messages sent from the browser process using 'send' method
+     */
+    ipc.on(`zoom-${renderFrameId}`, (event, zoom) => {
+        if ('level' in zoom) {
+            webFrame.setZoomLevel(zoom.level);
+        } else if ('increment' in zoom) {
+            webFrame.setZoomLevel(zoom.increment ? Math.floor(webFrame.getZoomLevel()) + zoom.increment : 0);
         }
     });
 


### PR DESCRIPTION
This PR is fixing window zoom issue for HSBC. (for .36)
Tests:
[Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5bd0d0d1cb360141a7dfd14b)
[Windos 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5bd0d210cb360141a7dfd14c)