### PR TITLE
RUN-5014 Window creation via window.open should use waitForPageLoad false

### DIFF
--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -126,7 +126,7 @@ function five0BaseOptions() {
         'transparent': false,
         'url': 'about:blank',
         'uuid': '',
-        'waitForPageLoad': true,
+        'waitForPageLoad': false,
         'backgroundColor': '#FFF',
         'webSecurity': true
     };

--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -126,7 +126,7 @@ function five0BaseOptions() {
         'transparent': false,
         'url': 'about:blank',
         'uuid': '',
-        'waitForPageLoad': false,
+        'waitForPageLoad': true,
         'backgroundColor': '#FFF',
         'webSecurity': true
     };

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -346,7 +346,8 @@
             url,
             uuid: initialOptions.uuid,
             name: name,
-            autoShow: true
+            autoShow: true,
+            waitForPageLoad: false
         });
 
         const convertedOpts = convertOptionsToElectronSync(options);


### PR DESCRIPTION
#### Description of Change

This PR creates an assumption of `waitForPageLoad: false` when creating a child window through `window.open()`
#### Checklist

- [X] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [X] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR release notes describe the change in a way relevant to app-developers


#### Release Notes

Creates a behavior more similar to a browser, where a window opens before fetching and drawing parsing its DOM.