### PR TITLE
RUN-4958 Warning in console if no license key is included

### DIFF
--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -33,7 +33,8 @@
         options: { api: { iframe: { enableDeprecatedSharedName } } },
         socketServerState,
         runtimeArguments,
-        frames
+        frames,
+        licenseKey
     } = glbl.__startOptions;
 
     //Check if we need to use the process.eval in a nodeless environment.
@@ -129,6 +130,13 @@
 
     function getIpcConfigSync() {
         return elIPCConfig;
+    }
+
+    function isLicenseKeyValid() {
+        if (licenseKey && licenseKey.length === 36) {
+            return true;
+        }
+        return false;
     }
 
     function raiseEventSync(eventName, eventArgs) {
@@ -310,7 +318,10 @@
 
 
     function onContentReady(bindObject, callback) {
-
+        if (!isLicenseKeyValid()) {
+            console.warn('WARNING : Application does not have a valid OpenFin license key implemented in application manifest.' +
+                'To obtain a valid license key or to begin your 30 days of free support, please contact support@openfin.co.');
+        }
         if (currPageHasLoaded && (getOpenerSuccessCallbackCalled() || window.opener === null || initialOptions.rawWindowOpen)) {
             deferByTick(() => {
                 callback();

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -38,8 +38,9 @@ const api = (windowId, initialOptions) => {
     const mainWindowOptions = windowOptionSet.options || {};
     const enableV2Api = (mainWindowOptions.experimental || {}).v2Api;
     const v2AdapterShim = (!enableV2Api ? '' : jsAdapterV2);
-
+    const { uuid, name } = mainWindowOptions;
     windowOptionSet.runtimeArguments = JSON.stringify(coreState.args);
+    windowOptionSet.licenseKey = coreState.getManifest({ uuid, name }).licenseKey;
 
     return [
         `global.__startOptions = ${JSON.stringify(windowOptionSet)}`,


### PR DESCRIPTION
#### Description of Change
This PR is to check the license key field in the app manifest and also does validation that the length of license key should be 36 characters. If the license key is missing or the length is wrong, we will display a warning message in the console. 

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR release notes describe the change in a way relevant to app-developers

