### PR TITLE
RUN-4855 fixed multi-runtime propagation

### DIFF
--- a/src/browser/of_events.ts
+++ b/src/browser/of_events.ts
@@ -21,11 +21,12 @@ class OFEvents extends EventEmitter {
         const timestamp = app.nowFromSystemTime();
         const tokenizedRoute = routeString.split('/');
         const eventPropagations = new Map<string, any>();
-        const [payload, maybeOpts, ...extraArgs] = data;
+        const [payload, maybeOpts, ...otherExtraArgs] = data;
         if (this.isSavingEvents) {
             this.history.push({ payload, routeString, timestamp });
         }
-
+        const isMultiRuntimeEvent = maybeOpts && maybeOpts.isMultiRuntime;
+        const extraArgs = isMultiRuntimeEvent ? otherExtraArgs : [maybeOpts, ...otherExtraArgs];
         if (tokenizedRoute.length >= 2) {
             const [channel, topic] = tokenizedRoute;
             const uuid: string = (payload && payload.uuid) || tokenizedRoute[2] || '*';
@@ -43,7 +44,6 @@ class OFEvents extends EventEmitter {
                 // Wildcard on any channel/topic of a specified source (ex: 'window/*/myUUID-myWindow')
                 super.emit(route(channel, '*', source), envelope);
             }
-            const isMultiRuntimeEvent = maybeOpts && maybeOpts.isMultiRuntime;
             const shouldPropagate = (channel === 'window' || channel === 'application') && !isMultiRuntimeEvent;
             if (shouldPropagate) {
                 const checkedPayload = typeof payload === 'object' ? payload : { payload };

--- a/src/browser/remote_subscriptions.ts
+++ b/src/browser/remote_subscriptions.ts
@@ -125,7 +125,7 @@ async function applyRemoteSubscription(subscription: RemoteSubscription, runtime
     const listener = (data: any) => {
         if (!data.runtimeUuid) {
             data.runtimeUuid = getMeshUuid();
-            ofEvents.emit(fullEventName, data);
+            ofEvents.emit(fullEventName, data, {isMultiRuntime: true});
         }
 
         // As soon as the event listener fires, we know which runtime is a true
@@ -286,7 +286,7 @@ function applySubscriptionToAllRuntimes(subscription: RemoteSubscription, runtim
     const listener = (data: any) => {
         if (!data.runtimeUuid) {
             data.runtimeUuid = getMeshUuid();
-            ofEvents.emit(fullEventName, data);
+            ofEvents.emit(fullEventName, data, {isMultiRuntime: true});
         }
     };
 


### PR DESCRIPTION
Don't re-propagate events from an external runtime to avoid double propagation