### PR TITLE
RUN-4816 disabled frame group now on by default

### DIFF
--- a/src/browser/api_protocol/api_handlers/window.ts
+++ b/src/browser/api_protocol/api_handlers/window.ts
@@ -78,18 +78,11 @@ export const windowApiMap = {
 };
 
 export function init() {
-    const registerThis = argo['disabled-frame-groups']
+    const registerThis = !argo['use-legacy-window-groups']
        ? hijackMovesForGroupedWindows(windowApiMap)
        : windowApiMap;
     registerActionMap(registerThis, 'Window');
 }
-
-// function decorateActionMapForGroups(actionMap: ActionSpecMap): ActionSpecMap {
-//     const hijackOnGroup = {
-//         'set-window-bounds':
-//     }
-// actionMap.keys().
-// }
 
 function windowAuthenticate(identity: Identity, message: APIMessage, ack: Acker, nack: (error: Error) => void): void {
     const { payload } = message;

--- a/src/browser/bounds_changed_state_tracker.ts
+++ b/src/browser/bounds_changed_state_tracker.ts
@@ -104,7 +104,7 @@ export default class BoundsChangedStateTracker {
                 const groupUuid = ofWindow ? ofWindow.groupUuid : null;
 
                 const dispatchedChange = this.handleBoundsChange(true);
-                if (groupUuid && coreState.argo['disabled-frame-groups']) {
+                if (groupUuid && !coreState.argo['use-legacy-window-groups']) {
                     return;
                 }
                 if (dispatchedChange) {
@@ -351,7 +351,7 @@ export default class BoundsChangedStateTracker {
             const reason = this.boundsChangeReason(this.name, groupUuid);
 
             // handle window group movements
-            if (groupUuid && !coreState.argo['disabled-frame-groups']) {
+            if (groupUuid && coreState.argo['use-legacy-window-groups']) {
                 let groupLeader = WindowGroupTransactionTracker.getGroupLeader(groupUuid);
 
                 if (force) {

--- a/src/browser/window_groups.ts
+++ b/src/browser/window_groups.ts
@@ -232,7 +232,7 @@ export class WindowGroups extends EventEmitter {
         const group = this.getGroup(_groupUuid);
         this._windowGroups[_groupUuid][windowGroupId] = win;
         win.groupUuid = _groupUuid;
-        if (argo['disabled-frame-groups']) {
+        if (!argo['use-legacy-window-groups']) {
             groupTracker.addWindowToGroup(win);
         }
         if (!win.isProxy) {
@@ -248,7 +248,7 @@ export class WindowGroups extends EventEmitter {
 
     private _removeWindowFromGroup = async (groupUuid: string, win: OpenFinWindow): Promise<void> => {
         const windowGroupId = this.getWindowGroupId(win);
-        if (argo['disabled-frame-groups']) {
+        if (!argo['use-legacy-window-groups']) {
             groupTracker.removeWindowFromGroup(win);
         }
         delete this._windowGroups[groupUuid][windowGroupId];
@@ -284,7 +284,7 @@ export class WindowGroups extends EventEmitter {
                 win.groupUuid = null;
             }));
             delete this._windowGroups[groupUuid];
-            if (argo['disabled-frame-groups']) {
+            if (!argo['use-legacy-window-groups']) {
                 groupTracker.deleteGroupInfoCache(groupUuid);
             }
 

--- a/src/browser/window_groups_runtime_proxy.ts
+++ b/src/browser/window_groups_runtime_proxy.ts
@@ -205,12 +205,16 @@ export async function getRuntimeProxyWindow(identity: Identity): Promise<Runtime
     } else {
         const { runtime: hostRuntime} = await connectionManager.resolveIdentity(identity);
         const apiVersion = hostRuntime.portInfo.version.split('.')[2];
+
         if (+apiVersion < MIN_API_VER) {
             throw new Error(`Window belongs to an older version, cannot group with Windows on version ${ hostRuntime.portInfo.version }`);
         }
-        if (!argo['disabled-frame-groups']) {
+        if (argo['use-legacy-window-groups']) {
             // tslint:disable-next-line:max-line-length
-            throw new Error('Window belongs to another instance of OpenFin, experimental feature only enabled by setting the "disabled-frame-groups" flag');
+            throw new Error('Unsupported action: Window belongs to another instance of OpenFin and "use-legacy-window-groups" flag suplied.');
+        }
+        if (hostRuntime.portInfo.options['use-legacy-window-groups']) {
+            throw new Error('Unsupported action: Window belongs to another instance of OpenFin that is using "use-legacy-window-groups".');
         }
         const wrappedWindow = hostRuntime.fin.Window.wrapSync(identity);
         const nativeId = await wrappedWindow.getNativeId();


### PR DESCRIPTION
Disabled frame group is now on by default,  the `use-legacy-window-groups` flag will be there to opt out.

Manual tests: OK

Auto Tests running.