### PR TITLE
RUN-4738 Send RVM heartbeat event on an interval

### DIFF
--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -26,7 +26,7 @@ let externalApiBase = require('../api_protocol/api_handlers/api_protocol_base');
 import { cachedFetch, fetchReadFile } from '../cached_resource_fetcher';
 import ofEvents from '../of_events';
 import WindowGroups from '../window_groups';
-import { sendToRVM } from '../rvm/utils';
+import { sendToRVM, stopRVMHeartbeatTimer, startRVMHeartbeatTimer } from '../rvm/utils';
 import { validateNavigationRules } from '../navigation_validation';
 import * as log from '../log';
 import SubscriptionManager from '../subscription_manager';
@@ -610,6 +610,7 @@ function run(identity, mainWindowOpts, userAppConfigArgs) {
         ofEvents.on(route.application(appEvent, uuid), sendAppsEventsToRVMListener);
     });
 
+    startRVMHeartbeatTimer(argo['rvm-heartbeat-interval']);
 
     //for backwards compatibility main window needs to have name === uuid
     mainWindowOpts = Object.assign({}, mainWindowOpts, { name: uuid }); //avoid mutating original object
@@ -708,6 +709,7 @@ function run(identity, mainWindowOpts, userAppConfigArgs) {
                 // Unregister all shortcuts.
                 globalShortcut.unregisterAll();
 
+                stopRVMHeartbeatTimer();
             } catch (err) {
                 // comma separation seems to fail core side
                 console.error('Error shutting down runtime');


### PR DESCRIPTION
[JIRA](https://appoji.jira.com/browse/RUN-4738)

Send a heartbeat event to the RVM on an interval (default 5s) which can be configured with `--rvm-heartbeat-interval`. This event will be used in the future for better RVM lifecycle awareness and for RVM recovery by the runtime.  

Tests:  
[Win7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5be2030ecb360141a7dfd245)
[Win10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5be20411cb360141a7dfd246)