### PR TITLE
RUN-4819: mac main window close

### DIFF
--- a/index.js
+++ b/index.js
@@ -277,6 +277,12 @@ app.on('ready', function() {
     registerShortcuts();
     registerMacMenu();
 
+    app.on('activate', function() {
+        // On OS X it's common to re-create a window in the app when the
+        // dock icon is clicked and there are no other windows open.
+        launchApp(coreState.argo, true);
+    });
+
     //subscribe to auth requests:
     app.on('login', (event, webContents, request, authInfo, callback) => {
         let browserWindow = webContents.getOwnerBrowserWindow();

--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -687,7 +687,8 @@ function run(identity, mainWindowOpts, userAppConfigArgs) {
             app._options._type !== ERROR_BOX_TYPES.RENDERER_CRASH &&
             !app._options._runtimeAuthDialog &&
             !runtimeIsClosing &&
-            coreState.shouldCloseRuntime();
+            coreState.shouldCloseRuntime() &&
+            process.platform !== 'darwin';
 
         if (shouldCloseRuntime) {
             try {

--- a/src/browser/transports/unix_domain_socket.ts
+++ b/src/browser/transports/unix_domain_socket.ts
@@ -41,7 +41,7 @@ class UnixDomainSocket extends BaseTransport {
         });
         this.server.bind(this.serverName);
 
-        app.on('window-all-closed', this.cleanUpServer);
+        app.on('quit', this.cleanUpServer);
 
         // Clean up abandoned file descriptors
         Promise.all([this.getAllFileDescriptors(), this.getOpenFileDescriptors()]).then((values: [FileDescriptor[], FileDescriptor[]]) => {


### PR DESCRIPTION
Although there is no standard when close main window on mac,
it's petty reasonable to keep runtime alive after main window is closed (all-window-closed),
and then create the same main window when click on dock icon(just like chrome did on mac).
The tests works well on windows.