### PR TITLE
RUN-5084 - Proxy Window _options are not updated when the original window is.

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -1697,13 +1697,21 @@ Window.defineDraggableArea = function() {};
 
 Window.updateOptions = function(identity, updateObj) {
     let browserWindow = getElectronBrowserWindow(identity, 'update settings for');
+    let { uuid, name } = identity;
+    let diff = [];
 
     try {
         for (var opt in updateObj) {
             if (optionSetters[opt]) {
+                let optionValues = { optionName: opt };
+                optionValues.oldVal = getOptFromBrowserWin(opt, browserWindow);
                 optionSetters[opt](updateObj[opt], browserWindow);
+                optionValues.newVal = getOptFromBrowserWin(opt, browserWindow);
+                diff.push(optionValues);
             }
         }
+        ofEvents.emit(route.window('options-changed', uuid, name), { diff, uuid, name });
+
     } catch (e) {
         console.log(e.message);
     }

--- a/src/browser/window_groups_runtime_proxy.ts
+++ b/src/browser/window_groups_runtime_proxy.ts
@@ -235,6 +235,7 @@ export async function getRuntimeProxyWindow(identity: Identity): Promise<Runtime
         const windowOptions = await wrappedWindow.getOptions();
         const win = new RuntimeProxyWindow(hostRuntime, wrappedWindow, nativeId, windowOptions);
         win.wireUpEvents();
+        
         return win;
     }
 }

--- a/src/browser/window_groups_runtime_proxy.ts
+++ b/src/browser/window_groups_runtime_proxy.ts
@@ -9,7 +9,7 @@ import * as coreState from './core_state';
 import { _Window } from '../../js-adapter/src/api/window/window';
 import { EventEmitter } from 'events';
 import { writeToLog } from './log';
-import { WindowGroupChanged, WindowOptionsChanged } from '../../js-adapter/src/api/events/window';
+import { WindowGroupChanged, WindowOptionsChanged, WindowOptionDiffObject } from '../../js-adapter/src/api/events/window';
 import { argo } from './core_state';
 
 //Only allow window proxies to >=.35 runtimes.
