### PR TITLE
RUN-5077: Write not-responsive events to log

### DIFF
--- a/index.js
+++ b/index.js
@@ -158,6 +158,8 @@ includeFlashPlugin();
 // Opt in to launch crash reporter
 initializeCrashReporter(coreState.argo);
 
+initializeDiagnosticReporter(coreState.argo);
+
 // Safe errors initialization
 errors.initSafeErrors(coreState.argo);
 
@@ -449,6 +451,20 @@ function initializeCrashReporter(argo) {
     }
 
     crashReporter.startOFCrashReporter({ diagnosticMode, configUrl });
+}
+
+function initializeDiagnosticReporter(argo) {
+    if (!argo['diagnostics']) {
+        return;
+    }
+
+    // This event may be fired more than once for an unresponsive window.
+    ofEvents.on(route.window('not-responding', '*'), (payload) => {
+        log.writeToLog('info', `Window is not responding. uuid: ${payload.data[0].uuid}, name: ${payload.data[0].name}`);
+    });
+    ofEvents.on(route.window('responding', '*'), (payload) => {
+        log.writeToLog('info', `Window responding again. uuid: ${payload.data[0].uuid}, name: ${payload.data[0].name}`);
+    });
 }
 
 function rotateLogs(argo) {


### PR DESCRIPTION
#### Description of Change
Write info about `not-responding` and `responding` events to the log when in diagnostics mode.
https://appoji.jira.com/browse/RUN-5077

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [ ] manual tests are [changed or added](https://github.com/openfin/test_apps)
- [ ] relevant documentation is [changed or added](https://github.com/hadoukenio/js-adapter)
- [x] PR release notes describe the change in a way relevant to app-developers


#### Release Notes

Notes: Added `not-responding` and `responding` events to logging when in diagnostics mode.
