### PR TITLE
RUN-5003 task: Use runtime's ExternalWindow mock

### DIFF
--- a/src/browser/api/external_window.ts
+++ b/src/browser/api/external_window.ts
@@ -1,4 +1,4 @@
-import { app as electronApp, BrowserWindow } from 'electron';
+import { app as electronApp, ExternalWindow } from 'electron';
 import { Bounds } from '../../../js-adapter/src/shapes';
 import { extendNativeWindowInfo } from '../utils';
 import { Identity } from '../../../js-adapter/src/identity';
@@ -7,7 +7,7 @@ import * as Shapes from '../../shapes';
 import ofEvents from '../of_events';
 import route from '../../common/route';
 
-export const registeredExternalWindows = new Map<string, BrowserWindow>();
+export const registeredExternalWindows = new Map<string, ExternalWindow>();
 
 export function addEventListener(identity: Shapes.Identity, type: string, listener: Shapes.Listener): Shapes.Func {
   const evt = route.externalWindow(type, identity.uuid);
@@ -156,12 +156,12 @@ export function stopExternalWindowFlashing(identity: Identity): void {
   NativeWindowModule.stopFlashing(nativeWindow);
 }
 
-function getNativeWindow(identity: Identity): BrowserWindow {
+function getNativeWindow(identity: Identity): ExternalWindow {
   const { uuid } = identity;
   let nativeWindow = registeredExternalWindows.get(uuid);
 
   if (!nativeWindow) {
-    nativeWindow = new BrowserWindow({ hwnd: uuid });
+    nativeWindow = new ExternalWindow({ hwnd: uuid });
     registeredExternalWindows.set(uuid, nativeWindow);
   }
 

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -143,6 +143,8 @@ declare module 'electron' {
         };
     }
 
+    export class ExternalWindow extends BrowserWindow { }
+
     export class webContents {
         hasFrame: (frameName: string) => boolean;
         mainFrameRoutingId: number;


### PR DESCRIPTION
This prepares and decouples the core from any native refactor to decouple ExterrnalWindows from BrowserWindows.

Constructing instances of this module implicitly sets `releaseOnClose` behavior to ExternalWindows

Runtime changes are required: https://github.com/openfin/runtime/pull/1368