### PR TITLE
RUN-4733 - Multi-Runtime Channels Bug

### DIFF
--- a/src/browser/api_protocol/api_handlers/mesh_middleware.ts
+++ b/src/browser/api_protocol/api_handlers/mesh_middleware.ts
@@ -187,21 +187,21 @@ function aggregateFromExternalRuntime(msg: MessagePackage, next: (locals?: objec
                 aggregateData.action = 'get-all-channels';
             }
             Promise.all(filteredRuntimes.map(runtime => runtime.fin.System.executeOnRemote(identity, aggregateData)))
-                .then(externalResults => {
-                    const externalRuntimeData = externalResults.reduce((result, runtime) => {
-                        if (runtime && runtime.data) {
-                            if (Array.isArray(runtime.data)) {
-                                return [...result, ...runtime.data];
-                            } else {
-                                return [...result, runtime.data];
-                            }
+            .then(externalResults => {
+                const externalRuntimeData = externalResults.reduce((result, runtime) => {
+                    if (runtime && runtime.data) {
+                        if (Array.isArray(runtime.data)) {
+                            return [...result, ...runtime.data];
+                        } else {
+                            return [...result, runtime.data];
                         }
-                        return result;
-                    }, []);
-                    const locals = { aggregate: externalRuntimeData };
-                    next(locals);
-                })
-                .catch(nack);
+                    }
+                    return result;
+                }, []);
+                const locals = { aggregate: externalRuntimeData };
+                next(locals);
+            })
+            .catch(nack);
         } else {
             next();
         }

--- a/src/browser/api_protocol/transport_strategy/elipc_strategy.ts
+++ b/src/browser/api_protocol/transport_strategy/elipc_strategy.ts
@@ -1,9 +1,8 @@
-import { AckMessage, AckFunc, AckPayload } from './ack';
+import { AckMessage, AckFunc, AckPayload, NackPayload } from './ack';
 import { ApiTransportBase, MessagePackage, MessageConfiguration } from './api_transport_base';
 import { default as RequestHandler } from './base_handler';
 import { Endpoint, ActionMap } from '../shapes';
 import { Identity } from '../../../shapes';
-import { writeToLog } from '../../log';
 declare var require: any;
 
 const coreState = require('../../core_state');
@@ -80,6 +79,10 @@ export class ElipcStrategy extends ApiTransportBase<MessagePackage> {
                         }).catch(err => {
                             nack(err);
                         });
+                } else {
+                    const runtimeVersion = system.getVersion();
+                    const message = `API call ${data.action} not implemented in runtime version: ${runtimeVersion}.`;
+                    ack(new NackPayload(message));
                 }
             }
         });

--- a/src/browser/api_protocol/transport_strategy/ws_strategy.ts
+++ b/src/browser/api_protocol/transport_strategy/ws_strategy.ts
@@ -34,6 +34,10 @@ export class WebSocketStrategy extends ApiTransportBase<MessagePackage> {
                         }).catch(err => {
                             ack(new NackPayload(err));
                         });
+                } else {
+                    const runtimeVersion = system.getVersion();
+                    const nackMessage = `API call ${data.action} not implemented in runtime version: ${runtimeVersion}.`;
+                    ack(new NackPayload(nackMessage));
                 }
             }
         });


### PR DESCRIPTION
Fixed multi-runtime channels bug where channels calls that get aggregated across runtimes did not work when there was a runtime version alive that is prior to the version in which the call had been implemented.

Also added nack on unimplemented API calls.

[Win7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5bdc6feacb360141a7dfd1d8)
[Win10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5bdc711acb360141a7dfd1d9)