### PR TITLE
Windows with the same name can now join a group.

### DIFF
--- a/src/browser/window_groups.ts
+++ b/src/browser/window_groups.ts
@@ -72,6 +72,11 @@ export class WindowGroups extends EventEmitter {
         return hash.digest('hex');
     }
 
+    //cannot rely on nativeId as windows might leave a group after they are closed.
+    private getWindowGroupId = (identity: Identity): string => {
+        return `${identity.uuid}:${identity.name}`;
+    }
+
     public joinGroup = async (source: Identity, target: Identity): Promise<void> => {
         const sourceWindow: OpenFinWindow = <OpenFinWindow>coreState.getWindowByUuidName(source.uuid, source.name);
         let targetWindow: OpenFinWindow = <OpenFinWindow>coreState.getWindowByUuidName(target.uuid, target.name);
@@ -218,10 +223,11 @@ export class WindowGroups extends EventEmitter {
     };
 
     private _addWindowToGroup = async (groupUuid: string, win: OpenFinWindow): Promise<string> => {
+        const windowGroupId = this.getWindowGroupId(win);
         const _groupUuid = groupUuid || generateUuid();
         this._windowGroups[_groupUuid] = this._windowGroups[_groupUuid] || {};
         const group = this.getGroup(_groupUuid);
-        this._windowGroups[_groupUuid][win.name] = win;
+        this._windowGroups[_groupUuid][windowGroupId] = win;
         win.groupUuid = _groupUuid;
         if (argo['disabled-frame-groups']) {
             groupTracker.addWindowToGroup(win);
@@ -238,10 +244,11 @@ export class WindowGroups extends EventEmitter {
     };
 
     private _removeWindowFromGroup = async (groupUuid: string, win: OpenFinWindow): Promise<void> => {
+        const windowGroupId = this.getWindowGroupId(win);
         if (argo['disabled-frame-groups']) {
             groupTracker.removeWindowFromGroup(win);
         }
-        delete this._windowGroups[groupUuid][win.name];
+        delete this._windowGroups[groupUuid][windowGroupId];
 
         //update proxy windows to no longer be bound to this specific window.
         const group = this.getGroup(groupUuid);


### PR DESCRIPTION
Initially was using nativeId but windows leave groups during cleanup so the browserWindow has a change of being destroyed.

Auto Tests running.
Manual Tests pending.