### PR TITLE
 RUN-4690 only resize inside threshold plus move rectangle math 

### DIFF
--- a/src/browser/bounds_changed_state_tracker.ts
+++ b/src/browser/bounds_changed_state_tracker.ts
@@ -427,12 +427,24 @@ export default class BoundsChangedStateTracker {
                                 win.browserWindow.unmaximize();
                             }
 
-                            setPositions.push(() => {
-                                const myBounds = positions.get(win.name);
-                                const { x, y, width, height } = myBounds;
-                                const [w, h] = [width, height];
-                                wt.setWindowPos(hwnd, { x, y, w, h, flags });
-                            });
+                            /*
+                                Leave this in here (commented out) for now. The idea is to only actually move the
+                                windows after all window positions are known in order to detect if any min/max
+                                restriction has been violated. The reason it is not included here is that it changes
+                                the .deferred and .reason values on the event payloads in a way that breaks tests,
+                                though it may be the desired behavior. This will be revisited as we evaluate making
+                                the entire transaction happen deferred window bounds.
+
+
+                                setPositions.push(() => {
+                                    const myBounds = positions.get(win.name);
+                                    const { x, y, width, height } = myBounds;
+                                    const [w, h] = [width, height];
+                                    wt.setWindowPos(hwnd, { x, y, w, h, flags });
+                                });
+                             */
+                            const [w, h] = [width, height];
+                            wt.setWindowPos(hwnd, { x, y, w, h, flags });
 
                         } else {
                             if (win.browserWindow.isMaximized()) {
@@ -440,13 +452,16 @@ export default class BoundsChangedStateTracker {
                             }
 
                             positions.set(win.name, { x, y, width, height });
-                            setPositions.push(() => {
-                                win.browserWindow.setBounds(positions.get(win.name));
-                            });
+                            // see note above about deferred moves
+                            // setPositions.push(() => {
+                            //     win.browserWindow.setBounds(positions.get(win.name));
+                            // });
+                            win.browserWindow.setBounds(positions.get(win.name));
                         }
                     }
 
