### PR TITLE
RUN-4834 Updated Ack to send logId in a data payload.

### DIFF
--- a/src/browser/api_protocol/api_handlers/application.js
+++ b/src/browser/api_protocol/api_handlers/application.js
@@ -82,7 +82,11 @@ function sendApplicationLog(identity, message, ack) {
     const payload = message.payload;
     const appIdentity = apiProtocolBase.getTargetApplicationIdentity(payload);
 
-    return Application.sendApplicationLog(appIdentity).then(() => ack(successAck));
+    return Application.sendApplicationLog(appIdentity).then((logId) => {
+        const dataAck = _.clone(successAck);
+        dataAck.data = logId;
+        ack(dataAck);
+    });
 }
 
 function setTrayIcon(identity, rawMessage, ack, nack) {


### PR DESCRIPTION
The current implementation just receives an Ack or a Nack depending on whether the log was uploaded. Now we pass along a payload with the logId for the log that was uploaded.

To run:
```
app = fin.desktop.Application.getCurrent();

app.sendApplicationLog((info) => {
  console.log('logId', info.logId);
}, (err) => {
  console.log(err);
});
```