### PR TITLE
RUN-4813 RUN-4814 RUN-4815 Propagate resizes through the window graph

### DIFF
--- a/src/browser/rectangle.ts
+++ b/src/browser/rectangle.ts
@@ -140,10 +140,10 @@ export class Rectangle {
         const { x, y, width, height } = rect;
         let collision = false;
 
-        if (this.x < x + width &&
-            this.x + this.width > x &&
-            this.y < y + height &&
-            this.y + this.height > y) {
+        if (this.x <= x + width &&
+            this.x + this.width >= x &&
+            this.y <= y + height &&
+            this.y + this.height >= y) {
             collision = true;
         }
 
@@ -270,6 +270,12 @@ export class Rectangle {
         if (y && height) {
             movedSides.add('top');
         }
+        if (y && !height) {
+            movedSides.add(otherRectSharedSide);
+        }
+        if (x && !width) {
+            movedSides.add(otherRectSharedSide);
+        }
 
         return movedSides.has(otherRectSharedSide);
     }
@@ -342,64 +348,6 @@ export class Rectangle {
 
     public shift = (delta: RectangleBase) => {
         return new Rectangle(this.x + delta.x, this.y + delta.y, this.width + delta.width, this.height + delta.height, this.opts);
-    }
-
-    public crossedEdges = (initialBounds: Rectangle, finalBounds: Rectangle): EdgeCrossings => {
-        const positionsInitial = this.relativePositions(initialBounds);
-        const positionsFinal = this.relativePositions(finalBounds);
-        const crossedBounds: SideName[][] = []
-        const currentBoundsCollide = this.collidesWith(finalBounds);
-        const resizedOutOfContainingRect = (!currentBoundsCollide && this.collidesWith(initialBounds));
-        const adjacentOnAtLeastOneSide = this.sharedBoundsOnIntersection(finalBounds).hasSharedBounds;
-
-        if (currentBoundsCollide 
-            || resizedOutOfContainingRect
-            || adjacentOnAtLeastOneSide) {
-
-            for (let i = 0; i < Rectangle.EDGE_CROSSINGS.length; i++) {
-                if (positionsInitial[i] !== positionsFinal[i]) {
-                    crossedBounds.push(Rectangle.EDGE_CROSSINGS[i])
-                }
-            }
-        }
-        
-        let xCrossing: EdgeCrossing;
-        let yCrossing: EdgeCrossing;
-
-        for (let [mine, other] of crossedBounds) {
-            const distance = Math.abs(this[mine] - finalBounds[other]);
-
-            if (mine === 'left' || mine === 'right') {
-                if (!xCrossing || distance > xCrossing.distance) {
-                    xCrossing = {mine, other, distance};
-                }
-            } else {
-                if (!yCrossing || distance > yCrossing.distance) {
-                    yCrossing = {mine, other, distance};
-                }
-            }
-        }
-
-        return [xCrossing, yCrossing].filter(x => x);
-    }
-
-    public crossedEdgesBeyondThreshold = (initialBounds: Rectangle, finalBounds: Rectangle): EdgeCrossings => {
-        const crossedEdges = this.crossedEdges(initialBounds, finalBounds);
-        return crossedEdges.filter(({distance}) => distance > Rectangle.BOUND_SHARE_THRESHOLD);
-    }
-
-    public alignCrossedEdges = (edgeCrossings: EdgeCrossings, finalOtherBounds: Rectangle) => {
-        let rect: Rectangle = this;
-
-        for (const crossing of edgeCrossings) {
-            rect = rect.alignSide(crossing.mine, finalOtherBounds, crossing.other)
-        }
-
-        return rect;
-    }
- 
-    private relativePositions = (rect: Rectangle) => {
-        return Rectangle.EDGE_CROSSINGS.map(([mySide, otherSide]) => this[mySide] > rect[otherSide]);
     }
 
     public move = (cachedBounds: RectangleBase, currentBounds: RectangleBase): Rectangle => {
@@ -508,8 +456,50 @@ export class Rectangle {
 
     public static collisionsValidator(rect1: Rectangle, rect2: Rectangle): boolean  {
         return rect1.collidesWith(rect2);
-    } 
+    }
 
+
+    public static PROPAGATE_MOVE(leaderRectIndex: number,
+        start: Rectangle,
+        delta: RectangleBase,
+        rects: Rectangle[]): Rectangle[] {
+
+        const graphInitial = Rectangle.GRAPH_WITH_SIDE_DISTANCES(rects);
+        const maxDelta = Object.keys(delta).reduce((prev: number, curr: keyof RectangleBase) => {
+            const diff = Math.abs(delta[curr]);
+            return diff > prev ? diff : prev;
+        }, 0.00001);
+        const iterator = Math.ceil(maxDelta / Rectangle.BOUND_SHARE_THRESHOLD);
+        const iterDelta: RectangleBase = {
+            x: Math.round(delta.x / iterator),
+            y: Math.round(delta.y / iterator),
+            width: Math.round(delta.width / iterator),
+            height: Math.round(delta.height / iterator)
+        };
+        let iterStart = start;
+        let iterEnd = iterStart.shift(iterDelta);
+    
+        for (let i = 0; i < iterator; i++) {
+            const lastValidMoves = [...rects];
+            rects = propMoveThroughGraph(
+                rects,
+                leaderRectIndex,
+                Rectangle.CREATE_FROM_BOUNDS(iterStart),
+                Rectangle.CREATE_FROM_BOUNDS(iterEnd));
+    
+            iterStart = iterEnd;
+            iterEnd = iterEnd.shift(iterDelta);
+    
+            const graphFinal = Rectangle.GRAPH_WITH_SIDE_DISTANCES(rects);
+            if (!Rectangle.SUBGRAPH_AND_CLOSER(graphInitial, graphFinal)) {
+                rects = lastValidMoves;
+                break;
+            }
+        }
+
+        return rects;
+    }
+    
     public static GRAPH(rects: Rectangle[], validator = Rectangle.sharedBoundValidator): Graph  {
         const edges = [];
         const vertices: Array<number> = [];
@@ -590,6 +580,54 @@ export class Rectangle {
 
         return distances;
     }
+}
+
+function propMoveThroughGraph (
+    rects: Rectangle[], 
+    refVertex: number, 
+    cachedBounds: Rectangle, 
+    proposedBounds: Rectangle,
+    visited: number[] = []): Rectangle [] {
+
+    const graph = Rectangle.GRAPH(rects);
+    const [vertices, edges] = graph;
+    const distances = new Map();
+    let movedRef = rects[refVertex];
+
+    if (movedRef.hasIdenticalBounds( cachedBounds)) {
+        movedRef = Rectangle.CREATE_FROM_BOUNDS(proposedBounds);
+    } else {
+        movedRef = movedRef.move(cachedBounds, proposedBounds);
+    }
+
+    for (let v in vertices) {
+        distances.set(+v, Infinity);
+    }
+
+    distances.set(refVertex, 0);
+    visited.push(refVertex);
+
+    const toVisit = [refVertex];
+
+    while (toVisit.length) {
+        const u = toVisit.shift();
+        const e = (<number [][]>edges).filter(([uu]): boolean => uu === u);
+
+        e.forEach(([u, v]) => {
+            if (!visited.includes(v)) {
+                if (distances.get(v) === Infinity) {
+                    toVisit.push(v);
+                    distances.set(v, distances.get(u) + 1);
+                    
+                    propMoveThroughGraph(rects, v, rects[refVertex], movedRef, visited);
+                    visited.push(v);
+                }
+            }
+        });
+    }
+
+    rects[refVertex] = movedRef;
+    return rects;
 }
 
 enum Side {

--- a/src/browser/rectangle.ts
+++ b/src/browser/rectangle.ts
@@ -468,7 +468,7 @@ export class Rectangle {
         const maxDelta = Object.keys(delta).reduce((prev: number, curr: keyof RectangleBase) => {
             const diff = Math.abs(delta[curr]);
             return diff > prev ? diff : prev;
-        }, 0.00001);
+        }, 1);
         const iterator = Math.ceil(maxDelta / Rectangle.BOUND_SHARE_THRESHOLD);
         const iterDelta: RectangleBase = {
             x: Math.round(delta.x / iterator),

--- a/test/rectangle.ts
+++ b/test/rectangle.ts
@@ -311,109 +311,96 @@ describe('Rectangle', () => {
         assert.deepEqual([...distances], correctDistances, 'reported distances are incorrect');
     });
 
-    it('should detect that bounds were crossed, left to right', () => {
-        const baseRect = Rectangle.CREATE_FROM_BOUNDS({ 'x': 0, 'y': 0, 'width': 100, 'height': 100 });
-        const leaderRectInitial = Rectangle.CREATE_FROM_BOUNDS({ 'x': 150, 'y': 0, 'width': 100, 'height': 100 });
-        const leaderRectFinal = Rectangle.CREATE_FROM_BOUNDS({ 'x': 50, 'y': 0, 'width': 200, 'height': 100 });
+    it('should propagate a move through the window graph, center height constraint', () => {
+        const startRect = Rectangle.CREATE_FROM_BOUNDS({x: 0, y: 0, width: 100, height: 100});
+        const endRect = Rectangle.CREATE_FROM_BOUNDS({x: 0, y: 0, width: 100, height: 90});
+        const rectsInit = [
+            startRect,
+            Rectangle.CREATE_FROM_BOUNDS({x: 0, y: 100, width: 100, height: 100}, {maxHeight: 100}),
+            Rectangle.CREATE_FROM_BOUNDS({x: 0, y: 200, width: 100, height: 100})];
+        const rectsFinal = [
+            endRect,
+            Rectangle.CREATE_FROM_BOUNDS({x: 0, y: 90, width: 100, height: 100}, {maxHeight: 100}),
+            Rectangle.CREATE_FROM_BOUNDS({x: 0, y: 190, width: 100, height: 110})];
 
-        const crossedEdges = baseRect.crossedEdges(leaderRectInitial, leaderRectFinal);
-        const correctCrossedEdges = [
-            {
-                mine: 'right',
-                other: 'left',
-                distance: 50
-            }
-        ];
+        const delta = startRect.delta(endRect);
 
-        assert.deepStrictEqual(crossedEdges, correctCrossedEdges, 'reported bound crossing is incorrect');
+        const propagatedMoves = Rectangle.PROPAGATE_MOVE(0, startRect, delta, rectsInit);
+        assert.deepEqual(propagatedMoves.map(x => x.bounds), rectsFinal.map(x => x.bounds));
     });
 
-    it('should detect that bounds were crossed, top to bottom', () => {
-        const baseRect = Rectangle.CREATE_FROM_BOUNDS({ 'x': 0, 'y': 0, 'width': 100, 'height': 100 });
-        const leaderRectInitial = Rectangle.CREATE_FROM_BOUNDS({ 'x': 0, 'y': 150, 'width': 100, 'height': 100 });
-        const leaderRectFinal = Rectangle.CREATE_FROM_BOUNDS({ 'x': 0, 'y': 50, 'width': 100, 'height': 200 });
+    it('should propagate a move through the window graph, double center height constraint', () => {
+        const startRect = Rectangle.CREATE_FROM_BOUNDS({x: 0, y: 0, width: 100, height: 100});
+        const endRect = Rectangle.CREATE_FROM_BOUNDS({x: 0, y: 0, width: 100, height: 90});
+        const rectsInit = [
+            startRect,
+            Rectangle.CREATE_FROM_BOUNDS({x: 0, y: 100, width: 100, height: 100}, {maxHeight: 100}),
+            Rectangle.CREATE_FROM_BOUNDS({x: 0, y: 200, width: 100, height: 100}, {maxHeight: 100}),
+            Rectangle.CREATE_FROM_BOUNDS({x: 0, y: 300, width: 100, height: 100})];
+        const rectsFinal = [
+            endRect,
+            Rectangle.CREATE_FROM_BOUNDS({x: 0, y: 90, width: 100, height: 100}, {maxHeight: 100}),
+            Rectangle.CREATE_FROM_BOUNDS({x: 0, y: 190, width: 100, height: 100}, {maxHeight: 100}),
+            Rectangle.CREATE_FROM_BOUNDS({x: 0, y: 290, width: 100, height: 110})];
 
-        const crossedEdges = baseRect.crossedEdges(leaderRectInitial, leaderRectFinal);
-        const correctCrossedEdges = [
-            {
-                mine: 'bottom',
-                other: 'top',
-                distance: 50
-            }
-        ];
+        const delta = startRect.delta(endRect);
 
-        assert.deepStrictEqual(crossedEdges, correctCrossedEdges, 'reported bound crossing is incorrect');
+        const propagatedMoves = Rectangle.PROPAGATE_MOVE(0, startRect, delta, rectsInit);
+        assert.deepEqual(propagatedMoves.map(x => x.bounds), rectsFinal.map(x => x.bounds));
     });
 
-    it('should detect that bounds were crossed, right to right, inside out', () => {
-        const baseRect = Rectangle.CREATE_FROM_BOUNDS({ 'x': 0, 'y': 0, 'width': 100, 'height': 100 });
-        const leaderRectInitial = Rectangle.CREATE_FROM_BOUNDS({ 'x': 0, 'y': 0, 'width': 50, 'height': 100 });
-        const leaderRectFinal = Rectangle.CREATE_FROM_BOUNDS({ 'x': 0, 'y': 0, 'width': 150, 'height': 100 });
+    it('should propagate a move through the window graph, no constraint', () => {
+        const startRect = Rectangle.CREATE_FROM_BOUNDS({x: 0, y: 0, width: 100, height: 100});
+        const endRect = Rectangle.CREATE_FROM_BOUNDS({x: 0, y: 0, width: 100, height: 90});
+        const rectsInit = [
+            startRect,
+            Rectangle.CREATE_FROM_BOUNDS({x: 0, y: 100, width: 100, height: 100}),
+            Rectangle.CREATE_FROM_BOUNDS({x: 0, y: 200, width: 100, height: 100})];
+        const rectsFinal = [
+            endRect,
+            Rectangle.CREATE_FROM_BOUNDS({x: 0, y: 90, width: 100, height: 110}),
+            Rectangle.CREATE_FROM_BOUNDS({x: 0, y: 200, width: 100, height: 100})];
 
-        const crossedEdges = baseRect.crossedEdges(leaderRectInitial, leaderRectFinal);
-        const correctCrossedEdges = [
-            {
-                mine: 'right',
-                other: 'right',
-                distance: 50
-            }
-        ];
+        const delta = startRect.delta(endRect);
 
-        assert.deepStrictEqual(crossedEdges, correctCrossedEdges, 'reported bound crossing is incorrect');
+        const propagatedMoves = Rectangle.PROPAGATE_MOVE(0, startRect, delta, rectsInit);
+        assert.deepEqual(propagatedMoves.map(x => x.bounds), rectsFinal.map(x => x.bounds));
     });
 
-    it('should detect that bounds were crossed, top to top, inside out', () => {
-        const baseRect = Rectangle.CREATE_FROM_BOUNDS({ 'x': 0, 'y': 100, 'width': 100, 'height': 100 });
-        const leaderRectInitial = Rectangle.CREATE_FROM_BOUNDS({ 'x': 0, 'y': 150, 'width': 100, 'height': 100 });
-        const leaderRectFinal = Rectangle.CREATE_FROM_BOUNDS({ 'x': 0, 'y': 50, 'width': 100, 'height': 200 });
+    it('should propagate a move through the window graph, width constraint, horizontal', () => {
+        const startRect = Rectangle.CREATE_FROM_BOUNDS({x: 0, y: 0, width: 100, height: 100});
+        const endRect = Rectangle.CREATE_FROM_BOUNDS({x: 0, y: 0, width: 130, height: 100});
+        const rectsInit = [
+            startRect,
+            Rectangle.CREATE_FROM_BOUNDS({x: 100, y: 0, width: 100, height: 100}, {minWidth: 100}),
+            Rectangle.CREATE_FROM_BOUNDS({x: 200, y: 0, width: 100, height: 100})];
+        const rectsFinal = [
+            endRect,
+            Rectangle.CREATE_FROM_BOUNDS({x: 130, y: 0, width: 100, height: 100}),
+            Rectangle.CREATE_FROM_BOUNDS({x: 230, y: 0, width: 70, height: 100})];
 
-        const crossedEdges = baseRect.crossedEdges(leaderRectInitial, leaderRectFinal);
-        const correctCrossedEdges = [
-            {
-                mine: 'top',
-                other: 'top',
-                distance: 50
-            }
-        ];
+        const delta = startRect.delta(endRect);
 
-        assert.deepStrictEqual(crossedEdges, correctCrossedEdges, 'reported bound crossing is incorrect');
+        const propagatedMoves = Rectangle.PROPAGATE_MOVE(0, startRect, delta, rectsInit);
+        assert.deepEqual(propagatedMoves.map(x => x.bounds), rectsFinal.map(x => x.bounds));
     });
 
-    it('should detect that bounds were not crossed if not overlapping in the end', () => {
-        const baseRect = Rectangle.CREATE_FROM_BOUNDS({ 'x': 0, 'y': 100, 'width': 100, 'height': 100 });
-        const leaderRectInitial = Rectangle.CREATE_FROM_BOUNDS({ 'x': 210, 'y': 150, 'width': 100, 'height': 100 });
-        const leaderRectFinal = Rectangle.CREATE_FROM_BOUNDS({ 'x': 210, 'y': 50, 'width': 100, 'height': 200 });
+    it('should propagate a move through the window graph, width constraint, horizontal, huge jump', () => {
+        const startRect = Rectangle.CREATE_FROM_BOUNDS({x: 0, y: 0, width: 100, height: 100});
+        const endRect = Rectangle.CREATE_FROM_BOUNDS({x: 0, y: 0, width: 330, height: 100});
+        const rectsInit = [
+            startRect,
+            Rectangle.CREATE_FROM_BOUNDS({x: 100, y: 0, width: 100, height: 100}, {minWidth: 100}),
+            Rectangle.CREATE_FROM_BOUNDS({x: 200, y: 0, width: 100, height: 100}, {minWidth: 100})];
+        const rectsFinal = [
+            endRect,
+            Rectangle.CREATE_FROM_BOUNDS({x: 330, y: 0, width: 100, height: 100}),
+            Rectangle.CREATE_FROM_BOUNDS({x: 430, y: 0, width: 100, height: 100})];
 
-        const crossedEdges = baseRect.crossedEdges(leaderRectInitial, leaderRectFinal);
-        const xCrossing: undefined = undefined;
-        const yCrossing: undefined = undefined;
-        const correctCrossedEdges: EdgeCrossings = [];
+        const delta = startRect.delta(endRect);
 
-        assert.deepStrictEqual(crossedEdges, correctCrossedEdges, 'reported bound crossing is incorrect');
-    });
-
-    it('should align crossed edges right to left', () => {
-        const baseRect = Rectangle.CREATE_FROM_BOUNDS({ 'x': 0, 'y': 0, 'width': 100, 'height': 100 });
-        const leaderRectInitial = Rectangle.CREATE_FROM_BOUNDS({ 'x': 150, 'y': 0, 'width': 100, 'height': 100 });
-        const leaderRectFinal = Rectangle.CREATE_FROM_BOUNDS({ 'x': 50, 'y': 0, 'width': 200, 'height': 100 });
-
-        const crossedEdges = baseRect.crossedEdges(leaderRectInitial, leaderRectFinal);
-        const newBounds = baseRect.alignCrossedEdges(crossedEdges, leaderRectFinal).bounds;
-        const correctBounds = {x: 0, y: 0, height: 100, width: 50};
-
-        assert.deepStrictEqual(newBounds, correctBounds);
-    });
-
-    it('should align crossed edges when bound right to left, jumping top to top', () => {
-        const baseRect = Rectangle.CREATE_FROM_BOUNDS({ 'x': 0, 'y': 50, 'width': 100, 'height': 100 });
-        const leaderRectInitial = Rectangle.CREATE_FROM_BOUNDS({ 'x': 101, 'y': 75, 'width': 100, 'height': 100 });
-        const leaderRectFinal = Rectangle.CREATE_FROM_BOUNDS({ 'x': 101, 'y': 0, 'width': 200, 'height': 100 });
-
-        const crossedEdges = baseRect.crossedEdges(leaderRectInitial, leaderRectFinal);
-        const newBounds = baseRect.alignCrossedEdges(crossedEdges, leaderRectFinal).bounds;
-        const correctBounds = {x: 0, y: 0, height: 150, width: 100};
-
-        assert.deepStrictEqual(newBounds, correctBounds);
+        const propagatedMoves = Rectangle.PROPAGATE_MOVE(0, startRect, delta, rectsInit);
+        assert.deepEqual(propagatedMoves.map(x => x.bounds), rectsFinal.map(x => x.bounds));
     });
 });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
         "noImplicitAny": true,
         "removeComments": true,
         "preserveConstEnums": true,
-        "sourceMap": false,
+        "sourceMap": true,
         "outDir": "./staging/core/",
         "moduleResolution": "node",
         "allowJs": true


### PR DESCRIPTION
#### Description of Change

When a window resizes and is part of a group, the resize will now be
propagated through the group impacting windows that are "downstream"
of the resizing window in both the x and y directions. Resize events
along one axis or the other should now only impact windows that are
reachable through the window graph on that axis.

There are still cases where with this change I am seeing broken edges
on occation, in talks with the native team it may be due to scaling
(using dip or not). This exists currently and can be addressed in the
future if need be.
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Pull Request process: https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included and stakeholders cc'd
- [X] `npm test` passes
- [ ] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [ ] manual tests are [changed or added](https://github.com/openfin/test_apps)
- [ ] relevant documentation is [changed or added](https://github.com/hadoukenio/js-adapter)
- [X ] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [X ] PR release notes describe the change in a way relevant to app-developers


#### Release Notes
Window resizes in a group now propagate through the group. 

Notes: <!-- Please add a one-line description for app developers to read in the release notes. Examples and help on special cases: http://developer.openfin.co/versions/?product=Runtime&version=9.61.37.46 -->
