### PR TITLE
RUN-4765 Don't use decorated fs module; use the original

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,7 +164,10 @@ errors.initSafeErrors(coreState.argo);
 // Has a local copy of an app config
 if (coreState.argo['local-startup-url']) {
     try {
-        let localConfig = JSON.parse(fs.readFileSync(coreState.argo['local-startup-url']));
+        // Use this version of the fs module because the decorated version checks if the file
+        // has a matching signature file
+        const originalFs = require('original-fs');
+        let localConfig = JSON.parse(originalFs.readFileSync(coreState.argo['local-startup-url']));
 
         if (typeof localConfig['devtools_port'] === 'number') {
             if (!coreState.argo['remote-debugging-port']) {
@@ -175,7 +178,7 @@ if (coreState.argo['local-startup-url']) {
             }
         }
     } catch (err) {
-        console.error(err);
+        log.writeToLog(1, err, true);
     }
 }
 

--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -3,7 +3,6 @@
  */
 
 // built-in modules
-let fs = require('fs');
 let path = require('path');
 let queryString = require('querystring');
 
@@ -308,7 +307,10 @@ module.exports = {
         // allow fetching from the local-startup-url config
         if (localConfigPath) {
             try {
-                let localConfig = JSON.parse(fs.readFileSync(localConfigPath));
+                // Use this version of the fs module because the decorated version checks if the file
+                // has a matching signature file
+                const originalFs = require('original-fs');
+                let localConfig = JSON.parse(originalFs.readFileSync(localConfigPath));
 
                 if (localConfig['offlineAccess']) {
                     offlineAccess = true;


### PR DESCRIPTION
Electron decorate's NodeJS's fs module to handle asars. Since we are
adding on functionality to the fs module to also verify asars, this
causes an issue where for every file that needs to be read in via
fs.readFileSync, there needs to be a matching file that contains a
hashed signature. This prevents us from using the decorated fs module
for general purpose file reading.

Instead, we expose 'original-fs' in the case you don't need to read
files from asars.

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Pull Request process: https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [ ] manual tests are [changed or added](https://github.com/openfin/test_apps)
- [ ] relevant documentation is [changed or added](https://github.com/hadoukenio/js-adapter)
- [ ] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [ ] PR release notes describe the change in a way relevant to app-developers


#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes. Examples and help on special cases: http://developer.openfin.co/versions/?product=Runtime&version=9.61.37.46 -->
