### PR TITLE
RUN-4943 createFromManifest support for mac/linux

### DIFF
--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -750,14 +750,19 @@ function run(identity, mainWindowOpts, userAppConfigArgs) {
  * Run an application via RVM
  */
 Application.runWithRVM = function(identity, manifestUrl) {
-    return sendToRVM({
-        topic: 'application',
-        action: 'launch-app',
-        sourceUrl: coreState.getConfigUrlByUuid(identity.uuid),
-        data: {
-            configUrl: manifestUrl
-        }
-    });
+    // on mac/linux, launch the app, else hand off to RVM
+    if (os.platform() !== 'win32') {
+        return launch({ manifestUrl: manifestUrl });
+    } else {
+        return sendToRVM({
+            topic: 'application',
+            action: 'launch-app',
+            sourceUrl: coreState.getConfigUrlByUuid(identity.uuid),
+            data: {
+                configUrl: manifestUrl
+            }
+        });
+    }
 };
 
 Application.send = function() {

--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -3,6 +3,7 @@
  */
 
 // built-in modules
+let os = require('os');
 let path = require('path');
 let electron = require('electron');
 let queryString = require('querystring');
@@ -34,6 +35,7 @@ import route from '../../common/route';
 import { isAboutPageUrl, isValidChromePageUrl, isFileUrl, isHttpUrl, isURLAllowed, getIdentityFromObject } from '../../common/main';
 import { ERROR_BOX_TYPES } from '../../common/errors';
 import { deregisterAllRuntimeProxyWindows } from '../window_groups_runtime_proxy';
+import { launch } from '../../../js-adapter/src/main';
 
 const subscriptionManager = new SubscriptionManager();
 const TRAY_ICON_KEY = 'tray-icon-events';


### PR DESCRIPTION
#### Description of Change
Supporting the "createFromManifest" call on mac/linux.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Pull Request process: https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR release notes describe the change in a way relevant to app-developers


#### Release Notes
Enables support for createFromManifest on mac/linux.
Notes: <!-- Please add a one-line description for app developers to read in the release notes. Examples and help on special cases: http://developer.openfin.co/versions/?product=Runtime&version=9.61.37.46 -->
