### PR TITLE
RUN-4480: no API injection for Chrome pages

### DIFF
--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -1102,7 +1102,7 @@ function createAppObj(uuid, opts, configUrl = '') {
         // save the original value of autoShow, but set it false so we can
         // show only after the DOMContentLoaded event to prevent the flash
         opts.toShowOnRun = eOpts['autoShow'];
-        eOpts.show = false;
+        eOpts.show = isChromePageUrl(opts.url); // no API injection for chrome pages
 
         appObj.mainWindow = new BrowserWindow(eOpts);
         appObj.mainWindow.setFrameConnectStrategy(eOpts.frameConnect || 'last');

--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -1101,8 +1101,10 @@ function createAppObj(uuid, opts, configUrl = '') {
 
         // save the original value of autoShow, but set it false so we can
         // show only after the DOMContentLoaded event to prevent the flash
-        opts.toShowOnRun = eOpts['autoShow'];
-        eOpts.show = isChromePageUrl(opts.url); // no API injection for chrome pages
+        if (!isChromePageUrl(opts.url)) { // no API injection for chrome pages
+            opts.toShowOnRun = eOpts['autoShow'];
+            eOpts.show = false;
+        }
 
         appObj.mainWindow = new BrowserWindow(eOpts);
         appObj.mainWindow.setFrameConnectStrategy(eOpts.frameConnect || 'last');


### PR DESCRIPTION
[Tests](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5bd3b961cb360141a7dfd19b)
[Runtime](https://github.com/openfin/runtime/pull/1224)

Chrome pages need the original window.alert, confirm, prompt.