### PR TITLE
RUN-5010 Frame constraints

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -178,6 +178,11 @@ let optionSetters = {
             if (maxWidth !== -1 || maxHeight !== -1) {
                 browserWin.setMaximumSize(maxWidth, maxHeight);
             }
+            const minWidth = getOptFromBrowserWin('minWidth', browserWin, -1);
+            const minHeight = getOptFromBrowserWin('minHeight', browserWin, -1);
+            if (minWidth !== -1 || minHeight !== -1) {
+                browserWin.setMinimumSize(minWidth, minHeight);
+            }
         }
         if (!frameBool) {
             // reapply corner rounding

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -169,10 +169,16 @@ let optionSetters = {
     },
     frame: function(newVal, browserWin) {
         let frameBool = !!newVal;
-
+        const prevBool = getOptFromBrowserWin('frame', browserWin, true);
         setOptOnBrowserWin('frame', frameBool, browserWin);
         browserWin.setHasFrame(frameBool);
-
+        if (frameBool !== prevBool) {
+            const maxWidth = getOptFromBrowserWin('maxWidth', browserWin, -1);
+            const maxHeight = getOptFromBrowserWin('maxHeight', browserWin, -1);
+            if (maxWidth !== -1 || maxHeight !== -1) {
+                browserWin.setMaximumSize(maxWidth, maxHeight);
+            }
+        }
         if (!frameBool) {
             // reapply corner rounding
             let cornerRounding = getOptFromBrowserWin('cornerRounding', browserWin, {

--- a/src/browser/rectangle.ts
+++ b/src/browser/rectangle.ts
@@ -43,9 +43,14 @@ class RectOptionsOpts {
 const zeroDelta = { x: 0, y: 0, height: 0, width: 0 };
 
 export class Rectangle {
-    public static CREATE_FROM_BOUNDS(rect: RectangleBase, opts: Opts = {}): Rectangle {
+    public static CREATE_FROM_BOUNDS(rect: RectangleBase, opts?: Opts): Rectangle {
         const { x, y, width, height } = rect;
-        return new Rectangle(x, y, width, height, new RectOptionsOpts(opts));
+        const options = opts
+            ? opts
+            : rect instanceof Rectangle
+                ? rect.opts
+                : {};
+        return new Rectangle(x, y, width, height, new RectOptionsOpts(options));
     }
     public static BOUND_SHARE_THRESHOLD = 5;
 


### PR DESCRIPTION
#### Description of Change
The os treats bounds constraints as content size constraints. The api treats is as exterior bounds constraints. This is an issue when a window with constraints is toggled between framed and frameless state. This pr updates the os bounds constraints on changes to the frame.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR release notes describe the change in a way relevant to app-developers


#### Release Notes

Notes: Fixed an issue where toggling a window's frame would result in inconsistent size constraint enforcement.
