### PR TITLE
RUN-5006 deep merge of window options

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -35,7 +35,7 @@ import { toSafeInt } from '../../common/safe_int';
 import route from '../../common/route';
 import { FrameInfo } from './frame';
 import { System } from './system';
-import { isFileUrl, isHttpUrl, getIdentityFromObject } from '../../common/main';
+import { isFileUrl, isHttpUrl, getIdentityFromObject, isObject, mergeDeep } from '../../common/main';
 import {
     DEFAULT_RESIZE_REGION_SIZE,
     DEFAULT_RESIZE_REGION_BOTTOM_RIGHT_CORNER,
@@ -2016,10 +2016,17 @@ function getOptFromBrowserWin(opt, browserWin, defaultVal) {
 }
 
 
-function setOptOnBrowserWin(opt, val, browserWin) {
-    var opts = browserWin && browserWin._options;
-    if (opts) {
-        opts[opt] = val;
+function setOptOnBrowserWin(opt, newValue, browserWin) {
+    var options = browserWin && browserWin._options;
+
+    if (options) {
+        const oldValue = options[opt];
+
+        if (isObject(oldValue) && isObject(newValue)) {
+            mergeDeep(oldValue, newValue);
+        } else {
+            options[opt] = newValue;
+        }
     }
 }
 

--- a/src/common/main.ts
+++ b/src/common/main.ts
@@ -107,3 +107,35 @@ export function noop(): void {
 export function isFloat(n: any): boolean {
     return Number(n) === n && n % 1 !== 0;
 }
+
+export function isObject(item: any): boolean {
+    return (item && typeof item === 'object' && !Array.isArray(item));
+}
+
+// Deep merge https://stackoverflow.com/a/34749873
+export function mergeDeep(target: any, ...sources: any[]): any {
+    if (!sources.length) {
+        return target;
+    }
+
+    const source = sources.shift();
+
+    if (isObject(target) && isObject(source)) {
+        const keys = Object.keys(source);
+
+        for (let i = 0; i < keys.length; i++) {
+            const key = keys[i];
+
+            if (isObject(source[key])) {
+                if (!target[key]) {
+                    Object.assign(target, { [key]: {} });
+                }
+                mergeDeep(target[key], source[key]);
+            } else {
+                Object.assign(target, { [key]: source[key] });
+            }
+        }
+    }
+
+    return mergeDeep(target, ...sources);
+}


### PR DESCRIPTION
### Description of Change
Window options updates will now be extending previous options, instead of replacing them.
This was causing an exception in the core for this specific scenario:
1. Create a new window with `autoShow: false` and `frame: false`
2. Partially update window options (like in the example below)
3. Show the window
4. Error box shown for the exception thrown in the core

#### Old behavior example:
1. Window options before updating: `{ ..., resizeRegion: { ..., sides: { top: true, ... }}}`
2. `wnd.updateOptions({ resizeRegion: { sides: { top: false } } })`
3. Window options after updating: `{ resizeRegion: { sides: { top: false } } }` 

#### New behavior example (this PR):
1. Window options before updating: `{ ..., resizeRegion: { ..., sides: { top: true, ... }}}`
2. `wnd.updateOptions({ resizeRegion: { sides: { top: false } } })`
3. Window options after updating: `{ ..., resizeRegion: { ..., sides: { top: false, ... }}}` 

#### Docs changes:
1. [js-adapter](https://github.com/HadoukenIO/js-adapter/pull/250)
2. [javascript-adapter](https://github.com/openfin/javascript-adapter/pull/527)

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] automated test added: [Core exception: Window.updateOptions (resizeRegion)](https://testing-dashboard.openfin.co/#/app/tests/5c6db59ecb360141a7dfdbd0/edit)
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR release notes describe the change in a way relevant to app-developers

#### Release Notes
Bug fix: exception thrown in some cases when partially updating window's options.