### PR TITLE
RUN-4947 Undo clamp changes

### DIFF
--- a/src/browser/utils.ts
+++ b/src/browser/utils.ts
@@ -17,11 +17,6 @@ limitations under the License.
 import { BrowserWindow } from '../shapes';
 import { Rectangle, screen } from 'electron';
 
-interface Clamped {
-  value: number;
-  clampedOffset: number;
-}
-
 /*
   This function sets window's bounds to be in a visible area, in case
   the display where it was originally located was disconnected
@@ -60,29 +55,18 @@ export function clipBounds(bounds: Rectangle, browserWindow: BrowserWindow): Rec
 
   const { minWidth, minHeight, maxWidth, maxHeight } = browserWindow._options;
 
-  const xclamp = clamp(bounds.width, minWidth, maxWidth);
-  const yclamp = clamp(bounds.height, minHeight, maxHeight);
-
-  if (yclamp.clampedOffset || xclamp.clampedOffset) {
-    // here is where we can indicate a "pushed" window and may need to check all bounds
-  }
-
   return {
-    x: bounds.x + xclamp.clampedOffset,
-    y: bounds.y + yclamp.clampedOffset,
-    width: xclamp.value,
-    height: yclamp.value
+    x: bounds.x,
+    y: bounds.y,
+    width: clamp(bounds.width, minWidth, maxWidth),
+    height: clamp(bounds.height, minHeight, maxHeight)
   };
 }
 
 /*
   Adjust the number to be within the range of minimum and maximum values
 */
-function clamp(num: number, min: number = 0, max: number = Number.MAX_SAFE_INTEGER): Clamped {
+function clamp(num: number, min: number = 0, max: number = Number.MAX_SAFE_INTEGER): number {
   max = max < 0 ? Number.MAX_SAFE_INTEGER : max;
-  const value = Math.min(Math.max(num, min, 0), max);
-  return {
-    value,
-    clampedOffset: num < min ? -1 * (min - num) : 0 || num > max ? -1 * (num - max) : 0
-  };
+  return Math.min(Math.max(num, min, 0), max);
 }


### PR DESCRIPTION
#### Description of Change
This reverts unneeded changes to the clipBounds function that resulted in api calls moving windows when asked to shrink them past their minimums.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR release notes describe the change in a way relevant to app-developers


#### Release Notes

Notes: Resolved an issue where resize calls would move windows when trying to resize past constraints.
