### PR TITLE
RUN-3465 Read manifest file from rvm local cache folder

### DIFF
--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -303,9 +303,14 @@ Application.getManifest = function(identity, manifestUrl, callback, errCallback)
     }
 
     if (manifestUrl) {
-        fetchReadFile(manifestUrl, true)
-            .then(callback)
-            .catch(errCallback);
+        const configObj = coreState.getManifestByUrl(manifestUrl);
+        if (configObj) {
+            callback(configObj);
+        } else {
+            fetchReadFile(manifestUrl, true)
+                .then(callback)
+                .catch(errCallback);
+        }
     } else {
         errCallback(new Error('App not started from manifest'));
     }

--- a/src/browser/cached_resource_fetcher.ts
+++ b/src/browser/cached_resource_fetcher.ts
@@ -295,11 +295,15 @@ export function fetchURL(url: string, done: (resp: any) => void, onError: (err: 
  * Fetches a file to disk and then reads it
  */
 export function fetchReadFile(url: string, isJSON: boolean): Promise<string|object> {
+    app.vlog(1, `---------passedIn url: ${url}`);
     return new Promise((resolve, reject) => {
         if (isHttpUrl(url)) {
+            app.vlog(1, '===== url request====');
             fetchURL(url, resolve, reject);
 
         } else if (isFileUrl(url)) {
+            app.vlog(1, '---------read a local file');
+
             const pathToFile = uriToPath(url);
 
             readFile(pathToFile, isJSON)
@@ -307,6 +311,7 @@ export function fetchReadFile(url: string, isJSON: boolean): Promise<string|obje
                 .catch(reject);
 
         } else {
+            app.vlog(1, '---------non url or file');
             stat(url, (err: null|Error) => {
                 if (err) {
                     reject(new Error(`URL protocol is not supported in ${url}`));

--- a/src/browser/cached_resource_fetcher.ts
+++ b/src/browser/cached_resource_fetcher.ts
@@ -8,7 +8,7 @@ import { isFileUrl, isHttpUrl, uriToPath } from '../common/main';
 import { addPendingAuthRequests, createAuthUI } from './authentication_delegate';
 import { AuthCallback, Identity } from '../shapes';
 import { getSession } from './core_state';
-
+const path = require('path');
 let appQuiting: boolean = false;
 let cacheCleared: boolean = false;
 
@@ -295,15 +295,11 @@ export function fetchURL(url: string, done: (resp: any) => void, onError: (err: 
  * Fetches a file to disk and then reads it
  */
 export function fetchReadFile(url: string, isJSON: boolean): Promise<string|object> {
-    app.vlog(1, `---------passedIn url: ${url}`);
     return new Promise((resolve, reject) => {
         if (isHttpUrl(url)) {
-            app.vlog(1, '===== url request====');
             fetchURL(url, resolve, reject);
 
         } else if (isFileUrl(url)) {
-            app.vlog(1, '---------read a local file');
-
             const pathToFile = uriToPath(url);
 
             readFile(pathToFile, isJSON)
@@ -311,7 +307,6 @@ export function fetchReadFile(url: string, isJSON: boolean): Promise<string|obje
                 .catch(reject);
 
         } else {
-            app.vlog(1, '---------non url or file');
             stat(url, (err: null|Error) => {
                 if (err) {
                     reject(new Error(`URL protocol is not supported in ${url}`));
@@ -330,10 +325,15 @@ export function fetchReadFile(url: string, isJSON: boolean): Promise<string|obje
  */
 export function readFile(pathToFile: string, isJSON: boolean): Promise<string|object> {
     return new Promise((resolve, reject) => {
-        fsReadFile(pathToFile, 'utf-8', (error, data) => {
+        log.writeToLog(1, `Requested contents from ${pathToFile}`, true);
+        const normalizedPath = path.resolve(pathToFile);
+        log.writeToLog(1, `Normalized path as ${normalizedPath}`, true);
+        fsReadFile(normalizedPath, 'utf-8', (error, data) => {
             if (error) {
                 reject(error);
             } else {
+                log.writeToLog(1, `Contents from ${normalizedPath}`, true);
+                log.writeToLog(1, data, true);
                 isJSON ? resolve(JSON.parse(data)) : resolve(data);
             }
         });

--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -13,7 +13,8 @@ let _ = require('underscore');
 // local modules
 let coreState = require('./core_state.js');
 let log = require('./log');
-import { isFileUrl, isHttpUrl, uriToPath } from '../common/main';
+// import { isFileUrl, isHttpUrl, uriToPath } from '../common/main';
+import { isFileUrl } from '../common/main';
 import { fetchReadFile } from './cached_resource_fetcher';
 
 // constants
@@ -322,6 +323,8 @@ module.exports = {
         // ensure removal of eclosing double-quotes when absolute path.
         let configUrl = (argo['startup-url'] || argo['config']);
         let localConfigPath = argo['local-startup-url'];
+        log.writeToLog(1, `------configUrl: ${configUrl}`, true);
+        log.writeToLog(1, `------localConfigPath: ${localConfigPath}`, true);
         let offlineAccess = false;
         let errorCallback = err => {
             if (offlineAccess) {
@@ -344,6 +347,8 @@ module.exports = {
                 log.writeToLog(1, err, true);
             }
         }
+        // read file from RVM local cache folder to avoid sending url request
+        configUrl = localConfigPath ? localConfigPath : configUrl;
 
         if (typeof configUrl !== 'string') {
             configUrl = '';
@@ -358,21 +363,9 @@ module.exports = {
             return;
         }
 
-        if (isHttpUrl(configUrl)) {
-            fetchReadFile(configUrl, true)
-                .then((configObject) => onComplete({ configObject, configUrl }))
-                .catch(errorCallback);
-            return;
-        }
-
-        let filepath = isFileUrl(configUrl) ? uriToPath(configUrl) : configUrl;
-
-        return readFile(filepath, configObject => {
-            onComplete({
-                configObject,
-                configUrl
-            });
-        }, errorCallback);
+        fetchReadFile(configUrl, true)
+            .then((configObject) => onComplete({ configObject, configUrl }))
+            .catch(errorCallback);
     },
 
     normalizePreloadScripts(options) {

--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -135,30 +135,6 @@ function five0BaseOptions() {
 function isInContainer(type) {
     return process && process.versions && process.versions[type];
 }
-/*
-function readFile(filePath, done, onError) {
-    log.writeToLog(1, `Requested contents from ${filePath}`, true);
-    let normalizedPath = path.resolve(filePath);
-    log.writeToLog(1, `Normalized path as ${normalizedPath}`, true);
-    fs.readFile(normalizedPath, 'utf8', (err, data) => {
-        if (err) {
-            onError(err);
-            return;
-        }
-
-        log.writeToLog(1, `Contents from ${normalizedPath}`, true);
-        log.writeToLog(1, data, true);
-
-        let config;
-        try {
-            config = JSON.parse(data);
-        } catch (e) {
-            onError(e);
-            return;
-        }
-        done(config);
-    });
-}*/
 
 function validateOptions(options) {
     var baseOptions = five0BaseOptions();

--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -13,8 +13,6 @@ let _ = require('underscore');
 // local modules
 let coreState = require('./core_state.js');
 let log = require('./log');
-// import { isFileUrl, isHttpUrl, uriToPath } from '../common/main';
-import { isFileUrl } from '../common/main';
 import { fetchReadFile } from './cached_resource_fetcher';
 
 // constants


### PR DESCRIPTION
This PR is to read a manifest config file from RVM local cache folder. It will solve the issue that Runtime can't reach app config behind a firewall. 

Tests:
[Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5c3cc159cb360141a7dfd8ff)
[Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5c3cbce3cb360141a7dfd8fd)

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] automated tests are [added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)

