### PR TITLE
Moving cache folder to chromium cache folder

### DIFF
--- a/src/browser/cached_resource_fetcher.ts
+++ b/src/browser/cached_resource_fetcher.ts
@@ -130,7 +130,7 @@ async function prepDownloadLocation(appCacheDir: string) {
 
 
 function getRootCachePath () {
-    return join(app.getPath('userData') , 'Cache');
+    return join(app.getPath('userData') , 'Default', 'Cache');
 }
 
 /**


### PR DESCRIPTION
in EC builds `System.clearCache` does not clear any files under `userData/Cache`, this affects any resource acquired by the resource fetcher.

This fix moves resource fetcher folder to `userData/Default/Cache`

[Win7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5c06e749cb360141a7dfd53a)
[Win10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5c06e8c3cb360141a7dfd53b)
