### PR TITLE
Check if name passed to window.open()

### DIFF
--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -340,7 +340,7 @@
         const [url, requestedName, features = ''] = args; // jshint ignore:line
         const requestId = ++childWindowRequestId;
         const webContentsId = getWebContentsId();
-        const name = !windowExistsSync(initialOptions.uuid, requestedName) ? requestedName : fin.desktop.getUuid();
+        const name = requestedName && !windowExistsSync(initialOptions.uuid, requestedName) ? requestedName : fin.desktop.getUuid();
         const responseChannel = `${name}-created`;
 
         const options = Object.assign(featuresToOptionsObj(features), {


### PR DESCRIPTION
#### Description of Change
Fixes a bug where not passing a window name to `window.open()` (like `window.open('https://example.com')` ) ignores custom options (i.e. `waitForPageLoad: false`).

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR release notes describe the change in a way relevant to app-developers


#### Release Notes

Allows to use `window.open()` without passing a window name.