### PR TITLE
RUN-5032 Size constraints update when changing frame

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -178,6 +178,11 @@ let optionSetters = {
             if (maxWidth !== -1 || maxHeight !== -1) {
                 browserWin.setMaximumSize(maxWidth, maxHeight);
             }
+            const minWidth = getOptFromBrowserWin('minWidth', browserWin, -1);
+            const minHeight = getOptFromBrowserWin('minHeight', browserWin, -1);
+            if (minWidth !== -1 || minHeight !== -1) {
+                browserWin.setMinimumSize(minWidth, minHeight);
+            }
         }
         if (!frameBool) {
             // reapply corner rounding

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -177,11 +177,17 @@ let optionSetters = {
             const maxHeight = getOptFromBrowserWin('maxHeight', browserWin, -1);
             if (maxWidth !== -1 || maxHeight !== -1) {
                 browserWin.setMaximumSize(maxWidth, maxHeight);
+                const { width, height, x, y } = browserWin.getBounds();
+                const setMaxWidth = maxWidth === -1 ? Number.MAX_SAFE_INTEGER : maxWidth;
+                const setMaxHeight = maxHeight === -1 ? Number.MAX_SAFE_INTEGER : maxHeight;
+                browserWin.setBounds({ width: Math.min(width, setMaxWidth), height: Math.min(height, setMaxHeight), x, y });
             }
-            const minWidth = getOptFromBrowserWin('minWidth', browserWin, -1);
-            const minHeight = getOptFromBrowserWin('minHeight', browserWin, -1);
-            if (minWidth !== -1 || minHeight !== -1) {
+            const minWidth = getOptFromBrowserWin('minWidth', browserWin, 0);
+            const minHeight = getOptFromBrowserWin('minHeight', browserWin, 0);
+            if (minWidth !== 0 || minHeight !== 0) {
                 browserWin.setMinimumSize(minWidth, minHeight);
+                const { width, height, x, y } = browserWin.getBounds();
+                browserWin.setBounds({ width: Math.max(width, minWidth), height: Math.max(height, minHeight), x, y });
             }
         }
         if (!frameBool) {

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -169,10 +169,16 @@ let optionSetters = {
     },
     frame: function(newVal, browserWin) {
         let frameBool = !!newVal;
-
+        const prevBool = getOptFromBrowserWin('frame', browserWin, true);
         setOptOnBrowserWin('frame', frameBool, browserWin);
         browserWin.setHasFrame(frameBool);
-
+        if (frameBool !== prevBool) {
+            const maxWidth = getOptFromBrowserWin('maxWidth', browserWin, -1);
+            const maxHeight = getOptFromBrowserWin('maxHeight', browserWin, -1);
+            if (maxWidth !== -1 || maxHeight !== -1) {
+                browserWin.setMaximumSize(maxWidth, maxHeight);
+            }
+        }
         if (!frameBool) {
             // reapply corner rounding
             let cornerRounding = getOptFromBrowserWin('cornerRounding', browserWin, {

--- a/src/browser/rectangle.ts
+++ b/src/browser/rectangle.ts
@@ -43,9 +43,14 @@ class RectOptionsOpts {
 const zeroDelta = { x: 0, y: 0, height: 0, width: 0 };
 
 export class Rectangle {
-    public static CREATE_FROM_BOUNDS(rect: RectangleBase, opts: Opts = {}): Rectangle {
+    public static CREATE_FROM_BOUNDS(rect: RectangleBase, opts?: Opts): Rectangle {
         const { x, y, width, height } = rect;
-        return new Rectangle(x, y, width, height, new RectOptionsOpts(opts));
+        const options = opts
+            ? opts
+            : rect instanceof Rectangle
+                ? rect.opts
+                : {};
+        return new Rectangle(x, y, width, height, new RectOptionsOpts(options));
     }
     public static BOUND_SHARE_THRESHOLD = 5;
 


### PR DESCRIPTION
#### Description of Change
This pr makes sure that size constraints are accurate when updating the window frame option.
Previously these constraints would be off by the width of the window frame.
This would cause issues for grouping.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR release notes describe the change in a way relevant to app-developers


#### Release Notes

Notes: Fixes an issue where a window's size constraints would be inaccurate if the window frame option was toggled
