### PR TITLE
RUN-4893 fix(v11 core): upgrade rx to rxjs

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -52,132 +52,6 @@
       "integrity": "sha512-VkKcfuitP+Nc/TaTFH0B8qNmn+6NbI6crLkQonbedViVz7O2w8QV/GERPlkJ4bg42VGHiEWa31CoTOPs1q6z1w==",
       "dev": true
     },
-    "@types/rx": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@types/rx/-/rx-4.1.1.tgz",
-      "integrity": "sha1-WY/JSla67ZdfGUV04PVy/Y5iekg=",
-      "dev": true,
-      "requires": {
-        "@types/rx-core": "*",
-        "@types/rx-core-binding": "*",
-        "@types/rx-lite": "*",
-        "@types/rx-lite-aggregates": "*",
-        "@types/rx-lite-async": "*",
-        "@types/rx-lite-backpressure": "*",
-        "@types/rx-lite-coincidence": "*",
-        "@types/rx-lite-experimental": "*",
-        "@types/rx-lite-joinpatterns": "*",
-        "@types/rx-lite-testing": "*",
-        "@types/rx-lite-time": "*",
-        "@types/rx-lite-virtualtime": "*"
-      }
-    },
-    "@types/rx-core": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@types/rx-core/-/rx-core-4.0.3.tgz",
-      "integrity": "sha1-CzNUsSOM7b4rdPYybxOdvHpZHWA=",
-      "dev": true
-    },
-    "@types/rx-core-binding": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@types/rx-core-binding/-/rx-core-binding-4.0.4.tgz",
-      "integrity": "sha512-5pkfxnC4w810LqBPUwP5bg7SFR/USwhMSaAeZQQbEHeBp57pjKXRlXmqpMrLJB4y1oglR/c2502853uN0I+DAQ==",
-      "dev": true,
-      "requires": {
-        "@types/rx-core": "*"
-      }
-    },
-    "@types/rx-lite": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/@types/rx-lite/-/rx-lite-4.0.5.tgz",
-      "integrity": "sha512-KZk5XTR1dm/kNgBx8iVpjno6fRYtAUQWBOmj+O8j724+nk097sz4fOoHJNpCkOJUtHUurZlJC7QvSFCZHbkC+w==",
-      "dev": true,
-      "requires": {
-        "@types/rx-core": "*",
-        "@types/rx-core-binding": "*"
-      }
-    },
-    "@types/rx-lite-aggregates": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@types/rx-lite-aggregates/-/rx-lite-aggregates-4.0.3.tgz",
-      "integrity": "sha512-MAGDAHy8cRatm94FDduhJF+iNS5//jrZ/PIfm+QYw9OCeDgbymFHChM8YVIvN2zArwsRftKgE33QfRWvQk4DPg==",
-      "dev": true,
-      "requires": {
-        "@types/rx-lite": "*"
-      }
-    },
-    "@types/rx-lite-async": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/rx-lite-async/-/rx-lite-async-4.0.2.tgz",
-      "integrity": "sha512-vTEv5o8l6702ZwfAM5aOeVDfUwBSDOs+ARoGmWAKQ6LOInQ8J4/zjM7ov12fuTpktUKdMQjkeCp07Vd73mPkxw==",
-      "dev": true,
-      "requires": {
-        "@types/rx-lite": "*"
-      }
-    },
-    "@types/rx-lite-backpressure": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@types/rx-lite-backpressure/-/rx-lite-backpressure-4.0.3.tgz",
-      "integrity": "sha512-Y6aIeQCtNban5XSAF4B8dffhIKu6aAy/TXFlScHzSxh6ivfQBQw6UjxyEJxIOt3IT49YkS+siuayM2H/Q0cmgA==",
-      "dev": true,
-      "requires": {
-        "@types/rx-lite": "*"
-      }
-    },
-    "@types/rx-lite-coincidence": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@types/rx-lite-coincidence/-/rx-lite-coincidence-4.0.3.tgz",
-      "integrity": "sha512-1VNJqzE9gALUyMGypDXZZXzR0Tt7LC9DdAZQ3Ou/Q0MubNU35agVUNXKGHKpNTba+fr8GdIdkC26bRDqtCQBeQ==",
-      "dev": true,
-      "requires": {
-        "@types/rx-lite": "*"
-      }
-    },
-    "@types/rx-lite-experimental": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/rx-lite-experimental/-/rx-lite-experimental-4.0.1.tgz",
-      "integrity": "sha1-xTL1y98/LBXaFt7Ykw0bKYQCPL0=",
-      "dev": true,
-      "requires": {
-        "@types/rx-lite": "*"
-      }
-    },
-    "@types/rx-lite-joinpatterns": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/rx-lite-joinpatterns/-/rx-lite-joinpatterns-4.0.1.tgz",
-      "integrity": "sha1-9w/jcFGKhDLykVjMkv+1a05K/D4=",
-      "dev": true,
-      "requires": {
-        "@types/rx-lite": "*"
-      }
-    },
-    "@types/rx-lite-testing": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/rx-lite-testing/-/rx-lite-testing-4.0.1.tgz",
-      "integrity": "sha1-IbGdEfTf1v/vWp0WSOnIh5v+Iek=",
-      "dev": true,
-      "requires": {
-        "@types/rx-lite-virtualtime": "*"
-      }
-    },
-    "@types/rx-lite-time": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@types/rx-lite-time/-/rx-lite-time-4.0.3.tgz",
-      "integrity": "sha512-ukO5sPKDRwCGWRZRqPlaAU0SKVxmWwSjiOrLhoQDoWxZWg6vyB9XLEZViKOzIO6LnTIQBlk4UylYV0rnhJLxQw==",
-      "dev": true,
-      "requires": {
-        "@types/rx-lite": "*"
-      }
-    },
-    "@types/rx-lite-virtualtime": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@types/rx-lite-virtualtime/-/rx-lite-virtualtime-4.0.3.tgz",
-      "integrity": "sha512-3uC6sGmjpOKatZSVHI2xB1+dedgml669ZRvqxy+WqmGJDVusOdyxcKfyzjW0P3/GrCiN4nmRkLVMhPwHCc5QLg==",
-      "dev": true,
-      "requires": {
-        "@types/rx-lite": "*"
-      }
-    },
     "@types/underscore": {
       "version": "1.8.8",
       "resolved": "https://registry.npmjs.org/@types/underscore/-/underscore-1.8.8.tgz",
@@ -4533,11 +4407,6 @@
         "is-promise": "^2.1.0"
       }
     },
