### PR TITLE
RVM-733: User-configurable flush interval for app logs

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -919,7 +919,7 @@ Window.create = function(id, opts) {
             // Format timestamp to match debug.log
             const timeStamp = `${month}/${day}/${year} ${hour}:${minute}:${second}`;
 
-            addConsoleMessageToRVMMessageQueue({ level, message, appConfigUrl, timeStamp });
+            addConsoleMessageToRVMMessageQueue({ level, message, appConfigUrl, timeStamp }, app._options.appLogFlushInterval);
 
         }, 1);
     };

--- a/src/browser/rvm/utils.ts
+++ b/src/browser/rvm/utils.ts
@@ -13,8 +13,8 @@ interface SendToRVMOpts {
     payload?: any;
 }
 
-// 1 MB
-const maxBytes: number = 1000000;
+const maxBytes: number = 1000000;  // 1 MB
+const defaultFlushInterval: number = 10000;  // 10 seconds
 
 let consoleMessageQueue: ConsoleMessage[] = [];
 let isFlushScheduled: boolean = false;
@@ -43,7 +43,7 @@ function flushConsoleMessageQueue(): void {
     sendToRVM(obj, true);
 }
 
-export function addConsoleMessageToRVMMessageQueue(consoleMessage: ConsoleMessage): void {
+export function addConsoleMessageToRVMMessageQueue(consoleMessage: ConsoleMessage, flushInterval?: number): void {
     consoleMessageQueue.push(consoleMessage);
 
     const byteLength = Buffer.byteLength(consoleMessage.message, 'utf8');
@@ -61,7 +61,7 @@ export function addConsoleMessageToRVMMessageQueue(consoleMessage: ConsoleMessag
     // Otherwise if no timer already set, set one to flush the queue in 10s
     } else if (!isFlushScheduled) {
         isFlushScheduled = true;
-        timer = setTimeout(flushConsoleMessageQueue, 10000);
+        timer = setTimeout(flushConsoleMessageQueue, flushInterval ? flushInterval : defaultFlushInterval);
     }
 }
 

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -146,6 +146,7 @@ export interface WindowOptions {
     alwaysOnBottom?: boolean;
     alwaysOnTop?: boolean;
     applicationIcon?: string;
+    appLogFlushInterval?: number;
     aspectRatio?: number;
     autoShow?: boolean;
     backgroundColor?: string;


### PR DESCRIPTION
If `startup_app.appLogFlushInterval` is defined, it'll be used as a flush
interval for application logs, with the value being interpreted as
milliseconds. Note that flushing can still occur earlier if a buffer of 1
MB is hit (maybe we want to also make that magic value configurable?).

If it's not defined, the existing flush interval of ten seconds is used.