### PR TITLE
RUN-5069 Add window options updated event (take #2)

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -1697,12 +1697,31 @@ Window.defineDraggableArea = function() {};
 
 Window.updateOptions = function(identity, updateObj) {
     let browserWindow = getElectronBrowserWindow(identity, 'update settings for');
+    let { uuid, name } = identity;
+    let diff = {},
+        invalidOptions = [];
+    let clone = obj => JSON.parse(JSON.stringify(obj)); // this works here, but has limitations; reuse with caution.
 
     try {
         for (var opt in updateObj) {
+
             if (optionSetters[opt]) {
+                let oldVal = clone(getOptFromBrowserWin(opt, browserWindow));
                 optionSetters[opt](updateObj[opt], browserWindow);
+                let newVal = clone(getOptFromBrowserWin(opt, browserWindow));
+
+
+                if (!_.isEqual(oldVal, newVal)) {
+                    diff[opt] = { oldVal, newVal };
+                }
+            } else {
+                invalidOptions.push(opt);
             }
+        }
+
+        let options = browserWindow && clone(browserWindow._options);
+        if (Object.keys(diff).length) {
+            ofEvents.emit(route.window('options-changed', uuid, name), { uuid, name, options, diff, invalidOptions });
         }
     } catch (e) {
         console.log(e.message);


### PR DESCRIPTION
#### Description of Change
**Added a 'options-changed' event to window after window.updateOptions is done.** 

The payload contains a diff array containing prev and new values for all changed options.

Would appreciate if you could also take a look at the [dashboard test](https://testing-dashboard.openfin.co/#/app/tests/5c9a5c6acb360141a7dfdec4/edit)

Related [js adapter PR](https://github.com/HadoukenIO/js-adapter/pull/259)
#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included
- [x] `npm test` passes
- [x] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [x] relevant documentation was added
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR release notes describe the change in a way relevant to app-developers


#### Release Notes

Notes: Added a 'options-changed' event to window after window.updateOptions is done.
