### PR TITLE
RUN-4644 Replace Application "create" + "run" calls with "start" and "close" with "quit"

### DIFF
--- a/index.js
+++ b/index.js
@@ -521,7 +521,7 @@ function migrateLocalStorage(argo) {
     const newLocalStoragePath = argo['new-local-storage-path'] || '';
     const localStorageUrl = argo['local-storage-url'] || '';
 
-     if (oldLocalStoragePath && newLocalStoragePath && localStorageUrl) {
+    if (oldLocalStoragePath && newLocalStoragePath && localStorageUrl) {
         try {
             System.log('info', 'Migrating Local Storage from ' + oldLocalStoragePath + ' to ' + newLocalStoragePath);
             app.migrateLocalStorage(oldLocalStoragePath, newLocalStoragePath, localStorageUrl);

--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -278,14 +278,14 @@ Application.close = function(identity, force, callback) {
         Window.close(mainWindowIdentity, force, callback);
     }
 };
-Application.destroy = function (identity, cb, nack) {
+Application.destroy = function(identity, cb, nack) {
     if (coreState.getAppRunningState(identity.uuid)) {
         nack('Cannot destroy a running application');
     } else {
         coreState.deleteApp(identity.uuid);
         cb();
     }
-}
+};
 Application.getChildWindows = function(identity /*, callback, errorCallback*/ ) {
     const uuid = identity.uuid;
     const appError = checkApplicationAvailability(uuid);

--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -278,12 +278,12 @@ Application.close = function(identity, force, callback) {
         Window.close(mainWindowIdentity, force, callback);
     }
 };
-Application.destroy = function(identity, cb, nack) {
+Application.destroy = function(identity, ack, nack) {
     if (coreState.getAppRunningState(identity.uuid)) {
         nack('Cannot destroy a running application');
     } else {
         coreState.deleteApp(identity.uuid);
-        cb();
+        ack();
     }
 };
 Application.getChildWindows = function(identity /*, callback, errorCallback*/ ) {

--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -278,7 +278,14 @@ Application.close = function(identity, force, callback) {
         Window.close(mainWindowIdentity, force, callback);
     }
 };
-
+Application.destroy = function (identity, cb, nack) {
+    if (coreState.getAppRunningState(identity.uuid)) {
+        nack('Cannot destroy a running application');
+    } else {
+        coreState.deleteApp(identity.uuid);
+        cb();
+    }
+}
 Application.getChildWindows = function(identity /*, callback, errorCallback*/ ) {
     const uuid = identity.uuid;
     const appError = checkApplicationAvailability(uuid);

--- a/src/browser/api_protocol/api_handlers/application.js
+++ b/src/browser/api_protocol/api_handlers/application.js
@@ -78,10 +78,12 @@ module.exports.applicationApiMap = {
 module.exports.init = function() {
     apiProtocolBase.registerActionMap(module.exports.applicationApiMap, 'Application');
 };
-function destroyApplication (identity, message, ack, nack) {
+
+function destroyApplication(identity, message, ack, nack) {
     const appIdentity = apiProtocolBase.getTargetApplicationIdentity(message.payload);
-    Application.destroy(appIdentity, () => ack(successAck), nack)
+    Application.destroy(appIdentity, () => ack(successAck), nack);
 }
+
 function sendApplicationLog(identity, message, ack) {
     const payload = message.payload;
     const appIdentity = apiProtocolBase.getTargetApplicationIdentity(payload);

--- a/src/browser/api_protocol/api_handlers/application.js
+++ b/src/browser/api_protocol/api_handlers/application.js
@@ -46,6 +46,7 @@ module.exports.applicationApiMap = {
     'create-application': createApplication,
     'create-child-window': createChildWindow,
     'deregister-external-window': deregisterExternalWindow,
+    'destroy-application': destroyApplication,
     'external-window-action': externalWindowAction,
     'get-application-groups': getApplicationGroups,
     'get-application-manifest': getApplicationManifest,
@@ -77,7 +78,10 @@ module.exports.applicationApiMap = {
 module.exports.init = function() {
     apiProtocolBase.registerActionMap(module.exports.applicationApiMap, 'Application');
 };
-
+function destroyApplication (identity, message, ack, nack) {
+    const appIdentity = apiProtocolBase.getTargetApplicationIdentity(message.payload);
+    Application.destroy(appIdentity, () => ack(successAck), nack)
+}
 function sendApplicationLog(identity, message, ack) {
     const payload = message.payload;
     const appIdentity = apiProtocolBase.getTargetApplicationIdentity(payload);


### PR DESCRIPTION
#### Description of Change
This adds a call to 'destroy-application' to the core to remove an app from core-state if it is not running. This is a prerequisite to [this PR](https://github.com/HadoukenIO/js-adapter/pull/230).

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [x] relevant documentation is [changed or added](https://github.com/hadoukenio/js-adapter)
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)