### PR TITLE
RUN-4690 Formalize grouped resize behavior

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -810,8 +810,8 @@ Window.create = function(id, opts) {
 
         });
 
-        //Restoring window possitioning from disk cache.
-        //We treat this as a check point event, either succes or failure will raise the event.
+        //Restoring window positioning from disk cache.
+        //We treat this as a check point event, either success or failure will raise the event.
         const windowPositioningObserver = Rx.Observable.create(observer => {
             if (!_options.saveWindowState) {
                 observer.next();

--- a/src/browser/disabled_frame_group_tracker.ts
+++ b/src/browser/disabled_frame_group_tracker.ts
@@ -169,10 +169,26 @@ function handleBoundsChanging(
 
 function handleResizeMove(start: Rectangle, end: RectangleBase, positions: [OpenFinWindow, Rectangle][]): Move[] {
 
+    let leaderRect: number;
+    const numRects = positions.length;
+    const rectPositions: Rectangle[] = [];
 
-    return positions.map(([win, baseRect]): Move => {
-        const movedRect = baseRect.move(start, end);
-        return [win, movedRect];
+    for (let i = 0; i < numRects; i++) {
+        const [_, rect] = positions[i];
+        if (rect.hasIdenticalBounds(start)) { leaderRect = i; }
+        rectPositions.push(rect);
+    }
+
+    const windowGraph = Rectangle.GRAPH(rectPositions);
+    const distances = Rectangle.DISTANCES(windowGraph, leaderRect);
+
+    return positions.map(([win, baseRect], index): Move => {
+        let rectFinalPosition = baseRect;
+        if (distances.get(index) < Infinity) {
+            rectFinalPosition = baseRect.move(start, end);
+        }
+
+        return [win, rectFinalPosition];
     });
 }
 

--- a/src/browser/rectangle.ts
+++ b/src/browser/rectangle.ts
@@ -373,6 +373,13 @@ export class Rectangle {
         return Array.from(Rectangle.ADJACENCY_LIST([...rects, this as Rectangle]).values()).find(list => list.includes(this));
     }
 
+    public hasIdenticalBounds(rect: RectangleBase): boolean {
+        return this.x === rect.x &&
+            this.y === rect.y &&
+            this.width === rect.width &&
+            this.height === rect.height;
+    }
+
     public static ADJACENCY_LIST(rects: Rectangle[]): Map<number, Rectangle[]> {
         const adjLists = new Map();
         const rectLen = rects.length;

--- a/test/rectangle.ts
+++ b/test/rectangle.ts
@@ -276,4 +276,50 @@ describe('Rectangle', () => {
         const result = rect.move(rect1From, rect1To);
         assert(result.height === 38);
     });
+
+    it('should recognize if another window shares the same bounds', () => {
+        const rect1 = Rectangle.CREATE_FROM_BOUNDS({ 'x': 0, 'y': 0, 'width': 100, 'height': 100 });
+        const rect2 = Rectangle.CREATE_FROM_BOUNDS({ 'x': 0, 'y': 0, 'width': 100, 'height': 100 });
+
+        assert(rect1.hasIdenticalBounds(rect2), 'these windows share bounds');
+    });
+
+    it('should recognize if another window does not shares the same bounds', () => {
+        const rect1 = Rectangle.CREATE_FROM_BOUNDS({ 'x': 0, 'y': 0, 'width': 100, 'height': 100 });
+        const rect2 = Rectangle.CREATE_FROM_BOUNDS({ 'x': 1, 'y': 0, 'width': 100, 'height': 100 });
+
+        assert(!(rect1.hasIdenticalBounds(rect2)), 'these windows do not share bounds');
+    });
+
+    it('should produce a graph of the window list', () => {
+        const [vertices, edges] = Rectangle.GRAPH(rectList());
+        const correctVertices = [0, 1, 2, 3, 4, 5];
+        const correctEdges = [
+            [0, 1], [0, 3],
+            [1, 0], [1, 2], [1, 3], [1, 5],
+            [2, 1], [2, 5],
+            [3, 0], [3, 1],
+            [5, 1], [5, 2]];
+
+        assert.deepStrictEqual(vertices, correctVertices, 'vertices should match');
+        assert.deepStrictEqual(edges, correctEdges, 'edges should match');
+    });
+
+    it('should produce a distance set given a graph and a reference vertex', () => {
+        const distances = Rectangle.DISTANCES(Rectangle.GRAPH(rectList()), 0);
+        const correctDistances = [[0, 0], [1, 1], [2, 2], [3, 1], [4, Infinity], [5, 2]];
+
+        assert.deepEqual([...distances], correctDistances, 'reported distances are incorrect');
+    });
 });
+
+function rectList (): Rectangle[] {
+    return [
+        new Rectangle(0, 0, 100, 100),
+        new Rectangle(4, 4, 100, 100),
+        new Rectangle(8, 8, 100, 100),
+        new Rectangle(50, 0, 100, 100),
+        new Rectangle(400, 400, 100, 100),
+        new Rectangle(6, 6, 100, 100)
+    ];
+}


### PR DESCRIPTION
When in a group, a resizing window will only grab the edeges of
windows that are within the shared bounds threshold to the moving
edge

@HarsimranSingh 