### PR TITLE
Feature/RUN-5123 native window

### DIFF
--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -534,7 +534,6 @@
     }
 
     function getWebWindow(name) {
-
         let webWindow = webWindowMap.get(name);
         if (webWindow) {
             return webWindow;
@@ -547,21 +546,6 @@
             }
         }
     }
-
-
-    window.addEventListener('beforeunload', () => {
-        deregisterWebWindow(initialOptions.name);
-    });
-
-    onContentReady(window, () => {
-        const app = fin.Application.getCurrentSync();
-        app.on('window-closed', ({ name }) => {
-            deregisterWebWindow(name);
-        });
-    });
-
-    deferByTick(() => registerWebWindow(getWindowIdentitySync().name, window));
-    //End WEB Window Functionality
 
     ///external API Decorator:
     global.fin = {
@@ -676,5 +660,23 @@
 
         asyncApiCall(action, { allDone: true });
     }
+
+    window.addEventListener('beforeunload', () => {
+        try {
+            deregisterWebWindow(initialOptions.name);
+        } catch (err) {
+            console.error(err);
+        }
+    });
+
+    //if window content is cross domain, beforeunload might not catch this
+    onContentReady(window, () => {
+        const app = fin.Application.getCurrentSync();
+        app.on('window-closed', ({ name }) => {
+            deregisterWebWindow(name);
+        });
+    });
+
+    deferByTick(() => registerWebWindow(getWindowIdentitySync().name, window));
 
 }());

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -394,7 +394,7 @@
                         try {
                             let returnMeta = JSON.parse(meta);
                             cb({
-                                webWindow: webWindow,
+                                nativeWindow: webWindow,
                                 id: returnMeta.windowId
                             });
                         } catch (e) {}


### PR DESCRIPTION
#### Description of Change
Added the ability to get the [Window Object](https://developer.mozilla.org/en-US/docs/Web/API/Window) previously available in the V1 API as `getNativeWindow`

- [ X ] PR description included and stakeholders cc'd
- [ X ] `npm test` passes
- [ X ] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [] manual tests are [changed or added](https://github.com/openfin/test_apps)
- [X] relevant documentation is [changed or added](https://github.com/hadoukenio/js-adapter)
- [X] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [X] PR release notes describe the change in a way relevant to app-developers


Notes: 
Added `getWebWindow` API that returns the [Window Object](https://developer.mozilla.org/en-US/docs/Web/API/Window).  Previously `getNativeWindow` in API V1

Test Results: 
[Win 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5c9e79c1cb360141a7dfdf3a)
[Win 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5c9e7c0acb360141a7dfdf3b)
