### PR TITLE
RUN-4377 Handle new event "bounds-changing"

### DIFF
--- a/src/browser/external_window_event_adapter.js
+++ b/src/browser/external_window_event_adapter.js
@@ -57,6 +57,10 @@ class ExternalWindowEventAdapter {
             browserWindow.emit('bounds-changed');
         });
 
+        ofEvents.on(route.externalWindow('bounds-changing', uuid, name), (bounds) => {
+            browserWindow.emit('bounds-changing', bounds);
+        });
+
         ofEvents.on(route.externalWindow('visibility-changed', uuid, name), (visibility) => {
             browserWindow.emit('visibility-changed', {}, visibility);
         });


### PR DESCRIPTION
On Windows with performance mod enabled event "bounds-changing" is not emitted during user drag. I added new event to be emitted from runtime and created commit with support for this new runtime event.
This should be integrated together with https://github.com/openfin/runtime/pull/1240