### PR TITLE
Merge not handled for Target window

### DIFF
--- a/src/browser/window_groups_runtime_proxy.ts
+++ b/src/browser/window_groups_runtime_proxy.ts
@@ -179,13 +179,7 @@ export class RuntimeProxyWindow {
                         name: evt.targetWindowName
                     }, 'remove', []);
                 }
-                if (evt.reason === 'join') {
-                    this.raiseChangeEvents({
-                        uuid: evt.sourceWindowAppUuid,
-                        name: evt.sourceWindowName
-                    }, 'add', evt.sourceGroup);
-                }
-                if (evt.reason === 'merge') {
+                if (evt.reason === 'join' || evt.reason === 'merge') {
                     this.raiseChangeEvents({
                         uuid: evt.sourceWindowAppUuid,
                         name: evt.sourceWindowName

--- a/src/browser/window_groups_runtime_proxy.ts
+++ b/src/browser/window_groups_runtime_proxy.ts
@@ -185,6 +185,12 @@ export class RuntimeProxyWindow {
                         name: evt.sourceWindowName
                     }, 'add', evt.sourceGroup);
                 }
+                if (evt.reason === 'merge') {
+                    this.raiseChangeEvents({
+                        uuid: evt.sourceWindowAppUuid,
+                        name: evt.sourceWindowName
+                    }, 'add', evt.sourceGroup);
+                }
             } else if (this.window.uuid === evt.sourceWindowAppUuid && this.window.name === evt.sourceWindowName) {
                 if (evt.reason === 'merge') {
                     this.raiseChangeEvents({


### PR DESCRIPTION
#### Description of Change
Missing a `group-changed` event handler for multi runtime window groups.
When the reason equals `merge` and the targetWindow was our proxy window we would take no action.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
