### PR TITLE
RUN-4758 build fix

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -327,8 +327,9 @@ module.exports = (grunt) => {
     /*
         Build webpack'ed js-adapter
     */
-   grunt.registerTask('js-adapter', () => {
+    grunt.registerTask('js-adapter', () => {
+        const gruntSubmodPath = path.resolve('./js-adapter/node_modules/.bin/grunt');
         grunt.log.subhead('Building js-adapter...');
-        childProcess.execSync('cd js-adapter && npm run build');
+        childProcess.execSync(`cd js-adapter && ${gruntSubmodPath} webpack`);
     });
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The core app of the OpenFin Runtime 8",
   "main": "index.js",
   "scripts": {
-    "build": "grunt",
+    "build": "grunt build-pac",
     "deploy": "grunt deploy",
     "postinstall": "grunt",
     "pretest": "grunt babel && grunt ts",


### PR DESCRIPTION
ℹ️ Changes:
1. `npm run build` now points to the correct Grunt task
2. Grunt's _js-adapter_ task will work faster as it will only webpack for browser (core takes care of server js-adapter code)

⛓ Requires [these js-adapter changes](https://github.com/HadoukenIO/js-adapter/pull/208)