### PR TITLE
RUN-5104 Make app log flush interval configurable

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -982,7 +982,7 @@ Window.create = function(id, opts) {
             // Format timestamp to match debug.log
             const timeStamp = `${year}-${month}-${day} ${hour}:${minute}:${second}.${millisecond}`;
 
-            addConsoleMessageToRVMMessageQueue({ level, message, appConfigUrl, timeStamp }, app._options.appLogFlushInterval);
+            addConsoleMessageToRVMMessageQueue({ level, message, appConfigUrl, timeStamp }, coreState.argo['app-log-flush-interval-ms']);
 
         }, 1);
     };

--- a/src/browser/rvm/utils.ts
+++ b/src/browser/rvm/utils.ts
@@ -58,10 +58,16 @@ export function addConsoleMessageToRVMMessageQueue(consoleMessage: ConsoleMessag
 
         flushConsoleMessageQueue();
 
-    // Otherwise if no timer already set, set one to flush the queue in 10s
+    // Otherwise if no timer already set, set one to flush the queue in 'interval' seconds
     } else if (!isFlushScheduled) {
         isFlushScheduled = true;
-        timer = setTimeout(flushConsoleMessageQueue, flushInterval ? flushInterval : defaultFlushInterval);
+
+        let interval = defaultFlushInterval;
+        if (flushInterval !== undefined) {
+            interval = flushInterval;
+        }
+
+        timer = setTimeout(flushConsoleMessageQueue, interval);
     }
 }
 


### PR DESCRIPTION
#### Description of Change
Currently the core queues up all console.log messages internally, and flushes this queue to the RVM on a 10 second interval. Allow this interval to be configurable on a per-runtime basis via the runtime arg `--app-log-flush-interval-ms`

[JIRA](https://appoji.jira.com/browse/RUN-5104)

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Pull Request process: https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR release notes describe the change in a way relevant to app-developers


#### Release Notes
Notes: <!-- Please add a one-line description for app developers to read in the release notes. Examples and help on special cases: http://developer.openfin.co/versions/?product=Runtime&version=9.61.37.46 -->
The interval on which the core flushes the console log message queue to the RVM is now configurable via the runtime argument `--app-log-flush-interval-ms`. By default the value is `10000` ms.
