### PR TITLE
Check all elements in path, run on DOMContentLoaded

### DIFF
--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -3,6 +3,7 @@
 
 // THIS FILE GETS EVALED IN THE RENDERER PROCESS
 (function() {
+    console.log('in api_decorator');
     const glbl = global;
     const QUEUE_COUNTER_NAME = 'queueCounter';
     const noteGuidRegex = /^A21B62E0-16B1-4B10-8BE3-BBB6B489D862/;
@@ -196,17 +197,21 @@
             e.preventDefault();
         });
         global.addEventListener('click', e => {
-            const tag = e.target.tagName;
             const modifiedClick = e.shiftKey || e.metaKey || e.ctrlKey || e.altKey;
-            const mightOpenNewWindow = tag === 'A' || tag === 'IMG';
-            if (mightOpenNewWindow && modifiedClick) {
-                e.preventDefault();
-            } else if (modifiedClick && (tag === 'BUTTON' || tag === 'INPUT')) {
-                if (e.target.type === 'submit') {
+            e.path.some(target => {
+                const tag = target.tagName;
+                const mightOpenNewWindow = tag === 'A' || tag === 'IMG';
+                if (mightOpenNewWindow && modifiedClick) {
                     e.preventDefault();
-                }
+                    return true;
+                } else if (modifiedClick && (tag === 'BUTTON' || tag === 'INPUT')) {
+                    if (target.type === 'submit') {
+                        e.preventDefault();
+                        return true;
+                    }
 
-            }
+                }
+            });
         });
     }
 
@@ -245,18 +250,18 @@
     var pendingMainCallbacks = [];
     var currPageHasLoaded = false;
 
-    global.addEventListener('load', function() {
-
-        //---------------------------------------------------------------
+    global.addEventListener('DOMContentLoaded', function() {
+        disableModifiedClicks(glbl);
+    });
+    global.addEventListener('load', function() {        //---------------------------------------------------------------
         // TODO: extract this, used to be bound to ready
         //---------------------------------------------------------------
 
         // The api-ready event allows the webContents to assign api priority. This must happen after
         // any spin up windowing action or you risk stealing api priority from an already connected frame
         electron.remote.getCurrentWebContents(renderFrameId).emit('openfin-api-ready', renderFrameId);
-
+           
         wireUpMenu(glbl);
-        disableModifiedClicks(glbl);
         wireUpMouseWheelZoomEvents();
         raiseReadyEvents(entityInfo);
 


### PR DESCRIPTION
#### Description of Change
Updates the disabling of unsupported click types to prevent rogue child windows. It is still possible to click into a cross-origin iframe and have that Iframe open a child window which won't have the OpenFin api, but that is of less immediate concern.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR release notes describe the change in a way relevant to app-developers


#### Release Notes

Notes: Fixed an issue where clicking a link while holding a modifier click would open a child window which in tern could cause undesirable behavior.