### PR TITLE
RUN-4829 naming change from 'frame' to 'userMovement'

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -635,6 +635,12 @@ Window.create = function(id, opts) {
                     if (decoratorFn(payload, arguments)) {
                         // Let the decorator apply changes to the type
                         ofEvents.emit(route.window(payload.type, uuid, name), payload);
+                        // handle 'user-movement-disabled' or 'user-movement-enabled' events used in v2API
+                        if (evnt === 'user-movement-disabled' || evnt === 'user-movement-enabled') {
+                            let newPayload = _.clone(payload);
+                            newPayload.type = evnt;
+                            ofEvents.emit(route.window(newPayload.type, uuid, name), newPayload);
+                        }
                     }
                 };
 
@@ -1082,12 +1088,12 @@ function disabledFrameUnsubDecorator(identity) {
         if (refCount > 1) {
             disabledFrameRef.set(windowKey, --refCount);
         } else {
-            Window.enableFrame(identity);
+            Window.enableUserMovement(identity);
         }
     };
 }
 
-Window.disableFrame = function(requestorIdentity, windowIdentity) {
+Window.disableUserMovement = function(requestorIdentity, windowIdentity) {
     const browserWindow = getElectronBrowserWindow(windowIdentity);
     const windowKey = genWindowKey(windowIdentity);
 
@@ -1123,7 +1129,7 @@ Window.embed = function(identity, parentHwnd) {
     });
 };
 
-Window.enableFrame = function(identity) {
+Window.enableUserMovement = function(identity) {
     const windowKey = genWindowKey(identity);
     let browserWindow = getElectronBrowserWindow(identity);
 

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -635,10 +635,18 @@ Window.create = function(id, opts) {
                     if (decoratorFn(payload, arguments)) {
                         // Let the decorator apply changes to the type
                         ofEvents.emit(route.window(payload.type, uuid, name), payload);
-                        // handle 'user-movement-disabled' or 'user-movement-enabled' events used in v2API
+                        // emit new 'user-movement-disabled' or 'user-movement-enabled' events in v2API
                         if (evnt === 'user-movement-disabled' || evnt === 'user-movement-enabled') {
                             let newPayload = _.clone(payload);
                             newPayload.type = evnt;
+                            ofEvents.emit(route.window(newPayload.type, uuid, name), newPayload);
+                        }
+
+                        // emit new 'disabled-movement-bounds-changed' or 'disabled-movement-bounds-changing' events in v2API
+                        if (evnt === 'disabled-frame-bounds-changed' || evnt === 'disabled-frame-bounds-changing') {
+                            const newEventType = evnt === 'disabled-frame-bounds-changed' ? 'disabled-movement-bounds-changed' : 'disabled-movement-bounds-changing';
+                            let newPayload = _.clone(payload);
+                            newPayload.type = newEventType;
                             ofEvents.emit(route.window(newPayload.type, uuid, name), newPayload);
                         }
                     }

--- a/src/browser/api_protocol/api_handlers/window.ts
+++ b/src/browser/api_protocol/api_handlers/window.ts
@@ -26,9 +26,9 @@ export const windowApiMap = {
     'blur-window': blurWindow,
     'bring-window-to-front': bringWindowToFront,
     'close-window': closeWindow,
-    'disable-window-frame': disableWindowFrame,
+    'disable-window-frame': disableUserMovement,
     'dock-window': dockWindow,
-    'enable-window-frame': enableWindowFrame,
+    'enable-window-frame': enableUserMovement,
     'execute-javascript-in-window': { apiFunc: executeJavascript, apiPath: '.executeJavaScript' },
     'flash-window': flashWindow,
     'focus-window': focusWindow,
@@ -429,11 +429,11 @@ function flashWindow(identity: Identity, message: APIMessage, ack: Acker): void 
     ack(successAck);
 }
 
-function enableWindowFrame(identity: Identity, message: APIMessage, ack: Acker): void {
+function enableUserMovement(identity: Identity, message: APIMessage, ack: Acker): void {
     const { payload } = message;
     const windowIdentity = getTargetWindowIdentity(payload);
 
-    Window.enableFrame(windowIdentity);
+    Window.enableUserMovement(windowIdentity);
     ack(successAck);
 }
 
@@ -463,11 +463,11 @@ function executeJavascript(identity: Identity, message: APIMessage, ack: Acker, 
     return nack(new Error('Rejected, target window is not owned by requesting identity'));
 }
 
-function disableWindowFrame(identity: Identity, message: APIMessage, ack: Acker): void {
+function disableUserMovement(identity: Identity, message: APIMessage, ack: Acker): void {
     const { payload } = message;
     const windowIdentity = getTargetWindowIdentity(payload);
 
-    Window.disableFrame(identity, windowIdentity);
+    Window.disableUserMovement(identity, windowIdentity);
     ack(successAck);
 }
 


### PR DESCRIPTION
Test:
[Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5c111daccb360141a7dfd66f)

