### PR TITLE
RUN-4677 - Channel lifecycle

### DIFF
--- a/src/browser/api_protocol/api_handlers/channel.ts
+++ b/src/browser/api_protocol/api_handlers/channel.ts
@@ -14,6 +14,8 @@ export class ChannelApiHandler {
     private readonly actionMap: ActionSpecMap = {
         'connect-to-channel': this.connectToChannel,
         'create-channel': this.createChannel,
+        'destroy-channel': this.destroyChannel,
+        'disconnect-from-channel': this.disconnectFromChannel,
         'get-all-channels': this.getAllChannels,
         'send-channel-message': this.sendChannelMessage,
         'send-channel-result': this.sendChannelResult
@@ -46,7 +48,7 @@ export class ChannelApiHandler {
         return undefined;
     }
 
-    private createChannel(identity: Identity, message: APIMessage, ack: AckFunc, nack: NackFunc): void {
+    private createChannel(identity: Identity, message: APIMessage, ack: AckFunc): void {
         const { payload, locals } = message;
         const { channelName } = payload;
 
@@ -63,7 +65,21 @@ export class ChannelApiHandler {
         ack(dataAck);
     }
 
-    private getAllChannels(identity: Identity, message: APIMessage, ack: AckFunc, nack: NackFunc): ProviderIdentity[] {
+    private destroyChannel(identity: Identity, message: APIMessage, ack: AckFunc): void {
+        const { payload: { channelName } } = message;
+
+        Channel.destroyChannel(identity, channelName);
+        ack(successAck);
+    }
+
+    private disconnectFromChannel(identity: Identity, message: APIMessage, ack: AckFunc): void {
+        const { payload: { channelName } } = message;
+
+        Channel.disconnectFromChannel(identity, channelName);
+        ack(successAck);
+    }
+
+    private getAllChannels(identity: Identity, message: APIMessage, ack: AckFunc): ProviderIdentity[] {
         const { locals } = message;
 
         let allChannels = Channel.getAllChannels();


### PR DESCRIPTION
Added calls to destroy or disconnect from a channel and fixed some lifecycle eventing around a channel participant restarting or navigating (destroying context where channel class was created).  

[js-adapter PR](https://github.com/HadoukenIO/js-adapter/pull/203)

New Testrunner tests:
[test1](https://testing-dashboard.openfin.co/#/app/tests/5be1bffecb360141a7dfd22f/edit)
[test2](https://testing-dashboard.openfin.co/#/app/tests/5be09f96cb360141a7dfd1fc/edit)
[test3](https://testing-dashboard.openfin.co/#/app/tests/5be0a3d9cb360141a7dfd200/edit)
[test4](https://testing-dashboard.openfin.co/#/app/tests/5be0a5bfcb360141a7dfd201/edit)
[test5](https://testing-dashboard.openfin.co/#/app/tests/5be0a0facb360141a7dfd1fe/edit)
[test6](https://testing-dashboard.openfin.co/#/app/tests/5be1ac71cb360141a7dfd22a/edit)
[test7](https://testing-dashboard.openfin.co/#/app/tests/5be0acb4cb360141a7dfd202/edit)
[test8](https://testing-dashboard.openfin.co/#/app/tests/5be1e978cb360141a7dfd244/edit)

[Win7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5be1c842cb360141a7dfd234)
[Win10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5be1c976cb360141a7dfd235)