### PR TITLE
 RUN-4497 Restrict group resizing

### DIFF
--- a/src/browser/rectangle.ts
+++ b/src/browser/rectangle.ts
@@ -1,6 +1,4 @@
 import { BrowserWindow } from '../shapes';
-import { writeToLog } from './log';
-const l = (x: any) => writeToLog(1, x, true);
 
 type SideName = 'top' | 'right' | 'bottom' | 'left';
 type SharedBounds = {
@@ -359,27 +357,6 @@ export class Rectangle {
         return adjLists;
     }
 
-    public static GRAPH(rects: Rectangle[]): Graph  {
-        const edges = [];
-        const vertices: Array<number> = [];
-        const rectLen = rects.length;
-
-        for (let i = 0; i < rectLen; i++) {
-            const rect = rects[i];
-            vertices.push(i);
-
-            for (let ii = 0; ii < rectLen; ii++) {
-                if (i !== ii) {
-                    if (rect.sharedBoundsOnIntersection(rects[ii]).hasSharedBounds) {
-                        edges.push([i, ii]);
-                    }
-                }
-            }
-        }
-
-        return [vertices, edges];
-    }
-
     public static GRAPH_WITH_SIDE_DISTANCES(rects: Rectangle[])  {
         const edges: Set<string> = new Set();
         const edgeDistances: Map<string, number> = new Map();
@@ -398,9 +375,9 @@ export class Rectangle {
                         
                         sharedBoundsList.forEach((sides) => {
                             const [mySide, otherSide] = sides;
-                            const keyThing = [i, ii, Side[mySide], Side[otherSide]].toString();
-                            edges.add(keyThing)
-                            edgeDistances.set(keyThing, Math.abs(rect[mySide] - rects[ii][otherSide]));
+                            const key = [i, ii, Side[mySide], Side[otherSide]].toString();
+                            edges.add(key)
+                            edgeDistances.set(key, Math.abs(rect[mySide] - rects[ii][otherSide]));
                         });
                     }
                 }
@@ -430,94 +407,6 @@ export class Rectangle {
         }
 
         return true;
-    }
-
-    public static SETIFY_GRAPH (graph: Graph): GraphSet {
-
-        const vertices = new Set();
-        const edges = new Set();
-        graph[0].forEach(v => vertices.add(v));
-        graph[1].forEach(e => edges.add(e.toString()));
-        return {vertices, edges};
-    }
-
-    // is a a subgraph of b
-    public static IS_SUBGRAPH (a: GraphSet, b: GraphSet) {
-        for (const v of a.vertices) {
-            if (!b.vertices.has(v)) {
-                // writeToLog(1, `missing vert ${v}` , true);
-                return false;
-            }
-        }
-
-        for (const e of a.edges) {
-            if (!b.edges.has(e)) {
-                // writeToLog(1, `missing edge ${e}` , true);
-                // writeToLog(1, `the edge list ${JSON.stringify([...b.edges])}` , true);
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    public static DISTANCES(graph: (number[] | number[][])[] , refV: number) {
-        const [vertices, edges] = graph;
-        const distances = new Map();
-
-        for (let v in vertices) {
-            distances.set(+v, Infinity);
-        }
-
-        distances.set(refV, 0);
-
-        const toVisit = [refV];
-
-        while (toVisit.length) {
-            const u = toVisit.shift();
-
-            const e = (<number [][]>edges).filter(([uu]): boolean => uu === u);
-            
-            e.forEach(([u, v]) => {
-                if (distances.get(v) === Infinity) {
-                    toVisit.push(v);
-                    distances.set(v, distances.get(u) + 1); 
-                }
-            });
-        }
-
-        return distances;
-    }
-
-    public static BREADTH_WALK(graph: (number[] | number[][])[] , refV: number) {
-        const [vertices, edges] = graph;
-        const distances = new Map();
-
-        for (let v in vertices) {
-            distances.set(+v, []);
-        }
-
-        distances.set(refV, [refV]);
-
-        const toVisit = [refV];
-
-        while (toVisit.length) {
-            const u = toVisit.shift();
-
-            const e = (<number [][]>edges).filter(([uu]): boolean => uu === u);
-            
-            e.forEach(([u, v]) => {
-                if (distances.get(v).slice(-1)[0] !== v) {
-                    toVisit.push(v);
-                    const d = distances.get(u).concat(distances.get(v));
-
-                    d.push(v);
-                    distances.set(v, d); 
-                }
-            });
-        }
-
-        return distances;
     }
 }
 

--- a/test/rectangle.ts
+++ b/test/rectangle.ts
@@ -20,7 +20,7 @@ describe('Rectangle', () => {
     it('should return the shared bounds within threshold, above', () => {
         const rect1 = new Rectangle(0, 0, 100, 100);
         const rect2 = new Rectangle(0, 97, 100, 100);
-        const sharedBounds = rect1.sharedBounds(rect2);
+        const sharedBounds = rect1.sharedBoundsOnIntersection(rect2);
         const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
 
         assert(hasSharedBounds, 'should have had shared bounds');
@@ -33,7 +33,7 @@ describe('Rectangle', () => {
     it('should return the shared bounds within threshold, below', () => {
         const rect1 = new Rectangle(0, 0, 100, 100);
         const rect2 = new Rectangle(0, 104, 100, 100);
-        const sharedBounds = rect1.sharedBounds(rect2);
+        const sharedBounds = rect1.sharedBoundsOnIntersection(rect2);
         const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
 
         assert(hasSharedBounds, 'should have had shared bounds');
@@ -47,7 +47,7 @@ describe('Rectangle', () => {
 
         const rect1 = new Rectangle(0, 0, 100, 100);
         const rect2 = new Rectangle(0, 100, 100, 100);
-        const sharedBounds = rect1.sharedBounds(rect2);
+        const sharedBounds = rect1.sharedBoundsOnIntersection(rect2);
         const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
 
         assert(hasSharedBounds, 'should have had shared bounds');
@@ -61,7 +61,7 @@ describe('Rectangle', () => {
 
         const rect1 = new Rectangle(0, 0, 100, 100);
         const rect2 = new Rectangle(0, 106, 100, 100);
-        const sharedBounds = rect1.sharedBounds(rect2);
+        const sharedBounds = rect1.sharedBoundsOnIntersection(rect2);
         const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
 
         assert(hasSharedBounds === false, 'should have had shared bounds');
@@ -76,7 +76,7 @@ describe('Rectangle', () => {
 
         const rect1 = new Rectangle(0, 0, 100, 100);
         const rect2 = new Rectangle(0, 0, 100, 100);
-        const sharedBounds = rect1.sharedBounds(rect2);
+        const sharedBounds = rect1.sharedBoundsOnIntersection(rect2);
         const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
 
         assert(hasSharedBounds, 'should have had shared bounds');
@@ -89,7 +89,7 @@ describe('Rectangle', () => {
     it('should return true for all if directly on top, matching left bounds', () => {
         const rect1 = new Rectangle(0, 0, 100, 100);
         const rect2 = new Rectangle(0, 10, 90, 80);
-        const sharedBounds = rect1.sharedBounds(rect2);
+        const sharedBounds = rect1.sharedBoundsOnIntersection(rect2);
         const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
 
         assert(hasSharedBounds, 'should have had shared bounds');
@@ -102,7 +102,7 @@ describe('Rectangle', () => {
     it('should return true for all if directly on top, matching top, left bounds', () => {
         const rect1 = new Rectangle(0, 0, 100, 100);
         const rect2 = new Rectangle(0, 0, 90, 90);
-        const sharedBounds = rect1.sharedBounds(rect2);
+        const sharedBounds = rect1.sharedBoundsOnIntersection(rect2);
         const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
 
         assert(hasSharedBounds, 'should have had shared bounds');
@@ -116,7 +116,7 @@ describe('Rectangle', () => {
         // bottom
         const rect1 = new Rectangle(0, 0, 100, 100);
         const rect2 = new Rectangle(10, 0, 80, 90);
-        const sharedBounds = rect1.sharedBounds(rect2);
+        const sharedBounds = rect1.sharedBoundsOnIntersection(rect2);
         const {hasSharedBounds, top, right, bottom, left} = sharedBounds;
 
         assert(hasSharedBounds, 'should have had shared bounds');


### PR DESCRIPTION
This is a consumable iteration on group resize behavior. When a a resize would trigger a broken edge anywhere in the window graph it is not committed. There is a case (which already exists) where you can cross over the other edge of a window and attach to that. This case will be a follow up PR if we decide to take it on.

Pay no attention to the time stamp :) 