### PR TITLE
RUN-4846: cookie migration for enable_chromium

### DIFF
--- a/index.js
+++ b/index.js
@@ -230,8 +230,6 @@ app.on('chrome-browser-process-created', function() {
         app.exit(0);
 
         return;
-    } else {
-        migrateCookies(); // not doing this for delegated launches
     }
 });
 
@@ -269,6 +267,8 @@ app.on('ready', function() {
     }
 
     rotateLogs(coreState.argo);
+
+    migrateCookies();
 
     //Once we determine we are the first instance running we setup the API's
     //Create the new Application.

--- a/index.js
+++ b/index.js
@@ -210,6 +210,7 @@ function handleDeferredLaunches() {
 
 app.on('chrome-browser-process-created', function() {
     otherInstanceRunning = app.makeSingleInstance((commandLine) => {
+        log.writeToLog(1, `chrome-browser-process-created callback ${commandLine}`, true);
         const socketServerState = coreState.getSocketServerState();
         if (appIsReady && socketServerState && socketServerState.port) {
             return handleDelegatedLaunch(commandLine);
@@ -229,6 +230,8 @@ app.on('chrome-browser-process-created', function() {
         app.exit(0);
 
         return;
+    } else {
+        migrateCookies(); // not doing this for delegated launches
     }
 });
 
@@ -744,6 +747,36 @@ function handleMacSingleTenant() {
         cachePath = path.join(userData, 'cache', cachePath, process.versions['openfin']);
         app.setPath('userData', cachePath);
         app.setPath('userCache', cachePath);
+    }
+}
+
+function migrateCookies() {
+    if (!process.buildFlags.enableChromium) {
+        return;
+    }
+    const userData = app.getPath('userData');
+    const cookiePath = path.join(path.join(userData, 'Default'));
+    const legacyCookiePath = userData;
+    const cookieFile = path.join(path.join(cookiePath, 'Cookies'));
+    const cookieJrFile = path.join(path.join(cookiePath, 'Cookies-journal'));
+    const legacyCookieFile = path.join(path.join(legacyCookiePath, 'Cookies'));
+    const legacyCookieJrFile = path.join(path.join(legacyCookiePath, 'Cookies-journal'));
+    try {
+        if (fs.existsSync(legacyCookieFile) && !fs.existsSync(cookieFile)) {
+            log.writeToLog('info', `migrating cookies from ${legacyCookiePath} to ${cookiePath}`);
+            fs.copyFileSync(legacyCookieFile, cookieFile);
+            fs.copyFileSync(legacyCookieJrFile, cookieJrFile);
+        } else {
+            log.writeToLog(1, `skip cookie migration in ${cookiePath}`, true);
+        }
+    } catch (err) {
+        log.writeToLog('info', `Error migrating cookies from ${legacyCookiePath} to ${cookiePath} ${err}`);
+        try {
+            fs.unlinkSync(cookieFile);
+        } catch (ignored) {}
+        try {
+            fs.unlinkSync(cookieJrFile);
+        } catch (ignored) {}
     }
 }
 


### PR DESCRIPTION
Tests

[W7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5c115d98cb360141a7dfd690)
[W10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5c115f43cb360141a7dfd693)

Performance, measured with Date.now()
with copy:  8 milliseconds
without copy:  0 milliseconds

Tested migrations:  8.56.30.55  -> 9.61.37.42,  9.61.36.36 -> 9.61.37.42