### PR TITLE
 RUN-4786 event subscription improvement (Phase 2)

### DIFF
--- a/src/browser/of_events.ts
+++ b/src/browser/of_events.ts
@@ -1,3 +1,4 @@
+import { app } from 'electron';
 import { EventEmitter } from 'events';
 import route from '../common/route';
 
@@ -17,7 +18,7 @@ class OFEvents extends EventEmitter {
     }
 
     public emit(routeString: string, ...data: any[]) {
-        const timestamp = Date.now();
+        const timestamp = app.nowFromSystemTime();
         const tokenizedRoute = routeString.split('/');
         const eventPropagations = new Map<string, any>();
         const [payload, ...extraArgs] = data;

--- a/src/browser/remote_subscriptions.ts
+++ b/src/browser/remote_subscriptions.ts
@@ -16,6 +16,7 @@
  * then may come back up again in the future.
  */
 
+import { app } from 'electron';
 import { noop } from '../common/main';
 import connectionManager, { PeerRuntime, keyFromPortInfo, getMeshUuid } from './connection_manager';
 import ofEvents from './of_events';
@@ -67,7 +68,7 @@ export function addRemoteSubscription(subscriptionProps: RemoteSubscriptionProps
         const clonedProps = JSON.parse(JSON.stringify(subscriptionProps));
         const subscription: RemoteSubscription = Object.assign(clonedProps, {
             isCleaned: false,
-            timestamp: Date.now()
+            timestamp: app.nowFromSystemTime()
         });
 
         // Only generate an ID for new subscriptions

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -14,13 +14,13 @@ declare module 'electron' {
         export function getTickCount(): number;
         export function isAeroGlassEnabled(): boolean;
         export function log(level: string, message: any): any;
+        export function matchesURL(url: string, patterns: [string]): boolean;
+        export function now(): number;
+        export function nowFromSystemTime(): number;
         export function on(event: string, callback: () => void): void;
+        export function readRegistryValue(root: string, key: string, value: string): any;
         export function setMinLogLevel(level: number): void;
         export function vlog(level: number, message: any): any;
-
-        export function readRegistryValue(root: string, key: string, value: string): any;
-
-        export function matchesURL(url: string, patterns: [string]): boolean;
     }
     namespace windowTransaction {
         export class Transaction {

--- a/test/electron.ts
+++ b/test/electron.ts
@@ -30,6 +30,9 @@ export const mockElectron = {
         },
         getCommandLineArgv: (): any => {
             return [];
+        },
+        nowFromSystemTime: (): number => {
+            return Date.now();
         }
 
     },

--- a/test/event-propagation.ts
+++ b/test/event-propagation.ts
@@ -14,13 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 /*tslint:disable */
+import { mockElectron } from './electron';
 import * as assert from 'assert';
+import * as mockery from 'mockery';
 import ofEvents from '../src/browser/of_events';
 import route from '../src/common/route';
 
 const uuid = 'uuid4';
 const name = 'name3';
 
+mockery.registerMock('electron', mockElectron);
+mockery.enable({
+    warnOnReplace: false,
+    warnOnUnregistered: false
+});
 
 describe('Event Propagation', function () {
     it('propagates window events to system', function (done) {


### PR DESCRIPTION
⚠️ It requires [runtime changes](https://github.com/openfin/runtime/pull/1281)
ℹ️ This PR makes subscriptions use our new custom native-backed function for timing. This ensures that multiple runtimes are on the same timeline (using system time) as we've discovered some issues with javascript's `Date` class.