-                    setPositions.forEach(boundsSet => boundsSet());
+                    // see note above about deferred moves
+                    // setPositions.forEach(boundsSet => boundsSet());
 
                     if (wt) {
                         wt.commit();

--- a/src/browser/bounds_changed_state_tracker.ts
+++ b/src/browser/bounds_changed_state_tracker.ts
@@ -20,10 +20,6 @@ import { windowTransaction } from 'electron';
 import * as log from '../browser/log';
 import {RectangleBase, Rectangle} from './rectangle';
 
-import Bounds from 'hadouken-js-adapter/out/types/src/api/window/bounds';
-
-const l = (x: any) => log.writeToLog(1, x, true);
-
 // change types
 const POSITION = 0;
 const SIZE = 1;
@@ -269,93 +265,14 @@ export default class BoundsChangedStateTracker {
         return Math.abs(boundOne - boundTwo) < this.sharedBoundPixelDiff;
     };
 
-    // tslint:disable-next-line:max-line-length
-    private handleGroupedResize = (resizeChangeType: BoundChanged, delta: any, originalWindowCachedBounds: DecoratedBounds, windowToUpdate: OpenFinWindow, bounds: RectangleBase): RectangleBase => {
+    private handleGroupedResize = (windowToUpdate: OpenFinWindow, bounds: RectangleBase): RectangleBase => {
         if (!trackingResize) {
             return bounds;
         }
-        // let { x, y, width, height } = bounds;
-
-        //const leaderRect = Rectangle.CREATE_FROM_BOUNDS(<RectangleBase> originalWindowCachedBounds);
-        // l('take me to your leader!');
-        // l(JSON.stringify(leaderRect));
-        // const intersectionRect = thisRect.intersection(leaderRect.grow(5, 5));
-
-        // const sharedBounds = leaderRect.sharedBounds(thisRect);
-
-        // l(thisRect);
-        // l(leaderRect);
-
-        // if (sharedBounds.hasSharedBounds) {
-        //     l(sharedBounds);
-        // } else {
-        //     l('nope');
-        //     // l(sharedBounds);
-        // }
-        // const intersection = !intersectionRect.isEmpty();
-        // const intersection = thisRect.collidesWith(leaderRect.grow(5, 5));
-        // l(JSON.stringify(thisRect));
-        // l('.....');
-        // l(JSON.stringify(leaderRect.grow(5, 5)));
-        // if (intersection) {
-        //     // l('YESSSSSSSSS!@!@!@!@!@!@!@!@!@!@!@!@!@!@!@!@');
-        //     if (resizeChangeType.height) {
-        //         if (delta.y) {
-        //             if (this.sharedBound(y, originalWindowCachedBounds.y)) {
-        //                 // resize windows with matching top bound
-        //                 y = toSafeInt(y + delta.y, y);
-        //                 height = height + delta.height;
-        //             }
-        //             if (this.sharedBound(y + height, originalWindowCachedBounds.y)) {
-        //                 // resize windows with matching bottom bound
-        //                 height = height - delta.height;
-        //             }
-        //         }
-        //         if (delta.y2) {
-        //             if (this.sharedBound(y + height, originalWindowCachedBounds.y + originalWindowCachedBounds.height)) {
-        //                 // resize windows with matching bottom bound
-        //                 height = height + delta.height;
-        //             }
-        //             if (this.sharedBound(y, originalWindowCachedBounds.y + originalWindowCachedBounds.height)) {
-        //                 // resize windows with matching top bound
-        //                 y = toSafeInt(y + delta.height, y);
-        //                 height = height - delta.height;
-        //             }
-        //         }
-        //     }
-        //     if (resizeChangeType.width) {
-        //         if (delta.x) {
-        //             // changed...
-        //             if (this.sharedBound(x, originalWindowCachedBounds.x)
-        //                 // && originalWindowCachedBounds.x + originalWindowCachedBounds.width < x
-        //                 ) {
-        //                 // resize windows with matching left bound
-        //                 x = toSafeInt(x + delta.x, x);
-        //                 width = width + delta.width;
-        //             }
-        //             if (this.sharedBound(x + width, originalWindowCachedBounds.x)) {
-        //                 // resize windows with matching right bound
-        //                 width = width - delta.width;
-        //             }
-        //         }
-        //         if (delta.x2) {
-        //             if (this.sharedBound(x + width, originalWindowCachedBounds.x + originalWindowCachedBounds.width)) {
-        //                 // resize windows with matching right bound
-        //                 width = width + delta.width;
-        //             }
-        //             if (this.sharedBound(x, originalWindowCachedBounds.x + originalWindowCachedBounds.width)) {
-        //                 // resize windows with matching left bound
-        //                 x = toSafeInt(x + delta.width, x);
-        //                 width = width - delta.width;
-        //             }
-        //         }
-        //     }
-        // }
-
         const thisRect = Rectangle.CREATE_FROM_BOUNDS(bounds);
         const currentBounds = this.getCurrentBounds();
         const cachedBounds = this.getCachedBounds();
-        const moved = thisRect.move2(cachedBounds, currentBounds);
+        const moved = thisRect.move(cachedBounds, currentBounds);
         return clipBounds(moved, windowToUpdate.browserWindow);
     };
 
@@ -453,7 +370,6 @@ export default class BoundsChangedStateTracker {
                     const { flag: { noZorder, noSize, noActivate } } = WindowTransaction;
                     let flags: number;
 
-                    //todo 1 means a change in size. this should be a const
                     if (changeType === SIZE) {
                         // this may need to change to 1 or 2 if we fix functionality for changeType 2
                         flags = noZorder + noActivate;
@@ -481,7 +397,7 @@ export default class BoundsChangedStateTracker {
 
                         const bounds = (changeType === SIZE)
                             // here bounds compare and delta are from the window that is resizing
-                            ? this.handleGroupedResize(boundsCompare, delta, cachedBounds, win, winBounds)
+                            ? this.handleGroupedResize(win, winBounds)
                             : winBounds;
 
                         let { x, y } = bounds;
@@ -511,7 +427,6 @@ export default class BoundsChangedStateTracker {
                                 win.browserWindow.unmaximize();
                             }
 
-                            // no change on the resize behavior
                             setPositions.push(() => {
                                 const myBounds = positions.get(win.name);
                                 const { x, y, width, height } = myBounds;

--- a/src/browser/bounds_changed_state_tracker.ts
+++ b/src/browser/bounds_changed_state_tracker.ts
@@ -24,6 +24,11 @@ import Bounds from 'hadouken-js-adapter/out/types/src/api/window/bounds';
 
 const l = (x: any) => log.writeToLog(1, x, true);
 
+// change types
+const POSITION = 0;
+const SIZE = 1;
+const POSITION_AND_SIZE = 2;
+
 const isWin32 = process.platform === 'win32';
 
 const DisableWindowGroupTracking = 'disable-window-group-tracking';
@@ -269,100 +274,89 @@ export default class BoundsChangedStateTracker {
         if (!trackingResize) {
             return bounds;
         }
-        let { x, y, width, height } = bounds;
+        // let { x, y, width, height } = bounds;
+
+        //const leaderRect = Rectangle.CREATE_FROM_BOUNDS(<RectangleBase> originalWindowCachedBounds);
+        // l('take me to your leader!');
+        // l(JSON.stringify(leaderRect));
+        // const intersectionRect = thisRect.intersection(leaderRect.grow(5, 5));
+
+        // const sharedBounds = leaderRect.sharedBounds(thisRect);
+
+        // l(thisRect);
+        // l(leaderRect);
+
+        // if (sharedBounds.hasSharedBounds) {
+        //     l(sharedBounds);
+        // } else {
+        //     l('nope');
+        //     // l(sharedBounds);
+        // }
+        // const intersection = !intersectionRect.isEmpty();
+        // const intersection = thisRect.collidesWith(leaderRect.grow(5, 5));
+        // l(JSON.stringify(thisRect));
+        // l('.....');
+        // l(JSON.stringify(leaderRect.grow(5, 5)));
+        // if (intersection) {
+        //     // l('YESSSSSSSSS!@!@!@!@!@!@!@!@!@!@!@!@!@!@!@!@');
+        //     if (resizeChangeType.height) {
+        //         if (delta.y) {
+        //             if (this.sharedBound(y, originalWindowCachedBounds.y)) {
+        //                 // resize windows with matching top bound
+        //                 y = toSafeInt(y + delta.y, y);
+        //                 height = height + delta.height;
+        //             }
+        //             if (this.sharedBound(y + height, originalWindowCachedBounds.y)) {
+        //                 // resize windows with matching bottom bound
+        //                 height = height - delta.height;
+        //             }
+        //         }
+        //         if (delta.y2) {
+        //             if (this.sharedBound(y + height, originalWindowCachedBounds.y + originalWindowCachedBounds.height)) {
+        //                 // resize windows with matching bottom bound
+        //                 height = height + delta.height;
+        //             }
+        //             if (this.sharedBound(y, originalWindowCachedBounds.y + originalWindowCachedBounds.height)) {
+        //                 // resize windows with matching top bound
+        //                 y = toSafeInt(y + delta.height, y);
+        //                 height = height - delta.height;
+        //             }
+        //         }
+        //     }
+        //     if (resizeChangeType.width) {
+        //         if (delta.x) {
+        //             // changed...
+        //             if (this.sharedBound(x, originalWindowCachedBounds.x)
+        //                 // && originalWindowCachedBounds.x + originalWindowCachedBounds.width < x
+        //                 ) {
+        //                 // resize windows with matching left bound
+        //                 x = toSafeInt(x + delta.x, x);
+        //                 width = width + delta.width;
+        //             }
+        //             if (this.sharedBound(x + width, originalWindowCachedBounds.x)) {
+        //                 // resize windows with matching right bound
+        //                 width = width - delta.width;
+        //             }
+        //         }
+        //         if (delta.x2) {
+        //             if (this.sharedBound(x + width, originalWindowCachedBounds.x + originalWindowCachedBounds.width)) {
+        //                 // resize windows with matching right bound
+        //                 width = width + delta.width;
+        //             }
+        //             if (this.sharedBound(x, originalWindowCachedBounds.x + originalWindowCachedBounds.width)) {
+        //                 // resize windows with matching left bound
+        //                 x = toSafeInt(x + delta.width, x);
+        //                 width = width - delta.width;
+        //             }
+        //         }
+        //     }
+        // }
 
         const thisRect = Rectangle.CREATE_FROM_BOUNDS(bounds);
-        const leaderRect = Rectangle.CREATE_FROM_BOUNDS(<RectangleBase> originalWindowCachedBounds);
-        const intersectionRect = thisRect.intersection(leaderRect.grow(5, 5));
-
-        const sharedBounds = leaderRect.sharedBounds(thisRect);
-
-        l(thisRect);
-        l(leaderRect);
-
-        if (sharedBounds.hasSharedBounds) {
-            l(sharedBounds);
-        } else {
-            l('nope');
-            // l(sharedBounds);
-        }
-        const intersection = !intersectionRect.isEmpty();
-        if (intersection) {
-            if (resizeChangeType.height) {
-                if (delta.y) {
-                    if (this.sharedBound(y, originalWindowCachedBounds.y)) {
-                        // resize windows with matching top bound
-                        y = toSafeInt(y + delta.y, y);
-                        height = height + delta.height;
-                    }
-                    if (this.sharedBound(y + height, originalWindowCachedBounds.y)) {
-                        // resize windows with matching bottom bound
-                        height = height - delta.height;
-                    }
-                }
-                if (delta.y2) {
-                    if (this.sharedBound(y + height, originalWindowCachedBounds.y + originalWindowCachedBounds.height)) {
-                        // resize windows with matching bottom bound
-                        height = height + delta.height;
-                    }
-                    if (this.sharedBound(y, originalWindowCachedBounds.y + originalWindowCachedBounds.height)) {
-                        // resize windows with matching top bound
-                        y = toSafeInt(y + delta.height, y);
-                        height = height - delta.height;
-                    }
-                }
-            }
-
-            if (resizeChangeType.width) {
-                if (delta.x) {
-
-                    // changed...
-                    if (this.sharedBound(x, originalWindowCachedBounds.x)
-                        // && originalWindowCachedBounds.x + originalWindowCachedBounds.width < x
-                        ) {
-                        // resize windows with matching left bound
-                        x = toSafeInt(x + delta.x, x);
-                        width = width + delta.width;
-                    }
-                    if (this.sharedBound(x + width, originalWindowCachedBounds.x)) {
-                        // resize windows with matching right bound
-                        width = width - delta.width;
-                    }
-                }
-                if (delta.x2) {
-                    if (this.sharedBound(x + width, originalWindowCachedBounds.x + originalWindowCachedBounds.width)) {
-                        // resize windows with matching right bound
-                        width = width + delta.width;
-                    }
-                    if (this.sharedBound(x, originalWindowCachedBounds.x + originalWindowCachedBounds.width)) {
-                        // resize windows with matching left bound
-                        x = toSafeInt(x + delta.width, x);
-                        width = width - delta.width;
-                    }
-                }
-            }
-        }
-        const newWindowBounds = { x, y, width, height };
-
-        const sharedBoundsList = thisRect.sharedBoundsList(leaderRect);
         const currentBounds = this.getCurrentBounds();
         const cachedBounds = this.getCachedBounds();
-        const d2 = Rectangle.CREATE_FROM_BOUNDS(cachedBounds).delta(Rectangle.CREATE_FROM_BOUNDS(currentBounds));
         const moved = thisRect.move2(cachedBounds, currentBounds);
-
-        l(JSON.stringify(thisRect.bounds, null, ' '));
-        l('---------------!!!------------------');
-        l(JSON.stringify(d2, null, ' '));
-        l('---------------###------------------');
-        l(JSON.stringify(delta, null, ' '));
-        l('---------------()()()()------------------');
-        l(JSON.stringify(moved, null, ' '));
-        l('---------------###------------------');
-        l(JSON.stringify(newWindowBounds, null, ' '));
-        // newWindowBounds
         return clipBounds(moved, windowToUpdate.browserWindow);
-        // orig
-        // return clipBounds(newWindowBounds, windowToUpdate.browserWindow);
     };
 
     private checkTrackingApi = (groupLeader: ITransaction): boolean => groupLeader.type === 'api'
@@ -418,7 +412,7 @@ export default class BoundsChangedStateTracker {
             //1 means a change in size.
             //2 means a change in position and size.
             // Default to change in position when there is no change
-            const changeType = (sizeChange ? (posChange ? 2 : 1) : 0);
+            const changeType = (sizeChange ? (posChange ? POSITION_AND_SIZE : SIZE) : POSITION);
 
             const ofWindow = coreState.getWindowByUuidName(this.uuid, this.name);
             const groupUuid = ofWindow ? ofWindow.groupUuid : null;
@@ -460,7 +454,7 @@ export default class BoundsChangedStateTracker {
                     let flags: number;
 
                     //todo 1 means a change in size. this should be a const
-                    if (changeType === 1) {
+                    if (changeType === SIZE) {
                         // this may need to change to 1 or 2 if we fix functionality for changeType 2
                         flags = noZorder + noActivate;
                     } else {
@@ -469,61 +463,32 @@ export default class BoundsChangedStateTracker {
 
                     const windowGroup = WindowGroups.getGroup(groupUuid);
                     const winsToMove = [];
-                    // const adjLists = [];
-
-                    let resizingWindow;
-
                     const positions: Map<string, RectangleBase> = new Map();
+                    const setPositions: Array<() => void> = [];
 
                     for (let i = 0; i < windowGroup.length; i++) {
                         if (windowGroup[i].name !== this.name) {
                             winsToMove.push(windowGroup[i]);
-                            positions.set(windowGroup[i].name, windowGroup[i].browserWindow.getBounds());
-                        } else {
-                            resizingWindow = i;
                         }
+                        positions.set(windowGroup[i].name, windowGroup[i].browserWindow.getBounds());
                     }
-
-                    const adjacencyList = Rectangle.ADJACENCY_LIST(
-                        windowGroup.map(w => Rectangle.CREATE_FROM_BOUNDS(w.browserWindow.getBounds()))
-                    );
-
-                    const leaderAdj: number[] = adjacencyList.get(resizingWindow);
-
-                    // if (changeType !== 0) {
-                    //     winsToMove = winsToMove.filter((v, i) => leaderAdj.includes(i));
-                    // }
-                    // for (let [name, bounds] in positions) {
-
-                    // }
-
-                    // todo make this a delayed commit
-                    const setPositions: Array<() => void> = [];
 
                     for (let i = 0; i < winsToMove.length; i++) {
                         const win = winsToMove[i];
 
-
-                        // const resizingWindow = WindowGroups.getGroup(groupUuid).filter((win): boolean => {
-                        //     return win.name !== this.name;
-                        // });
-
-                        // what makes this needs to be broken apart, state why...
-                        //winsToMove.forEach((win): void => {
                         win.browserWindow.bringToFront(); // maybe just do this once?
-                        //changed
-                        //const winBounds = win.browserWindow.getBounds();
                         const winBounds = positions.get(win.name);
 
-                        //todo 1 means a change in size. this should be a const
-                        const bounds = (changeType === 1)
+                        const bounds = (changeType === SIZE)
                             // here bounds compare and delta are from the window that is resizing
                             ? this.handleGroupedResize(boundsCompare, delta, cachedBounds, win, winBounds)
                             : winBounds;
+
                         let { x, y } = bounds;
                         const { width, height } = bounds;
+
                         // If it is a change in position (working correctly) or a change in position and size (not yet implemented)
-                        if (changeType === 0 || changeType === 2) {
+                        if (changeType === POSITION || changeType === POSITION_AND_SIZE) {
                             x = toSafeInt(x + delta.x, x);
                             y = toSafeInt(y + delta.y, y);
                         }
@@ -545,26 +510,28 @@ export default class BoundsChangedStateTracker {
                             if (win.browserWindow.isMaximized()) {
                                 win.browserWindow.unmaximize();
                             }
-                            const [w, h] = [width, height];
+
                             // no change on the resize behavior
-                            wt.setWindowPos(hwnd, { x, y, w, h, flags });
+                            setPositions.push(() => {
+                                const myBounds = positions.get(win.name);
+                                const { x, y, width, height } = myBounds;
+                                const [w, h] = [width, height];
+                                wt.setWindowPos(hwnd, { x, y, w, h, flags });
+                            });
+
                         } else {
                             if (win.browserWindow.isMaximized()) {
                                 win.browserWindow.unmaximize();
                             }
-                            // no need to call clipBounds here because called earlier
-                            positions.set(win.name, { x, y, width, height });
 
+                            positions.set(win.name, { x, y, width, height });
                             setPositions.push(() => {
                                 win.browserWindow.setBounds(positions.get(win.name));
                             });
                         }
-                        //});
-
                     }
 
                     setPositions.forEach(boundsSet => boundsSet());
-                    // this.calculateAndExecuteWindowMoves();
 
                     if (wt) {
                         wt.commit();
@@ -623,9 +590,9 @@ export default class BoundsChangedStateTracker {
             let posChange = false;
 
             group.forEach((event): void => {
-                if (event.changeType === 0) {
+                if (event.changeType === POSITION) {
                     posChange = true;
-                } else if (event.changeType === 1) {
+                } else if (event.changeType === SIZE) {
                     sizeChange = true;
                 } else {
                     sizeChange = true;
@@ -634,7 +601,7 @@ export default class BoundsChangedStateTracker {
             });
 
             const lastEvent = _.last(group);
-            lastEvent.changeType = (sizeChange ? (posChange ? 2 : 1) : 0);
+            lastEvent.changeType = (sizeChange ? (posChange ? POSITION_AND_SIZE : SIZE) : POSITION);
 
             return lastEvent;
         });

--- a/src/browser/bounds_changed_state_tracker.ts
+++ b/src/browser/bounds_changed_state_tracker.ts
@@ -270,12 +270,6 @@ export default class BoundsChangedStateTracker {
             return bounds;
         }
         let { x, y, width, height } = bounds;
-        // const { x: leaderx, y: leadery, width: leaderwidth, height: leaderheight } = originalWindowCachedBounds;
-        // const thisRect = new Rectangle(x, y, width, height);
-        // const leaderRect = new Rect(leaderx, leadery, leaderwidth, leaderheight);
-        // const intersectionRect = thisRect.intersection(leaderRect.grow(5, 5));
-        // l(intersectionRect);
-        // l('ooooook');
 
         const thisRect = Rectangle.CREATE_FROM_BOUNDS(bounds);
         const leaderRect = Rectangle.CREATE_FROM_BOUNDS(<RectangleBase> originalWindowCachedBounds);
@@ -292,17 +286,6 @@ export default class BoundsChangedStateTracker {
             l('nope');
             // l(sharedBounds);
         }
-
-        const sharedBoundsList = thisRect.sharedBoundsList(leaderRect);
-        const currentBounds = this.getCurrentBounds();
-        const cachedBounds = this.getCachedBounds();
-
-        l(sharedBoundsList);
-        l(`current: ${currentBounds}, cached: ${cachedBounds}`);
-        l(Rectangle.CREATE_FROM_BOUNDS(cachedBounds).delta(Rectangle.CREATE_FROM_BOUNDS(currentBounds)));
-        l('and the \'real\' delta...');
-        l(delta);
-
         const intersection = !intersectionRect.isEmpty();
         if (intersection) {
             if (resizeChangeType.height) {
@@ -360,6 +343,24 @@ export default class BoundsChangedStateTracker {
             }
         }
         const newWindowBounds = { x, y, width, height };
+
+        const sharedBoundsList = thisRect.sharedBoundsList(leaderRect);
+        const currentBounds = this.getCurrentBounds();
+        const cachedBounds = this.getCachedBounds();
+        const d2 = Rectangle.CREATE_FROM_BOUNDS(cachedBounds).delta(Rectangle.CREATE_FROM_BOUNDS(currentBounds));
+
+        const moved = thisRect.move(sharedBoundsList, d2);
+
+        l(JSON.stringify(thisRect.bounds, null, ' '));
+        l('---------------!!!------------------');
+        l(JSON.stringify(d2, null, ' '));
+        l('---------------###------------------');
+        l(JSON.stringify(delta, null, ' '));
+        l('---------------()()()()------------------');
+        l(JSON.stringify(moved, null, ' '));
+        l('---------------###------------------');
+        l(JSON.stringify(newWindowBounds, null, ' '));
+        // newWindowBounds
         return clipBounds(newWindowBounds, windowToUpdate.browserWindow);
     };
 

--- a/src/browser/bounds_changed_state_tracker.ts
+++ b/src/browser/bounds_changed_state_tracker.ts
@@ -348,8 +348,7 @@ export default class BoundsChangedStateTracker {
         const currentBounds = this.getCurrentBounds();
         const cachedBounds = this.getCachedBounds();
         const d2 = Rectangle.CREATE_FROM_BOUNDS(cachedBounds).delta(Rectangle.CREATE_FROM_BOUNDS(currentBounds));
-
-        const moved = thisRect.move(sharedBoundsList, d2);
+        const moved = thisRect.move2(cachedBounds, currentBounds);
 
         l(JSON.stringify(thisRect.bounds, null, ' '));
         l('---------------!!!------------------');
@@ -361,7 +360,9 @@ export default class BoundsChangedStateTracker {
         l('---------------###------------------');
         l(JSON.stringify(newWindowBounds, null, ' '));
         // newWindowBounds
-        return clipBounds(newWindowBounds, windowToUpdate.browserWindow);
+        return clipBounds(moved, windowToUpdate.browserWindow);
+        // orig
+        // return clipBounds(newWindowBounds, windowToUpdate.browserWindow);
     };
 
     private checkTrackingApi = (groupLeader: ITransaction): boolean => groupLeader.type === 'api'

--- a/src/browser/rectangle.ts
+++ b/src/browser/rectangle.ts
@@ -73,27 +73,13 @@ export class Rectangle {
         return this.x + this.width;
     }
 
-    // set right(num: number) {
-    //     if (num > this.)
-    // }
-
     get bottom(): number {
         return this.y + this.height;
     }
 
-    // set bottom(num: number) {
-    //     if (num > this.top) {
-    //         this.height = num;
-    //     }
-    // }
-
     get top() {
         return this.y;
     }
-
-    // set top(num: number) {
-    //     this.y = num;
-    // }
 
     get left() {
         return this.x;
@@ -300,16 +286,15 @@ export class Rectangle {
                 this.width += (xInitial - this.x); 
             } break;
             case "right": {
-                this.width += (rect[sideToAlign] - (this.x +this.width));
+                this.width += (rect[sideToAlign] - (this.x + this.width));
             } break;
-            case "top": { // this is fucked
+            case "top": {
                 const yInitial = this.y;
                 this.y = rect[sideToAlign];
                 this.height += (yInitial - this.y); 
             } break;
             case "bottom": {
-                // made it too big! 
-                this.height += (rect[sideToAlign] - (this.y +this.height));
+                this.height += (rect[sideToAlign] - (this.y + this.height));
             } break;
 
         }
@@ -344,17 +329,17 @@ export class Rectangle {
             'left': 'right'
         };
 
-        console.log(' ');
-        console.log(JSON.stringify(bounds, null, ' '));
-        console.log('.............');
-        console.log(JSON.stringify(delta, null, ' '));
+        // console.log(' ');
+        // console.log(JSON.stringify(bounds, null, ' '));
+        // console.log('.............');
+        // console.log(JSON.stringify(delta, null, ' '));
 
         // tslint:disable
         // console.log(JSON.stringify(movementTranslation, null, ' '));
         for (let [thisRectSharedSide, otherRectSharedSide] of sharedBounds) {
-            console.log(`${thisRectSharedSide}, ${otherRectSharedSide}. ${movementTranslation[thisRectSharedSide]}`);
+            // console.log(`${thisRectSharedSide}, ${otherRectSharedSide}. ${movementTranslation[thisRectSharedSide]}`);
             const translation = movementTranslation[thisRectSharedSide];
-            console.log(`&&& ${translation}, ${delta[translation]}` );
+            // console.log(`&&& ${translation}, ${delta[translation]}` );
             /*
                 right, left
                 {"x":9,"y":0,"width":-9,"height":0}
@@ -364,26 +349,42 @@ export class Rectangle {
            if (this.edgeMoved([thisRectSharedSide, otherRectSharedSide], delta)) {
                const deltaOtherSide = delta[movementTranslation[otherRectSharedSide]];
                const deltaOtherCorrSide = delta[movementTranslation[correspondingSide[otherRectSharedSide]]];
-               console.log(`transition ${translation} (${bounds[translation]}): ${(deltaOtherSide + deltaOtherCorrSide)}`);
+               // console.log(`transition ${translation} (${bounds[translation]}): ${(deltaOtherSide + deltaOtherCorrSide)}`);
 
-            bounds[translation] += deltaOtherSide; //(deltaOtherSide + deltaOtherCorrSide);
+            bounds[translation] += deltaOtherSide;
 
             if (!(thisRectSharedSide === otherRectSharedSide)) {
                 bounds[movementTranslation[correspondingSide[thisRectSharedSide]]] += -(deltaOtherSide + deltaOtherCorrSide);
-                console.log('this and that...', movementTranslation[correspondingSide[otherRectSharedSide]], ' ',
-                movementTranslation[correspondingSide[thisRectSharedSide]], -(deltaOtherSide + deltaOtherCorrSide));
+                // console.log('this and that...', movementTranslation[correspondingSide[otherRectSharedSide]], ' ',
+                // movementTranslation[correspondingSide[thisRectSharedSide]], -(deltaOtherSide + deltaOtherCorrSide));
             }
-            
-            // figure out if that movement impacts my size
-            // if (!delta[movementTranslation[correspondingSide[otherRectSharedSide]]]) {
-            //     // console.log('this and that...', movementTranslation[correspondingSide[otherRectSharedSide]])
-            //     bounds[movementTranslation[correspondingSide[thisRectSharedSide]]] += -(deltaOtherSide + deltaOtherCorrSide)
-            // }
            }
-           // + delta[movementTranslation[correspondingSide[otherRectSharedSide]]]
         }
 
         return bounds;
+    }
+
+    public static ADJACENCY_LIST(rects: Rectangle[]) {
+        const adjLists = new Map();
+        const rectLen = rects.length;
+
+        for (let i = 0; i < rectLen; i++) {
+            const adjacentRects = [];
+            const rect = rects[i];
+
+            for (let ii = 0; ii < rectLen; ii++) {
+                if (i !== ii) {
+                    if (rect.sharedBounds(rects[ii]).hasSharedBounds) {
+                        adjacentRects.push(rects[ii]);
+                        adjacentRects.push(ii);
+                    }
+                }
+            }
+
+            adjLists.set(i, adjacentRects);
+        }
+
+        return adjLists;
     }
 }
 

--- a/src/browser/rectangle.ts
+++ b/src/browser/rectangle.ts
@@ -1,12 +1,4 @@
-import * as log from './log';
-const l = (x: any) => log.writeToLog(1, x, true);
-
-// import * as log from './log';
-// const l = (x: any) => console.log.writeToLog(1, x, true);
-
 type SideName = 'top' | 'right' | 'bottom' | 'left';
-type SharedBound = Array<SideName>;
-export type SharedBoundsList = Array<SharedBound>;
 type SharedBounds = {
     hasSharedBounds: boolean;
     top: SideName;
@@ -14,6 +6,9 @@ type SharedBounds = {
     bottom: SideName;
     left: SideName;
 };
+type SharedBound = Array<SideName>;
+type RectangleBaseKeys = 'x' | 'y' | 'width' | 'height';
+export type SharedBoundsList = Array<SharedBound>;
 
 interface Opts {
     minWidth?: number;
@@ -22,8 +17,6 @@ interface Opts {
     maxHeight?: number;
 }
 
-type RectangleBaseKeys = 'x' | 'y' | 'width' | 'height';
-
 export interface RectangleBase {
     x: number;
     y: number;
@@ -31,14 +24,12 @@ export interface RectangleBase {
     height: number;
 }
 
-// todo, does this make sense?
 class RectOptionsOpts {
     public minWidth?: number;
     public maxWidth?: number;
     public minHeight?: number;
     public maxHeight?: number;
 
-    // todo test this
     constructor(opts: Opts) {
         // when resizing, dont let the window get so small you cant see it / grab it
         this.minWidth = Math.max(opts.minWidth || 10, 10);
@@ -61,7 +52,6 @@ export class Rectangle {
     public opts: Opts;
     public boundShareThreshold = 5;
 
-    // todo check the constructor here...
     constructor (x: number, y: number, width: number, height: number, opts: Opts = {}) {
         this.x = x;
         this.y = y;
@@ -97,75 +87,49 @@ export class Rectangle {
 
     // tslint:disable 
     public grow(h: number, v: number): Rectangle {
-        let x0: number = this.x;
-        let y0: number = this.y;
-        let x1: number = this.width;
-        let y1: number = this.height;
+        let x: number = this.x;
+        let y: number = this.y;
+        let width: number = this.width;
+        let height: number = this.height;
 
-        let x0Sign: number = this.x > 0 ? 1 : -1;
-        let y0Sign: number = this.y > 0 ? 1 : -1;
-        //let x1Sign: number = this.width > 0 ? 1 : -1;
-        // let y1Sign: number = this.height > 0 ? 1 : -1;
+        width += x;
+        height += y;
 
-        // x0 = Math.abs(x0);
-        // y0 = Math.abs(y0);
+        x -= h;
+        y -= v;
+        width += h;
+        height += v;
 
-        // // these should not be neg ever...
-        // x1 = Math.abs(x1);
-        // y1 = Math.abs(y1);
-
-        x1 += x0;
-        y1 += y0;
-
-        x0 -= h; // * x0Sign;
-        y0 -= v; // * y0Sign;
-        x1 += h;
-        y1 += v;
-
-        if (x1 < x0) {
-            // Non-existant in X direction
-            // Final width must remain negative so subtract x0 before
-            // it is clipped so that we avoid the risk that the clipping
-            // of x0 will reverse the ordering of x0 and x1.
-            x1 -= x0;
-            if (x1 < Number.MIN_SAFE_INTEGER) x1 = Number.MIN_SAFE_INTEGER;
-            if (x0 < Number.MIN_SAFE_INTEGER) x0 = Number.MIN_SAFE_INTEGER;
-            else if (x0 > Number.MAX_VALUE) x0 = Number.MAX_VALUE;
-        } else { // (x1 >= x0)
-            // Clip x0 before we subtract it from x1 in case the clipping
-            // affects the representable area of the rectangle.
-            if (x0 < Number.MIN_SAFE_INTEGER) x0 = Number.MIN_SAFE_INTEGER;
-            else if (x0 > Number.MAX_VALUE) x0 = Number.MAX_VALUE;
-            x1 -= x0;
-            // The only way x1 can be negative now is if we clipped
-            // x0 against MIN and x1 is less than MIN - in which case
-            // we want to leave the width negative since the result
-            // did not intersect the representable area.
-            if (x1 < Number.MIN_SAFE_INTEGER) x1 = Number.MIN_SAFE_INTEGER;
-            else if (x1 > Number.MAX_VALUE) x1 = Number.MAX_VALUE;
+        if (width < x) {
+            width -= x;
+            if (width < Number.MIN_SAFE_INTEGER) width = Number.MIN_SAFE_INTEGER;
+            if (x < Number.MIN_SAFE_INTEGER) x = Number.MIN_SAFE_INTEGER;
+            else if (x > Number.MAX_VALUE) x = Number.MAX_VALUE;
+        } else {
+            if (x < Number.MIN_SAFE_INTEGER) x = Number.MIN_SAFE_INTEGER;
+            else if (x > Number.MAX_VALUE) x = Number.MAX_VALUE;
+            width -= x;
+            if (width < Number.MIN_SAFE_INTEGER) width = Number.MIN_SAFE_INTEGER;
+            else if (width > Number.MAX_VALUE) width = Number.MAX_VALUE;
         }
 
-        if (y1 < y0) {
-            // Non-existant in Y direction
-            y1 -= y0;
-            if (y1 < Number.MIN_SAFE_INTEGER) y1 = Number.MIN_SAFE_INTEGER;
-            if (y0 < Number.MIN_SAFE_INTEGER) y0 = Number.MIN_SAFE_INTEGER;
-            else if (y0 > Number.MAX_VALUE) y0 = Number.MAX_VALUE;
-        } else { // (y1 >= y0)
-            if (y0 < Number.MIN_SAFE_INTEGER) y0 = Number.MIN_SAFE_INTEGER;
-            else if (y0 > Number.MAX_VALUE) y0 = Number.MAX_VALUE;
-            y1 -= y0;
-            if (y1 < Number.MIN_SAFE_INTEGER) y1 = Number.MIN_SAFE_INTEGER;
-            else if (y1 > Number.MAX_VALUE) y1 = Number.MAX_VALUE;
+        if (height < y) {
+            height -= y;
+            if (height < Number.MIN_SAFE_INTEGER) height = Number.MIN_SAFE_INTEGER;
+            if (y < Number.MIN_SAFE_INTEGER) y = Number.MIN_SAFE_INTEGER;
+            else if (y > Number.MAX_VALUE) y = Number.MAX_VALUE;
+        } else {
+            if (y < Number.MIN_SAFE_INTEGER) y = Number.MIN_SAFE_INTEGER;
+            else if (y > Number.MAX_VALUE) y = Number.MAX_VALUE;
+            height -= y;
+            if (height < Number.MIN_SAFE_INTEGER) height = Number.MIN_SAFE_INTEGER;
+            else if (height > Number.MAX_VALUE) height = Number.MAX_VALUE;
         }
 
-        return new Rectangle(x0, y0, x1, y1);
+        return new Rectangle(x, y, width, height);
     }
+    // ts-lint:enable
     
-    public isEmpty(): boolean {
-        return (this.width <= 0.0001) || (this.height <= 0.0001);
-    }
-
     public collidesWith (rect: RectangleBase) {
         const {x, y, width, height } = rect;
         let collision = false;
@@ -179,32 +143,6 @@ export class Rectangle {
 
         return collision;
     }
-
-    // todo revisit this for external monitor 
-    public intersection(r: Rectangle): Rectangle {
-        let tx1: number = this.x;
-        let ty1: number = this.y;
-        const rx1: number = r.x;
-        const ry1: number = r.y;
-        let tx2: number = tx1; tx2 += this.width;
-        let ty2: number = ty1; ty2 += this.height;
-        let rx2: number = rx1; rx2 += r.width;
-        let ry2: number = ry1; ry2 += r.height;
-        if (tx1 < rx1) tx1 = rx1;
-        if (ty1 < ry1) ty1 = ry1;
-        if (tx2 > rx2) tx2 = rx2;
-        if (ty2 > ry2) ty2 = ry2;
-        tx2 -= tx1;
-        ty2 -= ty1;
-        // tx2,ty2 will never overflow (they will never be
-        // larger than the smallest of the two source w,h)
-        // they might underflow, though...
-        if (tx2 < Number.MIN_SAFE_INTEGER) tx2 = Number.MIN_SAFE_INTEGER;
-        if (ty2 < Number.MIN_SAFE_INTEGER) ty2 = Number.MIN_SAFE_INTEGER;
-        return new Rectangle(tx1, ty1, tx2, ty2);
-    }
-    // ts-lint:enable
-
 
     // note this does not match both... just note it
     private sharedBound(side: SideName, rect: Rectangle): SideName {
@@ -288,9 +226,6 @@ export class Rectangle {
 
     // this is only for resize, move would be different
     private edgeMoved(pair: Array<SideName>, delta: RectangleBase): boolean {
-        // { "x": 0, "y": 0, "width":  0, "height": -4 }    => bottom
-        // { "x": 9, "y": 0, "width": -9, "height":  0 }    => left
-        // { "x": 0, "y": 0, "width": -9, "height":  0 }    => right
         const {x, y, width, height } = delta;
         const [mySide, otherRectSharedSide] = pair;
 
@@ -326,7 +261,7 @@ export class Rectangle {
         }
     }
 
-    public move2(cachedBounds: RectangleBase, currentBounds: RectangleBase) {
+    public move(cachedBounds: RectangleBase, currentBounds: RectangleBase) {
         const sharedBoundsList = this.sharedBoundsList(Rectangle.CREATE_FROM_BOUNDS(cachedBounds));
         const currLeader = Rectangle.CREATE_FROM_BOUNDS(currentBounds);
         const delta = Rectangle.CREATE_FROM_BOUNDS(cachedBounds).delta(currLeader);
@@ -340,50 +275,6 @@ export class Rectangle {
         return this.bounds;
     }
 
-    public move(sharedBounds: SharedBoundsList, delta: RectangleBase) {
-        const bounds = this.bounds;
-        const movementTranslation: MovementTranslation = {
-            left: 'x',
-            top: 'y',
-            right: 'width',
-            bottom: 'height'
-        };
-        const correspondingSide: {[S in SideName]: SideName}= {
-            'top': 'bottom',
-            'bottom': 'top',
-            'right': 'left',
-            'left': 'right'
-        };
-
-        // tslint:disable
-        for (let [thisRectSharedSide, otherRectSharedSide] of sharedBounds) {
-            // console.log(`${thisRectSharedSide}, ${otherRectSharedSide}. ${movementTranslation[thisRectSharedSide]}`);
-            const translation = movementTranslation[thisRectSharedSide];
-            // console.log(`&&& ${translation}, ${delta[translation]}` );
-            /*
-                right, left
-                {"x":9,"y":0,"width":-9,"height":0}
-            */
-           // figure out if the side that moves impacts my position
-           // LOCATION AND SIZE ARE DIFFERENT AND NEED TO BE HANDLED DIFFERENTLY!!!
-           if (this.edgeMoved([thisRectSharedSide, otherRectSharedSide], delta)) {
-               const deltaOtherSide = delta[movementTranslation[otherRectSharedSide]];
-               const deltaOtherCorrSide = delta[movementTranslation[correspondingSide[otherRectSharedSide]]];
-               // console.log(`transition ${translation} (${bounds[translation]}): ${(deltaOtherSide + deltaOtherCorrSide)}`);
-
-            bounds[translation] += deltaOtherSide;
-
-            if (!(thisRectSharedSide === otherRectSharedSide)) {
-                bounds[movementTranslation[correspondingSide[thisRectSharedSide]]] += -(deltaOtherSide + deltaOtherCorrSide);
-                // console.log('this and that...', movementTranslation[correspondingSide[otherRectSharedSide]], ' ',
-                // movementTranslation[correspondingSide[thisRectSharedSide]], -(deltaOtherSide + deltaOtherCorrSide));
-            }
-           }
-        }
-
-        return bounds;
-    }
-
     public static ADJACENCY_LIST(rects: Rectangle[]) {
         const adjLists = new Map();
         const rectLen = rects.length;
@@ -395,7 +286,6 @@ export class Rectangle {
             for (let ii = 0; ii < rectLen; ii++) {
                 if (i !== ii) {
                     if (rect.sharedBounds(rects[ii]).hasSharedBounds) {
-                        // adjacentRects.push(rects[ii]);
                         adjacentRects.push(ii);
                     }
                 }
@@ -407,17 +297,3 @@ export class Rectangle {
         return adjLists;
     }
 }
-
-// type SideName = 'top' | 'right' | 'bottom' | 'left';
-type MovementTranslation = {[S in SideName]: RectangleBaseKeys};
-
-// export interface RectangleBase {
-//     x: number;
-//     y: number;
-//     width: number;
-//     height: number;
-// }
-
-// interface MovementTranslation {
-//     [name: SideName]: SideName;
-// }

--- a/src/browser/rectangle.ts
+++ b/src/browser/rectangle.ts
@@ -302,64 +302,31 @@ export class Rectangle {
             case "right": {
                 this.width += (rect[sideToAlign] - (this.x +this.width));
             } break;
-            case "top": {
+            case "top": { // this is fucked
                 const yInitial = this.y;
                 this.y = rect[sideToAlign];
-                this.height += (yInitial - this.height); 
+                this.height += (yInitial - this.y); 
             } break;
             case "bottom": {
-                this.height = rect[sideToAlign];
+                // made it too big! 
+                this.height += (rect[sideToAlign] - (this.y +this.height));
             } break;
 
         }
     }
 
     public move2(cachedBounds: RectangleBase, currentBounds: RectangleBase) {
-        // const bounds = this.bounds;
         const sharedBoundsList = this.sharedBoundsList(Rectangle.CREATE_FROM_BOUNDS(cachedBounds));
         const currLeader = Rectangle.CREATE_FROM_BOUNDS(currentBounds);
         const delta = Rectangle.CREATE_FROM_BOUNDS(cachedBounds).delta(currLeader);
-        const mt: MovementTranslation = {
-            left: 'x',
-            top: 'y',
-            right: 'width',
-            bottom: 'height'
-        };
-
-        const correspondingSide: {[S in SideName]: SideName}= {
-            'top': 'bottom',
-            'bottom': 'top',
-            'right': 'left',
-            'left': 'right'
-        };
 
         for (let [thisRectSharedSide, otherRectSharedSide] of sharedBoundsList) {
             if (this.edgeMoved([thisRectSharedSide, otherRectSharedSide], delta)) {
-                const deltaOtherSide = delta[mt[otherRectSharedSide]];
-                const deltaOtherCorrSide = delta[mt[correspondingSide[otherRectSharedSide]]];
-                const foo = mt[thisRectSharedSide];
-                
-                this.alignSide(thisRectSharedSide, currLeader, otherRectSharedSide)
-                // if (foo === 'x') {
-                //     bounds[foo] = currentBounds[mt[otherRectSharedSide]]
-                //     bounds.width += -deltaOtherSide;
-                // }
-                // if (foo === 'y') {
-                //     bounds[foo] = currentBounds[mt[otherRectSharedSide]]
-                //     bounds.height += -deltaOtherSide;
-                // }
-                // if (foo === 'width' || foo === 'height') {
-                //     bounds[foo] += deltaOtherSide
-                // }
-
-                // if (!(thisRectSharedSide === otherRectSharedSide)) {
-                //     bounds[mt[correspondingSide[thisRectSharedSide]]] += -(deltaOtherSide + deltaOtherCorrSide);
-                // }
+                this.alignSide(thisRectSharedSide, currLeader, otherRectSharedSide);
             }
         }
 
         return this.bounds;
-        
     }
 
     public move(sharedBounds: SharedBoundsList, delta: RectangleBase) {

--- a/src/browser/rectangle.ts
+++ b/src/browser/rectangle.ts
@@ -1,0 +1,252 @@
+import * as log from './log';
+const l = (x: any) => log.writeToLog(1, x, true);
+
+type SideName = 'top' | 'right' | 'bottom' | 'left';
+
+interface Opts {
+    minWidth?: number;
+    maxWidth?: number;
+    minHeight?: number;
+    maxHeight?: number;
+}
+
+// todo, does this make sense?
+class RectOptionsOpts {
+    public minWidth?: number;
+    public maxWidth?: number;
+    public minHeight?: number;
+    public maxHeight?: number;
+
+    constructor(opts: Opts) {
+        // when resizing, dont let the window get so small you cant see it / grab it
+        this.minWidth = Math.max(opts.minWidth || 10, 10);
+        this.maxWidth = opts.maxWidth || Number.MAX_SAFE_INTEGER;
+        this.minHeight = Math.max(opts.maxHeight || 10, 10);
+        this.maxHeight = opts.maxHeight || Number.MAX_SAFE_INTEGER;
+    }
+}
+
+export interface RectangleBase {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+}
+
+export class Rectangle {
+    public static CREATE_FROM_BOUNDS(rect: RectangleBase, opts: Opts = {}): Rectangle {
+        const { x, y, width, height } = rect;
+        return new Rectangle(x, y, width, height, new RectOptionsOpts(opts));
+    }
+
+    public x: number;
+    public y: number;
+    public width: number;
+    public height: number;
+    public opts: Opts;
+    public boundShareThreshold = 5;
+
+    // todo check the constructor here...
+    constructor (x: number, y: number, width: number, height: number, opts: Opts = {}) {
+        this.x = x;
+        this.y = y;
+        this.width = width;
+        this.height = height;
+        this.opts = new RectOptionsOpts(opts);
+    }
+
+    get right(): number {
+        return this.x + this.width;
+    }
+
+    get bottom(): number {
+        return this.y + this.height;
+    }
+
+    get top() {
+        return this.y;
+    }
+
+    get left() {
+        return this.x;
+    }
+
+    // public hasAdjacentEdge (r: Rectangle): { hasAdjacency: boolean, sharedEdge: string } {
+    //     const intersectionRect = this.intersection(r.grow(5, 5));
+
+    //     const intersection = !intersectionRect.isEmpty();
+
+    //     if (!intersection) { return { hasAdjacency: false, sharedEdge: null }; }
+
+    // }
+
+    // tslint:disable 
+    public grow(h: number, v: number): Rectangle {
+        let x0: number = this.x;
+        let y0: number = this.y;
+        let x1: number = this.width;
+        let y1: number = this.height;
+        x1 += x0;
+        y1 += y0;
+
+        x0 -= h;
+        y0 -= v;
+        x1 += h;
+        y1 += v;
+
+        if (x1 < x0) {
+            // Non-existant in X direction
+            // Final width must remain negative so subtract x0 before
+            // it is clipped so that we avoid the risk that the clipping
+            // of x0 will reverse the ordering of x0 and x1.
+            x1 -= x0;
+            if (x1 < Number.MIN_VALUE) x1 = Number.MIN_VALUE;
+            if (x0 < Number.MIN_VALUE) x0 = Number.MIN_VALUE;
+            else if (x0 > Number.MAX_VALUE) x0 = Number.MAX_VALUE;
+        } else { // (x1 >= x0)
+            // Clip x0 before we subtract it from x1 in case the clipping
+            // affects the representable area of the rectangle.
+            if (x0 < Number.MIN_VALUE) x0 = Number.MIN_VALUE;
+            else if (x0 > Number.MAX_VALUE) x0 = Number.MAX_VALUE;
+            x1 -= x0;
+            // The only way x1 can be negative now is if we clipped
+            // x0 against MIN and x1 is less than MIN - in which case
+            // we want to leave the width negative since the result
+            // did not intersect the representable area.
+            if (x1 < Number.MIN_VALUE) x1 = Number.MIN_VALUE;
+            else if (x1 > Number.MAX_VALUE) x1 = Number.MAX_VALUE;
+        }
+
+        if (y1 < y0) {
+            // Non-existant in Y direction
+            y1 -= y0;
+            if (y1 < Number.MIN_VALUE) y1 = Number.MIN_VALUE;
+            if (y0 < Number.MIN_VALUE) y0 = Number.MIN_VALUE;
+            else if (y0 > Number.MAX_VALUE) y0 = Number.MAX_VALUE;
+        } else { // (y1 >= y0)
+            if (y0 < Number.MIN_VALUE) y0 = Number.MIN_VALUE;
+            else if (y0 > Number.MAX_VALUE) y0 = Number.MAX_VALUE;
+            y1 -= y0;
+            if (y1 < Number.MIN_VALUE) y1 = Number.MIN_VALUE;
+            else if (y1 > Number.MAX_VALUE) y1 = Number.MAX_VALUE;
+        }
+
+        return new Rectangle(x0, y0, x1, y1);
+    }
+    
+    public isEmpty(): boolean {
+        return (this.width <= 0.0001) || (this.height <= 0.0001);
+    }
+
+    // todo revisit this for external monitor 
+    public intersection(r: Rectangle): Rectangle {
+        let tx1: number = this.x;
+        let ty1: number = this.y;
+        const rx1: number = r.x;
+        const ry1: number = r.y;
+        let tx2: number = tx1; tx2 += this.width;
+        let ty2: number = ty1; ty2 += this.height;
+        let rx2: number = rx1; rx2 += r.width;
+        let ry2: number = ry1; ry2 += r.height;
+        if (tx1 < rx1) tx1 = rx1;
+        if (ty1 < ry1) ty1 = ry1;
+        if (tx2 > rx2) tx2 = rx2;
+        if (ty2 > ry2) ty2 = ry2;
+        tx2 -= tx1;
+        ty2 -= ty1;
+        // tx2,ty2 will never overflow (they will never be
+        // larger than the smallest of the two source w,h)
+        // they might underflow, though...
+        if (tx2 < Number.MIN_VALUE) tx2 = Number.MIN_VALUE;
+        if (ty2 < Number.MIN_VALUE) ty2 = Number.MIN_VALUE;
+        return new Rectangle(tx1, ty1, tx2, ty2);
+    }
+    // ts-lint:enable
+
+
+    // note this does not match both... just note it
+    private sharedBound(side: SideName, rect: Rectangle): SideName {
+        let delta: SideName;
+        let oppositeDelta: SideName;
+
+        switch (side) {
+            case "top":
+            case "bottom": {
+                delta = 'top';
+                oppositeDelta = 'bottom'
+            } break;
+            case "left":
+            case "right": {
+                delta = 'left';
+                oppositeDelta = 'right';
+            }
+        }
+
+        if (Math.abs(this[side] - rect[delta]) <= this.boundShareThreshold) {
+            return delta;
+        }
+
+        if (Math.abs(this[side] - rect[oppositeDelta]) <= this.boundShareThreshold) {
+            return oppositeDelta;
+        }
+
+        return null;
+    }
+
+
+
+    public sharedBounds(rect: Rectangle): {hasSharedBounds: boolean, top: string, right: string, bottom: string, left: string} {
+        const intersectionRect = this.intersection(rect.grow(this.boundShareThreshold, this.boundShareThreshold));
+        const intersection = !intersectionRect.isEmpty();
+
+        l('ogging')
+        l(rect);
+    
+        l(this);
+
+        let hasSharedBounds = false;
+        let top: string = null;
+        let right: string = null;
+        let bottom: string = null;
+        let left: string = null;
+
+        if (!intersection) {
+            return {hasSharedBounds, top, right, bottom, left};
+        }
+
+        // what about if the top and bottom are in the same range... a super small window
+        top = this.sharedBound('top', rect);
+        right = this.sharedBound('right', rect);
+        bottom = this.sharedBound('bottom', rect);
+        left = this.sharedBound('left', rect);
+
+        hasSharedBounds = !!(top || right || bottom || left);
+
+        return {hasSharedBounds, top, right, bottom, left};
+    }
+
+    public sharedBoundsList(rect: Rectangle) {
+        const sides: Array<SideName> = ['top', 'right', 'left', 'bottom'];
+        const sharedBounds = this.sharedBounds(rect);
+
+        return sides.map(side => {
+            const correspondingSide = sharedBounds[side];
+            let pair;
+
+            if (correspondingSide) {
+                return [side, correspondingSide]
+            }
+
+            return pair;
+        }).filter(x => x);
+    }
+
+    public delta(rect: Rectangle): RectangleBase {
+        return {
+            x: rect.x - this.x,
+            y: rect.y - this.y,
+            width: rect.width - this.width,
+            height: rect.height - this.height
+        }
+    }
+}

--- a/src/browser/rectangle.ts
+++ b/src/browser/rectangle.ts
@@ -1,7 +1,7 @@
-// import * as log from './log';
-// const l = (x: any) => log.writeToLog(1, x, true);
+import * as log from './log';
+const l = (x: any) => log.writeToLog(1, x, true);
 
-//import * as log from './log';
+// import * as log from './log';
 // const l = (x: any) => console.log.writeToLog(1, x, true);
 
 type SideName = 'top' | 'right' | 'bottom' | 'left';
@@ -90,6 +90,10 @@ export class Rectangle {
     get top() {
         return this.y;
     }
+
+    // set top(num: number) {
+    //     this.y = num;
+    // }
 
     get left() {
         return this.x;
@@ -285,6 +289,79 @@ export class Rectangle {
         return movedSides.has(otherRectSharedSide);
     }
 
+
+    public alignSide(mySide: SideName, rect: Rectangle , sideToAlign: SideName) {
+        // left is joined to right is different than right is joined to left! 
+        l(`$$$$$$$$$$$$$$$$$ mySide: ${mySide}, sideToAlign: ${sideToAlign}`)
+        switch (mySide){
+            case "left": {
+                const xInitial = this.x;
+                this.x = rect[sideToAlign];
+                this.width += (xInitial - this.x); 
+            } break;
+            case "right": {
+                this.width += (rect[sideToAlign] - (this.x +this.width));
+            } break;
+            case "top": {
+                const yInitial = this.y;
+                this.y = rect[sideToAlign];
+                this.height += (yInitial - this.height); 
+            } break;
+            case "bottom": {
+                this.height = rect[sideToAlign];
+            } break;
+
+        }
+    }
+
+    public move2(cachedBounds: RectangleBase, currentBounds: RectangleBase) {
+        // const bounds = this.bounds;
+        const sharedBoundsList = this.sharedBoundsList(Rectangle.CREATE_FROM_BOUNDS(cachedBounds));
+        const currLeader = Rectangle.CREATE_FROM_BOUNDS(currentBounds);
+        const delta = Rectangle.CREATE_FROM_BOUNDS(cachedBounds).delta(currLeader);
+        const mt: MovementTranslation = {
+            left: 'x',
+            top: 'y',
+            right: 'width',
+            bottom: 'height'
+        };
+
+        const correspondingSide: {[S in SideName]: SideName}= {
+            'top': 'bottom',
+            'bottom': 'top',
+            'right': 'left',
+            'left': 'right'
+        };
+
+        for (let [thisRectSharedSide, otherRectSharedSide] of sharedBoundsList) {
+            if (this.edgeMoved([thisRectSharedSide, otherRectSharedSide], delta)) {
+                const deltaOtherSide = delta[mt[otherRectSharedSide]];
+                const deltaOtherCorrSide = delta[mt[correspondingSide[otherRectSharedSide]]];
+                const foo = mt[thisRectSharedSide];
+                
+                this.alignSide(thisRectSharedSide, currLeader, otherRectSharedSide)
+                // if (foo === 'x') {
+                //     bounds[foo] = currentBounds[mt[otherRectSharedSide]]
+                //     bounds.width += -deltaOtherSide;
+                // }
+                // if (foo === 'y') {
+                //     bounds[foo] = currentBounds[mt[otherRectSharedSide]]
+                //     bounds.height += -deltaOtherSide;
+                // }
+                // if (foo === 'width' || foo === 'height') {
+                //     bounds[foo] += deltaOtherSide
+                // }
+
+                // if (!(thisRectSharedSide === otherRectSharedSide)) {
+                //     bounds[mt[correspondingSide[thisRectSharedSide]]] += -(deltaOtherSide + deltaOtherCorrSide);
+                // }
+            }
+        }
+
+        return this.bounds;
+        
+    }
+
     public move(sharedBounds: SharedBoundsList, delta: RectangleBase) {
         const bounds = this.bounds;
         const movementTranslation: MovementTranslation = {
@@ -321,13 +398,15 @@ export class Rectangle {
                const deltaOtherSide = delta[movementTranslation[otherRectSharedSide]];
                const deltaOtherCorrSide = delta[movementTranslation[correspondingSide[otherRectSharedSide]]];
                console.log(`transition ${translation} (${bounds[translation]}): ${(deltaOtherSide + deltaOtherCorrSide)}`);
-               
+
             bounds[translation] += deltaOtherSide; //(deltaOtherSide + deltaOtherCorrSide);
 
-            bounds[movementTranslation[correspondingSide[thisRectSharedSide]]] += -(deltaOtherSide + deltaOtherCorrSide);
-            console.log('this and that...', movementTranslation[correspondingSide[otherRectSharedSide]], ' ',
-            movementTranslation[correspondingSide[thisRectSharedSide]], -(deltaOtherSide + deltaOtherCorrSide));
-
+            if (!(thisRectSharedSide === otherRectSharedSide)) {
+                bounds[movementTranslation[correspondingSide[thisRectSharedSide]]] += -(deltaOtherSide + deltaOtherCorrSide);
+                console.log('this and that...', movementTranslation[correspondingSide[otherRectSharedSide]], ' ',
+                movementTranslation[correspondingSide[thisRectSharedSide]], -(deltaOtherSide + deltaOtherCorrSide));
+            }
+            
             // figure out if that movement impacts my size
             // if (!delta[movementTranslation[correspondingSide[otherRectSharedSide]]]) {
             //     // console.log('this and that...', movementTranslation[correspondingSide[otherRectSharedSide]])

--- a/src/browser/utils.ts
+++ b/src/browser/utils.ts
@@ -57,13 +57,18 @@ export function clipBounds(bounds: Rectangle, browserWindow: BrowserWindow): Rec
   const { minWidth, minHeight, maxWidth, maxHeight } = browserWindow._options;
 
   const xclamp = clamp(bounds.width, minWidth, maxWidth);
-  log.writeToLog(1, xclamp, true);
   log.writeToLog(1, browserWindow._options.name, true);
-
+  log.writeToLog(1, xclamp, true);
   const yclamp = clamp(bounds.height, minHeight, maxHeight);
+  log.writeToLog(1, yclamp, true);
+
+  if (yclamp.clampedOffsetHigh < 0) {
+    // !! reprop the move and (remeasure???)
+  }
+
   return {
-    x: bounds.x + xclamp.clampedOffset,
-    y: bounds.y,
+    x: bounds.x + xclamp.clampedOffsetLow,
+    y: bounds.y + yclamp.clampedOffsetHigh,
     width: xclamp.value,
     height: yclamp.value
   };
@@ -73,11 +78,15 @@ export function clipBounds(bounds: Rectangle, browserWindow: BrowserWindow): Rec
   Adjust the number to be within the range of minimum and maximum values
   TODO: explain the offset
 */
-function clamp(num: number, min: number = 0, max: number = Number.MAX_SAFE_INTEGER): { value: number; clampedOffset: number; } {
+function clamp(num: number, min: number = 0, max: number = Number.MAX_SAFE_INTEGER):
+{ value: number;
+  clampedOffsetLow: number;
+  clampedOffsetHigh: number; } {
   max = max < 0 ? Number.MAX_SAFE_INTEGER : max;
   const value = Math.min(Math.max(num, min, 0), max);
   return {
     value,
-    clampedOffset: num < min ? -1 * (min - num) : 0
+    clampedOffsetLow: num < min ? -1 * (min - num) : 0,
+    clampedOffsetHigh: num > max ? -1 * (num - max) : 0
   };
 }

--- a/src/browser/utils.ts
+++ b/src/browser/utils.ts
@@ -16,6 +16,7 @@ limitations under the License.
 
 import { BrowserWindow } from '../shapes';
 import { Rectangle, screen } from 'electron';
+import * as log from '../browser/log';
 
 /*
   This function sets window's bounds to be in a visible area, in case
@@ -55,18 +56,28 @@ export function clipBounds(bounds: Rectangle, browserWindow: BrowserWindow): Rec
 
   const { minWidth, minHeight, maxWidth, maxHeight } = browserWindow._options;
 
+  const xclamp = clamp(bounds.width, minWidth, maxWidth);
+  log.writeToLog(1, xclamp, true);
+  log.writeToLog(1, browserWindow._options.name, true);
+
+  const yclamp = clamp(bounds.height, minHeight, maxHeight);
   return {
-    x: bounds.x,
+    x: bounds.x + xclamp.clampedOffset,
     y: bounds.y,
-    width: clamp(bounds.width, minWidth, maxWidth),
-    height: clamp(bounds.height, minHeight, maxHeight)
+    width: xclamp.value,
+    height: yclamp.value
   };
 }
 
 /*
   Adjust the number to be within the range of minimum and maximum values
+  TODO: explain the offset
 */
-function clamp(num: number, min: number = 0, max: number = Number.MAX_SAFE_INTEGER): number {
+function clamp(num: number, min: number = 0, max: number = Number.MAX_SAFE_INTEGER): { value: number; clampedOffset: number; } {
   max = max < 0 ? Number.MAX_SAFE_INTEGER : max;
-  return Math.min(Math.max(num, min, 0), max);
+  const value = Math.min(Math.max(num, min, 0), max);
+  return {
+    value,
+    clampedOffset: num < min ? -1 * (min - num) : 0
+  };
 }

--- a/test/rectangle.ts
+++ b/test/rectangle.ts
@@ -1,5 +1,14 @@
 import * as assert from 'assert';
-import { Rectangle } from '../src/browser/rectangle';
+import * as mockery from 'mockery';
+
+import {mockElectron} from './electron';
+
+mockery.registerMock('electron', mockElectron);
+mockery.enable({
+    warnOnReplace: false,
+    warnOnUnregistered: false
+});
+import { Rectangle, SharedBoundsList } from '../src/browser/rectangle';
 
 describe('Rectangle', () => {
     it('should provide the correct sizes', () => {
@@ -15,7 +24,7 @@ describe('Rectangle', () => {
         const sharedBounds = rect1.sharedBounds(rect2);
         const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
         // tslint:disable 
-        console.log(rect1.sharedBounds(rect2));
+        // console.log(rect1.sharedBounds(rect2));
         assert(hasSharedBounds, 'should have had shared bounds');
         assert(top === null, 'should not have had shared top bounds');
         assert(right === 'right', 'should have had shared right bounds');
@@ -30,7 +39,7 @@ describe('Rectangle', () => {
         const sharedBounds = rect1.sharedBounds(rect2);
         const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
         // tslint:disable 
-        console.log(rect1.sharedBounds(rect2));
+        // console.log(rect1.sharedBounds(rect2));
         assert(hasSharedBounds, 'should have had shared bounds');
         assert(top === null, 'should not have had shared top bounds');
         assert(right === 'right', 'should have had shared right bounds');
@@ -45,7 +54,7 @@ describe('Rectangle', () => {
         const sharedBounds = rect1.sharedBounds(rect2);
         const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
         // tslint:disable 
-        console.log(rect1.sharedBounds(rect2));
+        // console.log(rect1.sharedBounds(rect2));
         assert(hasSharedBounds, 'should have had shared bounds');
         assert(top === null, 'should not have had shared top bounds');
         assert(right === 'right', 'should have had shared right bounds');
@@ -60,7 +69,7 @@ describe('Rectangle', () => {
         const sharedBounds = rect1.sharedBounds(rect2);
         const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
         // tslint:disable 
-        console.log(rect1.sharedBounds(rect2));
+        // console.log(rect1.sharedBounds(rect2));
         assert(hasSharedBounds === false, 'should have had shared bounds');
         assert(top === null, 'should not have had shared top bounds');
         assert(right === null, 'should not have had shared right bounds');
@@ -76,7 +85,7 @@ describe('Rectangle', () => {
         const sharedBounds = rect1.sharedBounds(rect2);
         const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
         // tslint:disable 
-        console.log(rect1.sharedBounds(rect2));
+        // console.log(rect1.sharedBounds(rect2));
         assert(hasSharedBounds, 'should have had shared bounds');
         assert(top === 'top', 'should have had shared top bounds');
         assert(right === 'right', 'should have had shared right bounds');
@@ -91,7 +100,7 @@ describe('Rectangle', () => {
         const sharedBounds = rect1.sharedBounds(rect2);
         const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
         // tslint:disable 
-        console.log(rect1.sharedBounds(rect2));
+        // console.log(rect1.sharedBounds(rect2));
         assert(hasSharedBounds, 'should have had shared bounds');
         assert(top === null, 'should not have had shared top bounds');
         assert(right === null, 'should have had shared right bounds');
@@ -106,7 +115,7 @@ describe('Rectangle', () => {
         const sharedBounds = rect1.sharedBounds(rect2);
         const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
         // tslint:disable 
-        console.log(rect1.sharedBounds(rect2));
+        // console.log(rect1.sharedBounds(rect2));
         assert(hasSharedBounds, 'should have had shared bounds');
         assert(top === 'top', 'should not have had shared top bounds');
         assert(right === null, 'should have had shared right bounds');
@@ -121,7 +130,7 @@ describe('Rectangle', () => {
         const sharedBounds = rect1.sharedBounds(rect2);
         const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
         // tslint:disable 
-        console.log(rect1.sharedBounds(rect2));
+        // console.log(rect1.sharedBounds(rect2));
         assert(hasSharedBounds, 'should have had shared bounds');
         assert(top === 'top', 'should not have had shared top bounds');
         assert(right === null, 'should have had shared right bounds');
@@ -146,6 +155,82 @@ describe('Rectangle', () => {
         // tslint:disable 
         assert.deepStrictEqual(sharedBoundsList, [['top', 'top'], ['left', 'left']], 'should only match top top')
     });
+
+    // enable me!!
+    it ('should return the bounds should the rect move left to right', () => {
+        const rect1 = new Rectangle(0, 0, 100, 100);
+        const rect2 = new Rectangle(100, 0, 100, 100);
+        const sharedBoundsList = rect2.sharedBoundsList(rect1);
+        const delta = {x: 0, y: 0, width: 10, height: 0};
+
+        const moved = rect2.move(sharedBoundsList, delta);
+
+        assert.deepStrictEqual(moved, {x: 110, y: 0, width: 90, height: 100});
+    });
+
+    it('should not move if the resizing edge is not a shared one', () => {
+        const rect1 = new Rectangle(0, 0, 100, 100);
+        const rect2 = new Rectangle(100, 0, 100, 100);
+        const sharedBoundsList = rect2.sharedBoundsList(rect1);
+        const delta = {x: 10, y: 0, width: -10, height: 0};
+
+        const moved = rect2.move(sharedBoundsList, delta);
+
+        assert.deepStrictEqual(moved, {x: 100, y: 0, width: 100, height: 100});
+    });
+
+    it('should not move if the resizing edge is not a shared one', () => {
+        const rect1 = new Rectangle(0, 0, 100, 100);
+        const rect2 = new Rectangle(100, 0, 100, 80);
+        const sharedBoundsList = rect2.sharedBoundsList(rect1);
+        const delta = {x: 0, y: 0, width: 0, height: -11};
+
+        const moved = rect2.move(sharedBoundsList, delta);
+
+        assert.deepStrictEqual(moved, {x: 100, y: 0, width: 100, height: 80});
+    });
+
+    it('should not move if the resizing edge is not a shared one, resize left, joined right', () => {
+        const rect1 = new Rectangle(10, 0, 100, 100);
+        const rect2 = new Rectangle(110, 0, 100, 100);
+        const sharedBoundsList = rect2.sharedBoundsList(rect1);
+        const delta = {x: -4, y: 0, width: 4, height: 0};
+
+        const moved = rect2.move(sharedBoundsList, delta);
+
+        assert.deepStrictEqual(moved, {x: 110, y: 0, width: 100, height: 100});
+    });
+
+    it ('should move the window when there is a shared edge', () => {
+        const rect1 = new Rectangle(0, 0, 100, 100);
+        const rect2 = new Rectangle(100, 0, 100, 100);
+        const sharedBoundsList = rect2.sharedBoundsList(rect1);
+        const delta = {x: 0, y: 0, width: -10, height: 0};
+        const moved = rect2.move(sharedBoundsList, delta);
+
+        assert.deepStrictEqual(moved, {x: 90, y: 0, width: 110, height: 100});
+    });
+
+    it ('should return the bounds should the rect move right to left', () => {
+        const rect1 = new Rectangle(0, 0, 100, 100);
+        const rect2 = Rectangle.CREATE_FROM_BOUNDS({
+            "x": 554,
+            "y": 69,
+            "width": 834,
+            "height": 300
+        });
+        const sharedBoundsList = <SharedBoundsList>[['top', 'top'], ['left', 'right']];
+        // const delta = {x: 10, y: 0, width: -10, height: 0};
+
+        const moved = rect2.move(sharedBoundsList, {
+            "x": 0,
+            "y": 0,
+            "width": -10,
+            "height": 0
+        });
+
+        assert.deepStrictEqual(moved, {"x": 544, "y": 69, "width": 844, "height": 300});
+    });
     // RIGHT 
     // OVERLAPPING exactly 
     // LEFT 
@@ -160,7 +245,7 @@ describe('Rectangle', () => {
     //     const sharedBounds = rect1.sharedBounds(rect2);
     //     const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
     //     // tslint:disable 
-    //     console.log(rect1.sharedBounds(rect2));
+    //     // console.log(rect1.sharedBounds(rect2));
     //     assert(hasSharedBounds, 'should have had shared bounds');
     //     assert(top === null, 'should not have had shared top bounds');
     //     assert(right === 'right', 'should have had shared bottom bounds');
@@ -175,7 +260,7 @@ describe('Rectangle', () => {
     //     const sharedBounds = rect1.sharedBounds(rect2);
     //     const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
     //     // tslint:disable 
-    //     console.log(rect1.sharedBounds(rect2));
+    //     // console.log(rect1.sharedBounds(rect2));
     //     assert(hasSharedBounds, 'should have had shared bounds');
     // });
 });

--- a/test/rectangle.ts
+++ b/test/rectangle.ts
@@ -142,62 +142,62 @@ describe('Rectangle', () => {
 
     it('should not move if no shared edges', () => {
         const rect = new Rectangle(0, 0, 100, 100);
-        const move = rect.move2({x: 200, y: 0, width: 100, height: 100}, {x: 300, y: 0, width: 100, height: 100});
+        const move = rect.move({x: 200, y: 0, width: 100, height: 100}, {x: 300, y: 0, width: 100, height: 100});
         assert.deepStrictEqual(move, {x: 0, y: 0, width: 100, height: 100});
     });
 
     it('should not move if the resizing edge is not a shared one, (leader right, leader grows not shared)', () => {
         const rect = new Rectangle(0, 0, 100, 100);
-        const move = rect.move2({x: 100, y: 0, width: 100, height: 100}, {x: 100, y: 0, width: 110, height: 100});
+        const move = rect.move({x: 100, y: 0, width: 100, height: 100}, {x: 100, y: 0, width: 110, height: 100});
         assert.deepStrictEqual(move, {x: 0, y: 0, width: 100, height: 100});
     });
 
 
     it('should move with just the leader window move (leader top, leader grows)', () => {
         const rect = new Rectangle(100, 100, 100, 100);
-        const move = rect.move2({x: 0, y: 0, width: 100, height: 100}, {x: 0, y: 0, width: 100, height: 110});
+        const move = rect.move({x: 0, y: 0, width: 100, height: 100}, {x: 0, y: 0, width: 100, height: 110});
         assert.deepStrictEqual(move, {x: 100, y: 110, width: 100, height: 90});
     });
 
     it('should move with just the leader window move (leader top, leader shrinks)', () => {
         const rect = new Rectangle(100, 100, 100, 100);
-        const move = rect.move2({x: 0, y: 0, width: 100, height: 100}, {x: 0, y: 0, width: 100, height: 90});
+        const move = rect.move({x: 0, y: 0, width: 100, height: 100}, {x: 0, y: 0, width: 100, height: 90});
         assert.deepStrictEqual(move, {x: 100, y: 90, width: 100, height: 110});
     });
 
     it('should move with just the leader window move (leader bottom, leader grows)', () => {
         const rect = new Rectangle(100, 100, 100, 100);
-        const move = rect.move2({x: 0, y: 200, width: 100, height: 100}, {x: 0, y: 190, width: 100, height: 110});
+        const move = rect.move({x: 0, y: 200, width: 100, height: 100}, {x: 0, y: 190, width: 100, height: 110});
         assert.deepStrictEqual(move, {x: 100, y: 100, width: 100, height: 90});
     });
 
     it('should move with just the leader window move (leader bottom, leader shrinks)', () => {
         const rect = new Rectangle(100, 100, 100, 100);
-        const move = rect.move2({x: 0, y: 200, width: 100, height: 100}, {x: 0, y: 210, width: 100, height: 90});
+        const move = rect.move({x: 0, y: 200, width: 100, height: 100}, {x: 0, y: 210, width: 100, height: 90});
         assert.deepStrictEqual(move, {x: 100, y: 100, width: 100, height: 110});
     });
 
     it('should move with just the leader window move (leader left, leader grows)', () => {
         const rect = new Rectangle(100, 0, 100, 100);
-        const move = rect.move2({x: 0, y: 0, width: 100, height: 100}, {x: 0, y: 0, width: 110, height: 100});
+        const move = rect.move({x: 0, y: 0, width: 100, height: 100}, {x: 0, y: 0, width: 110, height: 100});
         assert.deepStrictEqual(move, {x: 110, y: 0, width: 90, height: 100});
     });
 
     it('should move with just the leader window move (leader left, leader shrinks)', () => {
         const rect = new Rectangle(100, 0, 100, 100);
-        const move = rect.move2({x: 0, y: 0, width: 100, height: 100}, {x: 0, y: 0, width: 90, height: 100});
+        const move = rect.move({x: 0, y: 0, width: 100, height: 100}, {x: 0, y: 0, width: 90, height: 100});
         assert.deepStrictEqual(move, {x: 90, y: 0, width: 110, height: 100});
     });
 
     it('should move with just the leader window move (leader right, leader grows)', () => {
         const rect = new Rectangle(0, 0, 100, 100);
-        const move = rect.move2({x: 100, y: 0, width: 100, height: 100}, {x: 90, y: 0, width: 110, height: 100});
+        const move = rect.move({x: 100, y: 0, width: 100, height: 100}, {x: 90, y: 0, width: 110, height: 100});
         assert.deepStrictEqual(move, {x: 0, y: 0, width: 90, height: 100});
     });
 
     it('should move with just the leader window move (leader right, leader shrinks)', () => {
         const rect = new Rectangle(0, 0, 100, 100);
-        const move = rect.move2({x: 100, y: 0, width: 100, height: 100}, {x: 110, y: 0, width: 90, height: 100});
+        const move = rect.move({x: 100, y: 0, width: 100, height: 100}, {x: 110, y: 0, width: 90, height: 100});
         assert.deepStrictEqual(move, {x: 0, y: 0, width: 110, height: 100});
     });
 

--- a/test/rectangle.ts
+++ b/test/rectangle.ts
@@ -260,6 +260,35 @@ describe('Rectangle', () => {
         assert(rect.x === 90, 'side should line up');
         assert(rect.width === 110, 'width should have been adjusted');
     });
+
+    it('should align the side given, top to bottom', () => {
+        const rect = new Rectangle(0, 110, 100, 100);
+        const otherRect = {x: 0, y: 0, width: 100, height: 100};
+        rect.alignSide('top', Rectangle.CREATE_FROM_BOUNDS(otherRect), 'bottom');
+        // assert(rect.y === 90, 'side should line up');
+        // assert(rect.height === 110, 'height should have been adjusted');
+        assert.deepStrictEqual(rect.bounds, {x: 0, y: 100, width: 100, height: 110});
+    });
+
+    it('should return an adjacency list, quickly :)', () => {
+        const NS_PER_SEC = 1e9;
+        const time = process.hrtime();
+        const adjList = Rectangle.ADJACENCY_LIST([
+            new Rectangle(0,0,100,100),
+            new Rectangle(4,4,100,100),
+            new Rectangle(8,8,100,100),
+            new Rectangle(50,0,100,100),
+            new Rectangle(400,400,100,100),
+            new Rectangle(6,6,100,100),
+        ]);
+
+        const diff = process.hrtime(time);
+        const thing = diff[0] * NS_PER_SEC + diff[1];
+        const diffInMilliS = (diff[0] * NS_PER_SEC + diff[1]) / 1e6
+        const foo = adjList;
+        assert(diffInMilliS < 5);
+    });
+
     // it('should not jump left', () => {
     //     const rect = Rectangle.CREATE_FROM_BOUNDS({
     //         "x": 721,

--- a/test/rectangle.ts
+++ b/test/rectangle.ts
@@ -201,7 +201,7 @@ describe('Rectangle', () => {
         assert.deepStrictEqual(moved, {x: 110, y: 0, width: 100, height: 100});
     });
 
-    it ('should move the window when there is a shared edge', () => {
+    it ('should move the window when there is a shared edge (left edge to right)', () => {
         const rect1 = new Rectangle(0, 0, 100, 100);
         const rect2 = new Rectangle(100, 0, 100, 100);
         const sharedBoundsList = rect2.sharedBoundsList(rect1);
@@ -212,7 +212,7 @@ describe('Rectangle', () => {
     });
 
     it ('should return the bounds should the rect move right to left', () => {
-        const rect1 = new Rectangle(0, 0, 100, 100);
+        // const rect1 = new Rectangle(0, 0, 100, 100);
         const rect2 = Rectangle.CREATE_FROM_BOUNDS({
             "x": 554,
             "y": 69,
@@ -231,6 +231,45 @@ describe('Rectangle', () => {
 
         assert.deepStrictEqual(moved, {"x": 544, "y": 69, "width": 844, "height": 300});
     });
+
+    it ('should handle bounded bottom moves correctly', () =>{
+        const delta = { "x": 0, "y": 0, "width": 0, "height": 1 };
+        const rect = Rectangle.CREATE_FROM_BOUNDS({"x": 623, "y": 162, "width": 690, "height": 294})
+        const sharedBoundsList = <SharedBoundsList>[['bottom', 'bottom'], ['left', 'right']];
+        const moved = rect.move(sharedBoundsList, delta);
+        assert.deepStrictEqual(moved, {"x": 623, "y": 162, "width": 690, "height": 295})
+    });
+
+    it('should move with just the leader window move (leader left, leader grows)', () => {
+        const rect = new Rectangle(100, 0, 100, 100);
+        const move = rect.move2({x: 0, y: 0, width: 100, height: 100}, {x: 0, y: 0, width: 110, height: 100});
+        assert.deepStrictEqual(move, {x: 110, y: 0, width: 90, height: 100});
+    });
+
+    it('should move with just the leader window move (leader right, leader grows)', () => {
+        const rect = new Rectangle(0, 0, 100, 100);
+        const move = rect.move2({x: 100, y: 0, width: 100, height: 100}, {x: 90, y: 0, width: 110, height: 100});
+        assert.deepStrictEqual(move, {x: 0, y: 0, width: 90, height: 100});
+    });
+
+
+    it('should align the side given, left to right', () => {
+        const rect = new Rectangle(100, 0, 100, 100);
+        const otherRect = {x: 0, y: 0, width: 90, height: 100};
+        rect.alignSide('left', Rectangle.CREATE_FROM_BOUNDS(otherRect), 'right');
+        assert(rect.x === 90, 'side should line up');
+        assert(rect.width === 110, 'width should have been adjusted');
+    });
+    // it('should not jump left', () => {
+    //     const rect = Rectangle.CREATE_FROM_BOUNDS({
+    //         "x": 721,
+    //         "y": 193,
+    //         "width": 337,
+    //         "height": 212
+    //     });
+    //     const move = rect.move2({x: 100, y: 0, width: 100, height: 100}, {x: 90, y: 0, width: 110, height: 100});
+    // });
+
     // RIGHT 
     // OVERLAPPING exactly 
     // LEFT 

--- a/test/rectangle.ts
+++ b/test/rectangle.ts
@@ -1,0 +1,181 @@
+import * as assert from 'assert';
+import { Rectangle } from '../src/browser/rectangle';
+
+describe('Rectangle', () => {
+    it('should provide the correct sizes', () => {
+        const rect = new Rectangle(0, 0, 100, 100);
+        assert(rect.right === 100, 'should compute the right edge');
+        assert(rect.bottom === 100, 'should have computed the bottom');
+    });
+
+    it('should return the shared bounds within threshold, above', () => {
+        // bottom
+        const rect1 = new Rectangle(0, 0, 100, 100);
+        const rect2 = new Rectangle(0, 97, 100, 100);
+        const sharedBounds = rect1.sharedBounds(rect2);
+        const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
+        // tslint:disable 
+        console.log(rect1.sharedBounds(rect2));
+        assert(hasSharedBounds, 'should have had shared bounds');
+        assert(top === null, 'should not have had shared top bounds');
+        assert(right === 'right', 'should have had shared right bounds');
+        assert(bottom === 'top', 'should have had shared bottom bounds');
+        assert(left === 'left', 'should have had shared left bounds');
+    });
+
+    it('should return the shared bounds within threshold, below', () => {
+        // bottom
+        const rect1 = new Rectangle(0, 0, 100, 100);
+        const rect2 = new Rectangle(0, 104, 100, 100);
+        const sharedBounds = rect1.sharedBounds(rect2);
+        const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
+        // tslint:disable 
+        console.log(rect1.sharedBounds(rect2));
+        assert(hasSharedBounds, 'should have had shared bounds');
+        assert(top === null, 'should not have had shared top bounds');
+        assert(right === 'right', 'should have had shared right bounds');
+        assert(bottom === 'top', 'should have had shared bottom bounds');
+        assert(left === 'left', 'should have had shared left bounds');
+    });
+
+    it('should return the shared bounds exactly on the threshold', () => {
+        // bottom
+        const rect1 = new Rectangle(0, 0, 100, 100);
+        const rect2 = new Rectangle(0, 100, 100, 100);
+        const sharedBounds = rect1.sharedBounds(rect2);
+        const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
+        // tslint:disable 
+        console.log(rect1.sharedBounds(rect2));
+        assert(hasSharedBounds, 'should have had shared bounds');
+        assert(top === null, 'should not have had shared top bounds');
+        assert(right === 'right', 'should have had shared right bounds');
+        assert(bottom === 'top', 'should have had shared bottom bounds');
+        assert(left === 'left', 'should have had shared left bounds');
+    });
+
+    it('should return the false if past the threshold', () => {
+        // bottom
+        const rect1 = new Rectangle(0, 0, 100, 100);
+        const rect2 = new Rectangle(0, 106, 100, 100);
+        const sharedBounds = rect1.sharedBounds(rect2);
+        const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
+        // tslint:disable 
+        console.log(rect1.sharedBounds(rect2));
+        assert(hasSharedBounds === false, 'should have had shared bounds');
+        assert(top === null, 'should not have had shared top bounds');
+        assert(right === null, 'should not have had shared right bounds');
+        assert(bottom === null, 'should not have had shared bottom bounds');
+        assert(left === null, 'should not have had shared left bounds');
+    });
+
+
+    it('should return true for all if directly on top', () => {
+        // bottom
+        const rect1 = new Rectangle(0, 0, 100, 100);
+        const rect2 = new Rectangle(0, 0, 100, 100);
+        const sharedBounds = rect1.sharedBounds(rect2);
+        const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
+        // tslint:disable 
+        console.log(rect1.sharedBounds(rect2));
+        assert(hasSharedBounds, 'should have had shared bounds');
+        assert(top === 'top', 'should have had shared top bounds');
+        assert(right === 'right', 'should have had shared right bounds');
+        assert(bottom === 'bottom', 'should have had shared bottom bounds');
+        assert(left === 'left', 'should have had shared left bounds');
+    });
+
+    it('should return true for all if directly on top, matching left bounds', () => {
+        // bottom
+        const rect1 = new Rectangle(0, 0, 100, 100);
+        const rect2 = new Rectangle(0, 10, 90, 80);
+        const sharedBounds = rect1.sharedBounds(rect2);
+        const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
+        // tslint:disable 
+        console.log(rect1.sharedBounds(rect2));
+        assert(hasSharedBounds, 'should have had shared bounds');
+        assert(top === null, 'should not have had shared top bounds');
+        assert(right === null, 'should have had shared right bounds');
+        assert(bottom === null, 'should have had shared bottom bounds');
+        assert(left === 'left', 'should have had shared left bounds');
+    });
+
+    it('should return true for all if directly on top, matching top, left bounds', () => {
+        // bottom
+        const rect1 = new Rectangle(0, 0, 100, 100);
+        const rect2 = new Rectangle(0, 0, 90, 90);
+        const sharedBounds = rect1.sharedBounds(rect2);
+        const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
+        // tslint:disable 
+        console.log(rect1.sharedBounds(rect2));
+        assert(hasSharedBounds, 'should have had shared bounds');
+        assert(top === 'top', 'should not have had shared top bounds');
+        assert(right === null, 'should have had shared right bounds');
+        assert(bottom === null, 'should have had shared bottom bounds');
+        assert(left === 'left', 'should have had shared left bounds');
+    });
+
+    it('should return true for all if directly on top, matching top only', () => {
+        // bottom
+        const rect1 = new Rectangle(0, 0, 100, 100);
+        const rect2 = new Rectangle(10, 0, 80, 90);
+        const sharedBounds = rect1.sharedBounds(rect2);
+        const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
+        // tslint:disable 
+        console.log(rect1.sharedBounds(rect2));
+        assert(hasSharedBounds, 'should have had shared bounds');
+        assert(top === 'top', 'should not have had shared top bounds');
+        assert(right === null, 'should have had shared right bounds');
+        assert(bottom === null, 'should have had shared bottom bounds');
+        assert(left === null, 'should have had shared left bounds');
+    });
+
+    it('shared bound list should return true for all if directly on top, matching top only', () => {
+        // bottom
+        const rect1 = new Rectangle(0, 0, 100, 100);
+        const rect2 = new Rectangle(10, 0, 80, 90);
+        const sharedBoundsList = rect1.sharedBoundsList(rect2);
+        // tslint:disable 
+        assert.deepStrictEqual(sharedBoundsList, [['top', 'top']], 'should only match top top')
+    });
+
+    it('shared bound list should return true for all if directly on top, matching top, left', () => {
+        // bottom
+        const rect1 = new Rectangle(0, 0, 100, 100);
+        const rect2 = new Rectangle(0, 0, 90, 90);
+        const sharedBoundsList = rect1.sharedBoundsList(rect2);
+        // tslint:disable 
+        assert.deepStrictEqual(sharedBoundsList, [['top', 'top'], ['left', 'left']], 'should only match top top')
+    });
+    // RIGHT 
+    // OVERLAPPING exactly 
+    // LEFT 
+    // TOP 
+    // INSIDE 
+    // OVERLAPPING NO SHARED 
+
+    // it('should return the shared right bounds within threshold', () => {
+    //     // bottom
+    //     const rect1 = new Rectangle(0, 0, 100, 100);
+    //     const rect2 = new Rectangle(0, 97, 100, 100);
+    //     const sharedBounds = rect1.sharedBounds(rect2);
+    //     const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
+    //     // tslint:disable 
+    //     console.log(rect1.sharedBounds(rect2));
+    //     assert(hasSharedBounds, 'should have had shared bounds');
+    //     assert(top === null, 'should not have had shared top bounds');
+    //     assert(right === 'right', 'should have had shared bottom bounds');
+    //     assert(bottom === 'top', 'should have had shared bottom bounds');
+    //     assert(left === 'left', 'should have had shared bottom bounds');
+    // });
+
+    // it('should return the shared bounds bottom right at the threshold', () => {
+    //     // bottom
+    //     const rect1 = new Rectangle(0, 0, 100, 100);
+    //     const rect2 = new Rectangle(0, 100, 100, 100);
+    //     const sharedBounds = rect1.sharedBounds(rect2);
+    //     const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
+    //     // tslint:disable 
+    //     console.log(rect1.sharedBounds(rect2));
+    //     assert(hasSharedBounds, 'should have had shared bounds');
+    // });
+});

--- a/test/rectangle.ts
+++ b/test/rectangle.ts
@@ -18,13 +18,11 @@ describe('Rectangle', () => {
     });
 
     it('should return the shared bounds within threshold, above', () => {
-        // bottom
         const rect1 = new Rectangle(0, 0, 100, 100);
         const rect2 = new Rectangle(0, 97, 100, 100);
         const sharedBounds = rect1.sharedBounds(rect2);
         const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
-        // tslint:disable 
-        // console.log(rect1.sharedBounds(rect2));
+
         assert(hasSharedBounds, 'should have had shared bounds');
         assert(top === null, 'should not have had shared top bounds');
         assert(right === 'right', 'should have had shared right bounds');
@@ -33,13 +31,11 @@ describe('Rectangle', () => {
     });
 
     it('should return the shared bounds within threshold, below', () => {
-        // bottom
         const rect1 = new Rectangle(0, 0, 100, 100);
         const rect2 = new Rectangle(0, 104, 100, 100);
         const sharedBounds = rect1.sharedBounds(rect2);
         const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
-        // tslint:disable 
-        // console.log(rect1.sharedBounds(rect2));
+
         assert(hasSharedBounds, 'should have had shared bounds');
         assert(top === null, 'should not have had shared top bounds');
         assert(right === 'right', 'should have had shared right bounds');
@@ -48,13 +44,12 @@ describe('Rectangle', () => {
     });
 
     it('should return the shared bounds exactly on the threshold', () => {
-        // bottom
+
         const rect1 = new Rectangle(0, 0, 100, 100);
         const rect2 = new Rectangle(0, 100, 100, 100);
         const sharedBounds = rect1.sharedBounds(rect2);
         const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
-        // tslint:disable 
-        // console.log(rect1.sharedBounds(rect2));
+
         assert(hasSharedBounds, 'should have had shared bounds');
         assert(top === null, 'should not have had shared top bounds');
         assert(right === 'right', 'should have had shared right bounds');
@@ -63,13 +58,12 @@ describe('Rectangle', () => {
     });
 
     it('should return the false if past the threshold', () => {
-        // bottom
+
         const rect1 = new Rectangle(0, 0, 100, 100);
         const rect2 = new Rectangle(0, 106, 100, 100);
         const sharedBounds = rect1.sharedBounds(rect2);
         const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
-        // tslint:disable 
-        // console.log(rect1.sharedBounds(rect2));
+
         assert(hasSharedBounds === false, 'should have had shared bounds');
         assert(top === null, 'should not have had shared top bounds');
         assert(right === null, 'should not have had shared right bounds');
@@ -79,13 +73,12 @@ describe('Rectangle', () => {
 
 
     it('should return true for all if directly on top', () => {
-        // bottom
+
         const rect1 = new Rectangle(0, 0, 100, 100);
         const rect2 = new Rectangle(0, 0, 100, 100);
         const sharedBounds = rect1.sharedBounds(rect2);
         const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
-        // tslint:disable 
-        // console.log(rect1.sharedBounds(rect2));
+
         assert(hasSharedBounds, 'should have had shared bounds');
         assert(top === 'top', 'should have had shared top bounds');
         assert(right === 'right', 'should have had shared right bounds');
@@ -94,13 +87,11 @@ describe('Rectangle', () => {
     });
 
     it('should return true for all if directly on top, matching left bounds', () => {
-        // bottom
         const rect1 = new Rectangle(0, 0, 100, 100);
         const rect2 = new Rectangle(0, 10, 90, 80);
         const sharedBounds = rect1.sharedBounds(rect2);
         const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
-        // tslint:disable 
-        // console.log(rect1.sharedBounds(rect2));
+
         assert(hasSharedBounds, 'should have had shared bounds');
         assert(top === null, 'should not have had shared top bounds');
         assert(right === null, 'should have had shared right bounds');
@@ -109,13 +100,11 @@ describe('Rectangle', () => {
     });
 
     it('should return true for all if directly on top, matching top, left bounds', () => {
-        // bottom
         const rect1 = new Rectangle(0, 0, 100, 100);
         const rect2 = new Rectangle(0, 0, 90, 90);
         const sharedBounds = rect1.sharedBounds(rect2);
         const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
-        // tslint:disable 
-        // console.log(rect1.sharedBounds(rect2));
+
         assert(hasSharedBounds, 'should have had shared bounds');
         assert(top === 'top', 'should not have had shared top bounds');
         assert(right === null, 'should have had shared right bounds');
@@ -129,8 +118,7 @@ describe('Rectangle', () => {
         const rect2 = new Rectangle(10, 0, 80, 90);
         const sharedBounds = rect1.sharedBounds(rect2);
         const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
-        // tslint:disable 
-        // console.log(rect1.sharedBounds(rect2));
+
         assert(hasSharedBounds, 'should have had shared bounds');
         assert(top === 'top', 'should not have had shared top bounds');
         assert(right === null, 'should have had shared right bounds');
@@ -139,105 +127,54 @@ describe('Rectangle', () => {
     });
 
     it('shared bound list should return true for all if directly on top, matching top only', () => {
-        // bottom
         const rect1 = new Rectangle(0, 0, 100, 100);
         const rect2 = new Rectangle(10, 0, 80, 90);
         const sharedBoundsList = rect1.sharedBoundsList(rect2);
-        // tslint:disable 
-        assert.deepStrictEqual(sharedBoundsList, [['top', 'top']], 'should only match top top')
+        assert.deepStrictEqual(sharedBoundsList, [['top', 'top']], 'should only match top top');
     });
 
     it('shared bound list should return true for all if directly on top, matching top, left', () => {
-        // bottom
         const rect1 = new Rectangle(0, 0, 100, 100);
         const rect2 = new Rectangle(0, 0, 90, 90);
         const sharedBoundsList = rect1.sharedBoundsList(rect2);
-        // tslint:disable 
-        assert.deepStrictEqual(sharedBoundsList, [['top', 'top'], ['left', 'left']], 'should only match top top')
+        assert.deepStrictEqual(sharedBoundsList, [['top', 'top'], ['left', 'left']], 'should only match top top');
     });
 
-    // enable me!!
-    it ('should return the bounds should the rect move left to right', () => {
-        const rect1 = new Rectangle(0, 0, 100, 100);
-        const rect2 = new Rectangle(100, 0, 100, 100);
-        const sharedBoundsList = rect2.sharedBoundsList(rect1);
-        const delta = {x: 0, y: 0, width: 10, height: 0};
-
-        const moved = rect2.move(sharedBoundsList, delta);
-
-        assert.deepStrictEqual(moved, {x: 110, y: 0, width: 90, height: 100});
+    it('should not move if no shared edges', () => {
+        const rect = new Rectangle(0, 0, 100, 100);
+        const move = rect.move2({x: 200, y: 0, width: 100, height: 100}, {x: 300, y: 0, width: 100, height: 100});
+        assert.deepStrictEqual(move, {x: 0, y: 0, width: 100, height: 100});
     });
 
-    it('should not move if the resizing edge is not a shared one', () => {
-        const rect1 = new Rectangle(0, 0, 100, 100);
-        const rect2 = new Rectangle(100, 0, 100, 100);
-        const sharedBoundsList = rect2.sharedBoundsList(rect1);
-        const delta = {x: 10, y: 0, width: -10, height: 0};
-
-        const moved = rect2.move(sharedBoundsList, delta);
-
-        assert.deepStrictEqual(moved, {x: 100, y: 0, width: 100, height: 100});
+    it('should not move if the resizing edge is not a shared one, (leader right, leader grows not shared)', () => {
+        const rect = new Rectangle(0, 0, 100, 100);
+        const move = rect.move2({x: 100, y: 0, width: 100, height: 100}, {x: 100, y: 0, width: 110, height: 100});
+        assert.deepStrictEqual(move, {x: 0, y: 0, width: 100, height: 100});
     });
 
-    it('should not move if the resizing edge is not a shared one', () => {
-        const rect1 = new Rectangle(0, 0, 100, 100);
-        const rect2 = new Rectangle(100, 0, 100, 80);
-        const sharedBoundsList = rect2.sharedBoundsList(rect1);
-        const delta = {x: 0, y: 0, width: 0, height: -11};
 
-        const moved = rect2.move(sharedBoundsList, delta);
-
-        assert.deepStrictEqual(moved, {x: 100, y: 0, width: 100, height: 80});
+    it('should move with just the leader window move (leader top, leader grows)', () => {
+        const rect = new Rectangle(100, 100, 100, 100);
+        const move = rect.move2({x: 0, y: 0, width: 100, height: 100}, {x: 0, y: 0, width: 100, height: 110});
+        assert.deepStrictEqual(move, {x: 100, y: 110, width: 100, height: 90});
     });
 
-    it('should not move if the resizing edge is not a shared one, resize left, joined right', () => {
-        const rect1 = new Rectangle(10, 0, 100, 100);
-        const rect2 = new Rectangle(110, 0, 100, 100);
-        const sharedBoundsList = rect2.sharedBoundsList(rect1);
-        const delta = {x: -4, y: 0, width: 4, height: 0};
-
-        const moved = rect2.move(sharedBoundsList, delta);
-
-        assert.deepStrictEqual(moved, {x: 110, y: 0, width: 100, height: 100});
+    it('should move with just the leader window move (leader top, leader shrinks)', () => {
+        const rect = new Rectangle(100, 100, 100, 100);
+        const move = rect.move2({x: 0, y: 0, width: 100, height: 100}, {x: 0, y: 0, width: 100, height: 90});
+        assert.deepStrictEqual(move, {x: 100, y: 90, width: 100, height: 110});
     });
 
-    it ('should move the window when there is a shared edge (left edge to right)', () => {
-        const rect1 = new Rectangle(0, 0, 100, 100);
-        const rect2 = new Rectangle(100, 0, 100, 100);
-        const sharedBoundsList = rect2.sharedBoundsList(rect1);
-        const delta = {x: 0, y: 0, width: -10, height: 0};
-        const moved = rect2.move(sharedBoundsList, delta);
-
-        assert.deepStrictEqual(moved, {x: 90, y: 0, width: 110, height: 100});
+    it('should move with just the leader window move (leader bottom, leader grows)', () => {
+        const rect = new Rectangle(100, 100, 100, 100);
+        const move = rect.move2({x: 0, y: 200, width: 100, height: 100}, {x: 0, y: 190, width: 100, height: 110});
+        assert.deepStrictEqual(move, {x: 100, y: 100, width: 100, height: 90});
     });
 
-    it ('should return the bounds should the rect move right to left', () => {
-        // const rect1 = new Rectangle(0, 0, 100, 100);
-        const rect2 = Rectangle.CREATE_FROM_BOUNDS({
-            "x": 554,
-            "y": 69,
-            "width": 834,
-            "height": 300
-        });
-        const sharedBoundsList = <SharedBoundsList>[['top', 'top'], ['left', 'right']];
-        // const delta = {x: 10, y: 0, width: -10, height: 0};
-
-        const moved = rect2.move(sharedBoundsList, {
-            "x": 0,
-            "y": 0,
-            "width": -10,
-            "height": 0
-        });
-
-        assert.deepStrictEqual(moved, {"x": 544, "y": 69, "width": 844, "height": 300});
-    });
-
-    it ('should handle bounded bottom moves correctly', () =>{
-        const delta = { "x": 0, "y": 0, "width": 0, "height": 1 };
-        const rect = Rectangle.CREATE_FROM_BOUNDS({"x": 623, "y": 162, "width": 690, "height": 294})
-        const sharedBoundsList = <SharedBoundsList>[['bottom', 'bottom'], ['left', 'right']];
-        const moved = rect.move(sharedBoundsList, delta);
-        assert.deepStrictEqual(moved, {"x": 623, "y": 162, "width": 690, "height": 295})
+    it('should move with just the leader window move (leader bottom, leader shrinks)', () => {
+        const rect = new Rectangle(100, 100, 100, 100);
+        const move = rect.move2({x: 0, y: 200, width: 100, height: 100}, {x: 0, y: 210, width: 100, height: 90});
+        assert.deepStrictEqual(move, {x: 100, y: 100, width: 100, height: 110});
     });
 
     it('should move with just the leader window move (leader left, leader grows)', () => {
@@ -246,10 +183,22 @@ describe('Rectangle', () => {
         assert.deepStrictEqual(move, {x: 110, y: 0, width: 90, height: 100});
     });
 
+    it('should move with just the leader window move (leader left, leader shrinks)', () => {
+        const rect = new Rectangle(100, 0, 100, 100);
+        const move = rect.move2({x: 0, y: 0, width: 100, height: 100}, {x: 0, y: 0, width: 90, height: 100});
+        assert.deepStrictEqual(move, {x: 90, y: 0, width: 110, height: 100});
+    });
+
     it('should move with just the leader window move (leader right, leader grows)', () => {
         const rect = new Rectangle(0, 0, 100, 100);
         const move = rect.move2({x: 100, y: 0, width: 100, height: 100}, {x: 90, y: 0, width: 110, height: 100});
         assert.deepStrictEqual(move, {x: 0, y: 0, width: 90, height: 100});
+    });
+
+    it('should move with just the leader window move (leader right, leader shrinks)', () => {
+        const rect = new Rectangle(0, 0, 100, 100);
+        const move = rect.move2({x: 100, y: 0, width: 100, height: 100}, {x: 110, y: 0, width: 90, height: 100});
+        assert.deepStrictEqual(move, {x: 0, y: 0, width: 110, height: 100});
     });
 
 
@@ -265,8 +214,6 @@ describe('Rectangle', () => {
         const rect = new Rectangle(0, 110, 100, 100);
         const otherRect = {x: 0, y: 0, width: 100, height: 100};
         rect.alignSide('top', Rectangle.CREATE_FROM_BOUNDS(otherRect), 'bottom');
-        // assert(rect.y === 90, 'side should line up');
-        // assert(rect.height === 110, 'height should have been adjusted');
         assert.deepStrictEqual(rect.bounds, {x: 0, y: 100, width: 100, height: 110});
     });
 
@@ -274,61 +221,45 @@ describe('Rectangle', () => {
         const NS_PER_SEC = 1e9;
         const time = process.hrtime();
         const adjList = Rectangle.ADJACENCY_LIST([
-            new Rectangle(0,0,100,100),
-            new Rectangle(4,4,100,100),
-            new Rectangle(8,8,100,100),
-            new Rectangle(50,0,100,100),
-            new Rectangle(400,400,100,100),
-            new Rectangle(6,6,100,100),
+            new Rectangle(0, 0, 100, 100),
+            new Rectangle(4, 4, 100, 100),
+            new Rectangle(8, 8, 100, 100),
+            new Rectangle(50, 0, 100, 100),
+            new Rectangle(400, 400, 100, 100),
+            new Rectangle(6, 6, 100, 100)
         ]);
 
         const diff = process.hrtime(time);
-        const thing = diff[0] * NS_PER_SEC + diff[1];
-        const diffInMilliS = (diff[0] * NS_PER_SEC + diff[1]) / 1e6
-        const foo = adjList;
-        assert(diffInMilliS < 5);
+        const diffInMilliSec = (diff[0] * NS_PER_SEC + diff[1]) / 1e6;
+        assert(diffInMilliSec < 5);
     });
 
-    // it('should not jump left', () => {
-    //     const rect = Rectangle.CREATE_FROM_BOUNDS({
-    //         "x": 721,
-    //         "y": 193,
-    //         "width": 337,
-    //         "height": 212
-    //     });
-    //     const move = rect.move2({x: 100, y: 0, width: 100, height: 100}, {x: 90, y: 0, width: 110, height: 100});
-    // });
+    it ('should grow correctly on external monitors with negative y', () => {
+        const rect = Rectangle.CREATE_FROM_BOUNDS({'x': 1206, 'y': -540, 'width': 491, 'height': 253});
+        const grownUp = rect.grow(5, 5);
 
-    // RIGHT 
-    // OVERLAPPING exactly 
-    // LEFT 
-    // TOP 
-    // INSIDE 
-    // OVERLAPPING NO SHARED 
+        assert.deepStrictEqual(grownUp, Rectangle.CREATE_FROM_BOUNDS({'x': 1201, 'y': -545, 'width': 501, 'height': 263}));
+    });
 
-    // it('should return the shared right bounds within threshold', () => {
-    //     // bottom
-    //     const rect1 = new Rectangle(0, 0, 100, 100);
-    //     const rect2 = new Rectangle(0, 97, 100, 100);
-    //     const sharedBounds = rect1.sharedBounds(rect2);
-    //     const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
-    //     // tslint:disable 
-    //     // console.log(rect1.sharedBounds(rect2));
-    //     assert(hasSharedBounds, 'should have had shared bounds');
-    //     assert(top === null, 'should not have had shared top bounds');
-    //     assert(right === 'right', 'should have had shared bottom bounds');
-    //     assert(bottom === 'top', 'should have had shared bottom bounds');
-    //     assert(left === 'left', 'should have had shared bottom bounds');
-    // });
+    it ('should grow correctly on external monitors with negative x', () => {
+        const rect = Rectangle.CREATE_FROM_BOUNDS({'x': -1206, 'y': 540, 'width': 491, 'height': 253});
+        const grownUp = rect.grow(5, 5);
 
-    // it('should return the shared bounds bottom right at the threshold', () => {
-    //     // bottom
-    //     const rect1 = new Rectangle(0, 0, 100, 100);
-    //     const rect2 = new Rectangle(0, 100, 100, 100);
-    //     const sharedBounds = rect1.sharedBounds(rect2);
-    //     const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
-    //     // tslint:disable 
-    //     // console.log(rect1.sharedBounds(rect2));
-    //     assert(hasSharedBounds, 'should have had shared bounds');
-    // });
+        assert.deepStrictEqual(grownUp, Rectangle.CREATE_FROM_BOUNDS({'x': -1211, 'y': 535, 'width': 501, 'height': 263}));
+    });
+
+    it ('should grow correctly on external monitors with negative x, y', () => {
+        const rect = Rectangle.CREATE_FROM_BOUNDS({'x': -1206, 'y': -540, 'width': 491, 'height': 253});
+        const grownUp = rect.grow(5, 5);
+
+        assert.deepStrictEqual(grownUp, Rectangle.CREATE_FROM_BOUNDS({'x': -1211, 'y': -545, 'width': 501, 'height': 263}));
+    });
+
+    it('should collide', () => {
+        const rect = Rectangle.CREATE_FROM_BOUNDS({'x': 918, 'y': -1009, 'width': 670, 'height': 454});
+        const rect2 = Rectangle.CREATE_FROM_BOUNDS({'x': 952, 'y': -556, 'width': 641, 'height': 549});
+        const collides = rect.collidesWith(rect2);
+
+        assert(collides, 'should have collided, top to bottom and right to right');
+    });
 });


### PR DESCRIPTION
There are a few things that this PR does, but mostly it is a precursor to making group resizing a deferred-bounds transaction by starting to tease out and isolate the logic that handles the positioning from the logic that decides how and when to move it. 

The three changes to behavior that this makes are:
*  Windows will now only resize if they are within 5px of each other. Currently, for example, a vertical resize will resize any window resting on that `x` value no matter where it is on the screen
* Windows now, when they are within the 5 px threshold and are a candidate for a grouped resize will take the value of the resizing edge exactly, meaning that they snap to the resizing edge and stick there.
* When a window that is being resized reaches its minimum size it will be pushed in the direction of the resize instead of losing the connected edge. 

Also, hopefully you find that the changes here are generally more stable than whats currently there. In testing / investigating it seems like there is quite a bit of perhaps unintentional behavior associated with how it works now.

We need to validate these changes with layouts to make sure that we don't break them in a bad way. This should be treated as an intermediate step towards a larger behavior change, though should be consumable and stable as is.  

[Tests well](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5bd32ef0cb360141a7dfd18d)