@@ -199,7 +199,7 @@ export class RuntimeProxyWindow {
 
     private onOptionsChanged = (evt: WindowOptionsChanged<'window', 'group-changed'>) => {
         if (this.window.uuid === evt.uuid && this.window.name === evt.name) {
-            const optionsToUpdate: {[name: string]: any} = {};
+            const optionsToUpdate: {[name: string]: WindowOptionDiffObject} = {};
             evt.diff.forEach(option => optionsToUpdate[option.optionName] = option.newVal);
 
             this.window._options = Object.assign({}, this.window._options, optionsToUpdate);

--- a/src/browser/window_groups_runtime_proxy.ts
+++ b/src/browser/window_groups_runtime_proxy.ts
@@ -9,7 +9,7 @@ import * as coreState from './core_state';
 import { _Window } from '../../js-adapter/src/api/window/window';
 import { EventEmitter } from 'events';
 import { writeToLog } from './log';
-import { WindowGroupChanged } from '../../js-adapter/src/api/events/window';
+import { WindowGroupChanged, WindowOptionsChanged } from '../../js-adapter/src/api/events/window';
 import { argo } from './core_state';
 
 //Only allow window proxies to >=.35 runtimes.
@@ -113,6 +113,7 @@ export class RuntimeProxyWindow {
             this.window.browserWindow.setExternalWindowNativeId('0x0');
             this.window.browserWindow.close();
             await this.wrappedWindow.removeListener('group-changed', this.onGroupChanged);
+            await this.wrappedWindow.removeListener('options-changed', this.onOptionsChanged);
         } catch (err) {
             writeToLog('info', 'Non Fatal error: remove all listeners failed for proxy window');
             writeToLog('info', err);
@@ -129,6 +130,7 @@ export class RuntimeProxyWindow {
 
     public wireUpEvents = async (): Promise<void> => {
         await this.wrappedWindow.on('group-changed', this.onGroupChanged);
+        await this.wrappedWindow.on('options-changed', this.onOptionsChanged);
         await this.hostRuntime.fin.once('disconnected', () => {
             this.raiseChangeEvents(this.wrappedWindow.identity, 'remove', []);
         });
@@ -170,31 +172,42 @@ export class RuntimeProxyWindow {
     }
 
     private onGroupChanged = (evt: WindowGroupChanged<'window', 'group-changed'>) => {
-            writeToLog('info', 'Group changed event');
-            writeToLog('info', evt);
-            if (this.window.uuid === evt.targetWindowAppUuid && this.window.name === evt.targetWindowName) {
-                if (evt.reason === 'leave') {
-                    this.raiseChangeEvents({
-                        uuid: evt.targetWindowAppUuid,
-                        name: evt.targetWindowName
-                    }, 'remove', []);
-                }
-                if (evt.reason === 'join' || evt.reason === 'merge') {
-                    this.raiseChangeEvents({
-                        uuid: evt.sourceWindowAppUuid,
-                        name: evt.sourceWindowName
-                    }, 'add', evt.sourceGroup);
-                }
-            } else if (this.window.uuid === evt.sourceWindowAppUuid && this.window.name === evt.sourceWindowName) {
-                if (evt.reason === 'merge') {
-                    this.raiseChangeEvents({
-                        uuid: evt.targetWindowAppUuid,
-                        name: evt.targetWindowName
-                    }, 'add', []);
-                }
+        writeToLog('info', 'Group changed event');
+        writeToLog('info', evt);
+        if (this.window.uuid === evt.targetWindowAppUuid && this.window.name === evt.targetWindowName) {
+            if (evt.reason === 'leave') {
+                this.raiseChangeEvents({
+                    uuid: evt.targetWindowAppUuid,
+                    name: evt.targetWindowName
+                }, 'remove', []);
             }
-        };
-    }
+            if (evt.reason === 'join' || evt.reason === 'merge') {
+                this.raiseChangeEvents({
+                    uuid: evt.sourceWindowAppUuid,
+                    name: evt.sourceWindowName
+                }, 'add', evt.sourceGroup);
+            }
+        } else if (this.window.uuid === evt.sourceWindowAppUuid && this.window.name === evt.sourceWindowName) {
+            if (evt.reason === 'merge') {
+                this.raiseChangeEvents({
+                    uuid: evt.targetWindowAppUuid,
+                    name: evt.targetWindowName
+                }, 'add', []);
+            }
+        }
+    };
+
+    private onOptionsChanged = (evt: WindowOptionsChanged<'window', 'group-changed'>) => {
+        if (this.window.uuid === evt.uuid && this.window.name === evt.name) {
+            const optionsToUpdate: {[name: string]: any} = {};
+            evt.diff.forEach(option => optionsToUpdate[option.optionName] = option.newVal);
+
+            this.window._options = Object.assign({}, this.window._options, optionsToUpdate);
+            writeToLog('info', 'Options changed event');
+            writeToLog('info', evt);
+        }
+    };
+}
 
 export async function getRuntimeProxyWindow(identity: Identity): Promise<RuntimeProxyWindow> {
     const { uuid, name } = identity;


### PR DESCRIPTION
#### Description of Change
Proxy windows will now update their _options object once their proxied window's options change.

Would appreciate feedback on the [dashboard test](https://testing-dashboard.openfin.co/#/app/tests/5c9e80c0cb360141a7dfdf3d/edit)

This PR is dependent on the 'options-changed' event added in [this PR](https://github.com/HadoukenIO/core/pull/754)
Also dependent on [this js-adapter PR](https://github.com/HadoukenIO/js-adapter/pull/259)

#### Checklist
- [x] PR description included
- [x] `npm test` passes
- [x] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR release notes describe the change in a way relevant to app-developers