### PR TITLE
RUN-4856 fix(external-windows): Emitting 'close' events for ExternalWindows

### DIFF
--- a/src/browser/external_window_event_adapter.js
+++ b/src/browser/external_window_event_adapter.js
@@ -138,6 +138,9 @@ class ExternalWindowEventAdapter {
 
         ofEvents.on(route.externalWindow('close', uuid, name), () => {
             browserWindow.emit('close');
+            browserWindow.emit('will-close');
+
+            // ToDo: Determine if 'closed' is emitted twice on the external BrowserWindows
             browserWindow.close();
             browserWindow.emit('closed');
         });


### PR DESCRIPTION
ExternalWindows will now propagate 'will-close' for cleanup/API eventing.  The normal teardown/cleanup does occur in both the core and native


[Test Results: Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5c180ed5cb360141a7dfd72b)
[Test Results: Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5c181018cb360141a7dfd72d)
