### PR TITLE
RUN-5006 fixes core exception for resizeRegion

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -1956,7 +1956,7 @@ function handleForceActions(identity, force, eventType, eventPayload, defaultAct
 
 
 function applyAdditionalOptionsToWindow(browserWindow) {
-    let options = browserWindow && browserWindow._options;
+    const options = browserWindow && JSON.parse(JSON.stringify(browserWindow._options));
 
     if (!options) {
         return;


### PR DESCRIPTION
#### Description of Change
This fixes core exception thrown in some cases when updating window's `resizeRegion` option before the window is shown but immediately after it is created.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] automated test added: [Core exception: Window.updateOptions (resizeRegion)](https://testing-dashboard.openfin.co/#/app/tests/5c6db59ecb360141a7dfdbd0/edit)
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR release notes describe the change in a way relevant to app-developers

#### Release Notes
Bug fix: exception thrown in some cases when updating window's `resizeRegion` option.