### PR TITLE
Child windows not created with the OpenFin API will have waitForPageLoad set to false

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,10 +67,14 @@ const serverReadyPromise = new Promise((resolve) => {
     resolveServerReady = () => resolve();
 });
 
-app.on('child-window-created', function(parentId, childId, childOptions) {
+app.on('child-window-created', function(parentId, childId, childOptions, notApiCreated) {
 
     if (!coreState.addChildToWin(parentId, childId)) {
         console.warn('failed to add');
+    }
+
+    if (notApiCreated) {
+        Object.assign(childOptions, { waitForPageLoad: false });
     }
 
     Window.create(childId, childOptions);
@@ -357,13 +361,13 @@ app.on('ready', function() {
 
     rvmBus.on(route.rvmMessageBus('broadcast', 'application', 'runtime-download-progress'), payload => {
         if (payload) {
-            ofEvents.emit(route.system(`runtime-download-progress-${ payload.downloadId }`), payload);
+            ofEvents.emit(route.system(`runtime-download-progress-${payload.downloadId}`), payload);
         }
     });
 
     rvmBus.on(route.rvmMessageBus('broadcast', 'application', 'runtime-download-error'), payload => {
         if (payload) {
-            ofEvents.emit(route.system(`runtime-download-error-${ payload.downloadId }`), {
+            ofEvents.emit(route.system(`runtime-download-error-${payload.downloadId}`), {
                 reason: payload.error,
                 err: errors.errorToPOJO(new Error(payload.error))
             });
@@ -372,7 +376,7 @@ app.on('ready', function() {
 
     rvmBus.on(route.rvmMessageBus('broadcast', 'application', 'runtime-download-complete'), payload => {
         if (payload) {
-            ofEvents.emit(route.system(`runtime-download-complete-${ payload.downloadId }`), {
+            ofEvents.emit(route.system(`runtime-download-complete-${payload.downloadId}`), {
                 path: payload.path
             });
         }


### PR DESCRIPTION
#### Description of Change
Child window creation now checks if it the call did not come from our API. If it doesn't, then it will set waitForPageLoad to false for these calls.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included and stakeholders cc'd
- [X] `npm test` passes

#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes. Examples and help on special cases: http://developer.openfin.co/versions/?product=Runtime&version=9.61.37.46 -->