-    "rx": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
-    },
     "rx-lite": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
@@ -4554,10 +4423,9 @@
       }
     },
     "rxjs": {
-      "version": "5.5.11",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.11.tgz",
-      "integrity": "sha512-3bjO7UwWfA2CV7lmwYMBzj4fQ6Cq+ftHc2MvUe+WMS7wcdJ1LosDWmdjPQanYp2dBRj572p7PeU81JUxHKOcBA==",
-      "dev": true,
+      "version": "5.5.12",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.12.tgz",
+      "integrity": "sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==",
       "requires": {
         "symbol-observable": "1.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@types/mocha": "^5.2.5",
     "@types/mockery": "^1.4.29",
     "@types/node": "^10.5.2",
-    "@types/rx": "^4.1.1",
     "@types/underscore": "^1.8.8",
     "asar": "^0.14.3",
     "babel-core": "^6.26.3",
@@ -63,7 +62,7 @@
   "dependencies": {
     "minimist": "^1.2.0",
     "options": "0.0.6",
-    "rx": "^4.1.0",
+    "rxjs": "^5.5.12",
     "ultron": "^1.0.2",
     "underscore": "^1.8.3",
     "ws": "1.1.1"

--- a/src/browser/api/notifications/observable_sequences.ts
+++ b/src/browser/api/notifications/observable_sequences.ts
@@ -1,4 +1,4 @@
-import * as Rx from 'rx';
+import * as Rx from 'rxjs';
 import {Identity} from './shapes';
 
 export const createdNotes = new Rx.Subject();
@@ -40,6 +40,7 @@ export const noteStack = Rx.Observable.merge(
 
             if (idxRemoved === -1) {
                 acc.push({
+                    create: 0,
                     name: value.name,
                     uuid: value.uuid,
                     opacity: value.opacity

--- a/src/browser/api/notifications/subscriptions.ts
+++ b/src/browser/api/notifications/subscriptions.ts
@@ -1,4 +1,4 @@
-import * as Rx from 'rx';
+import * as Rx from 'rxjs';
 import * as seqs from './observable_sequences';
 import NoteAction from './note_action';
 import {
@@ -71,7 +71,7 @@ ofEvents.on(route.window('closed', '*'), (e: any) => {
             const {uuid, name} = e.data[0];
 
             if (Window.isNotification(name)) {
-                seqs.removes.onNext({uuid, name});
+                seqs.removes.next({uuid, name});
             }
         } catch (e) {
             writeToLog('info', e);
@@ -171,7 +171,7 @@ seqs.position
 
 seqs.noteStack
     .subscribe(liveNotes => {
-        seqs.position.onNext(liveNotes);
+        seqs.position.next(liveNotes);
     });
 
 seqs.isAnimating
@@ -497,7 +497,7 @@ function handleNoteCreated(msg: NotificationMessage): void {
     if (idx !== -1) {
         notesToBeCreated.splice(idx, 1);
     }
-    seqs.createdNotes.onNext({ identity, options });
+    seqs.createdNotes.next({ identity, options });
 }
 
 function routeRequest(id: any, msg: NotificationMessage, ack: any) {
@@ -548,7 +548,7 @@ function routeRequest(id: any, msg: NotificationMessage, ack: any) {
             break;
 
         case NoteAction.animating:
-            seqs.isAnimating.onNext(data);
+            seqs.isAnimating.next(data);
             break;
 
         case NoteAction.qQuery:
@@ -572,7 +572,7 @@ function requestNoteClose(msg: NotificationMessage): void {
         msg.id.uuid = NOTE_APP_UUID;
     }
 
-    seqs.requestNoteClose.onNext(msg);
+    seqs.requestNoteClose.next(msg);
 }
 
 function dispatchMessageToNote (msg: NotificationMessage): void {
@@ -682,7 +682,7 @@ function closeNotification(req: NotificationMessage): void {
 }
 
 function updateAnimationState(animationState: boolean): void {
-    seqs.isAnimating.onNext(<any> {
+    seqs.isAnimating.next(<any> {
         animating: animationState,
         from: {}
     });
@@ -701,13 +701,9 @@ function getPrimaryMonitorRect(): AvailableRect {
 }
 
 function scheduleNoteClose(req: NotificationMessage, timeout: number): void {
-    Rx.Scheduler.default.scheduleFuture(req,
-        timeout,
-        (scheduler: any, request: any) => {
-            seqs.requestNoteClose.onNext(request);
-
-            return scheduler;
-        });
+    Rx.Scheduler.asap.schedule((request: any) => {
+            seqs.requestNoteClose.next(request);
+        }, timeout);
 }
 
 function shouldCreatePendingNote(): boolean {

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -15,7 +15,7 @@ let nativeImage = electron.nativeImage;
 // npm modules
 let _ = require('underscore');
 const crypto = require('crypto');
-import * as Rx from 'rx';
+import * as Rx from 'rxjs';
 
 // local modules
 let animations = require('../animations.js');
@@ -827,8 +827,7 @@ Window.create = function(id, opts) {
             }
 
             ofEvents.emit(route.window('fire-constructor-callback', uuid, name), constructorCallbackMessage);
-            //need to use the old RXJS API: https://github.com/Reactive-Extensions/RxJS/blob/master/doc/api/core/operators/create.md
-            subscription.dispose();
+            subscription.unsubscribe();
         });
     } // end noregister
 

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -185,9 +185,3 @@ declare module 'electron' {
         export function readText(type?: string): string;
     }
 }
-
-declare namespace Rx {
-    interface IScheduler {
-        scheduleFuture<TState>(state: TState, dueTime: number | Date, action: (scheduler: IScheduler, state: TState) => IDisposable): IDisposable;
-    }
-}


### PR DESCRIPTION
just what the doctor ordered (get it? because `rx`? ha)

implicit here is that an internet connection exists when building the core (because rxjs doesn't distribute a .min.js file, instead relying on [unpkg](https://unpkg.com) to do it)

this was followed, which was mostly painless: https://github.com/ReactiveX/rxjs/blob/4ffbbe56ab6c5ba46497c0154d83d27f882476fb/MIGRATION.md