### PR TITLE
RUN-4734: better solution for disabling API injection for chrome page…

### DIFF
--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -1101,12 +1101,8 @@ function createAppObj(uuid, opts, configUrl = '') {
 
         // save the original value of autoShow, but set it false so we can
         // show only after the DOMContentLoaded event to prevent the flash
-        if (isChromePageUrl(opts.url)) { // no API injection for chrome pages
-            eOpts.show = true;
-        } else {
-            opts.toShowOnRun = eOpts['autoShow'];
-            eOpts.show = false;
-        }
+        opts.toShowOnRun = eOpts['autoShow'];
+        eOpts.show = false;
 
         appObj.mainWindow = new BrowserWindow(eOpts);
         appObj.mainWindow.setFrameConnectStrategy(eOpts.frameConnect || 'last');

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -62,6 +62,9 @@ let Window = {}; // jshint ignore:line
 const disabledFrameRef = new Map();
 
 let browserWindowEventMap = {
+    'api-injection-disabled': {
+        topic: 'api-injection-disabled'
+    },
     'api-injection-failed': {
         topic: 'api-injection-failed'
     },
@@ -795,6 +798,16 @@ Window.create = function(id, opts) {
                     if (_options.autoShow) {
                         browserWindow.show();
                     }
+                    constructorCallbackMessage.data = {
+                        httpResponseCode,
+                        apiInjected: false
+                    };
+                    observer.next(constructorCallbackMessage);
+                });
+                ofEvents.once(route.window('api-injection-disabled', uuid, name), () => {
+                    electronApp.vlog(1, `api-injection-disabled ${uuid}-${name}`);
+                    // can happen for chrome pages
+                    browserWindow.show();
                     constructorCallbackMessage.data = {
                         httpResponseCode,
                         apiInjected: false


### PR DESCRIPTION
Instead of checking if API should be injected in init.js,  it is done in RenderClient::DidCreateScriptContext

[Runtime PR](https://github.com/openfin/runtime/pull/1238)

[Tests](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5be0a076cb360141a7dfd1fd)
