### PR TITLE
RUN-4823 delete cache folder on clear cache.

### DIFF
--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -9,7 +9,7 @@ const shell = electron.shell;
 const { crashReporter, idleState } = electron;
 
 // npm modules
-const path = require('path');
+const { path, join } = require('path');
 const crypto = require('crypto');
 const _ = require('underscore');
 
@@ -61,6 +61,20 @@ const defaultProc = {
         return 0;
     }
 };
+
+function rimraf(path) {
+    if (fs.existsSync(path)) {
+        fs.readdirSync(path).forEach(function(file, index) {
+            var curPath = join(path, file);
+            if (fs.lstatSync(curPath).isDirectory()) { // recurse
+                rimraf(curPath);
+            } else { // delete file
+                fs.unlinkSync(curPath);
+            }
+        });
+        fs.rmdirSync(path);
+    }
+}
 
 let MonitorInfo;
 let Session;
@@ -164,6 +178,7 @@ exports.System = {
 
         defaultSession.clearCache(() => {
             defaultSession.clearStorageData(cacheOptions, () => {
+                rimraf(join(electronApp.getPath('userData'), 'Cache'));
                 resolve();
             });
         });

--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -178,8 +178,12 @@ exports.System = {
 
         defaultSession.clearCache(() => {
             defaultSession.clearStorageData(cacheOptions, () => {
-                rimraf(join(electronApp.getPath('userData'), 'Cache'));
-                resolve();
+                try {
+                    rimraf(join(electronApp.getPath('userData'), 'Cache'));
+                    resolve();
+                } catch (err) {
+                    resolve(err);
+                }
             });
         });
 


### PR DESCRIPTION
in EC builds `System.clearCache` does not clear any files under `userData/Cache`, this affects any resource acquired by the resource fetcher.

This fix will ensure that the entire folder is removed on the API call.