### PR TITLE
RUN-5084 - Proxy Window _options are not updated when the original window is.

### DIFF
--- a/src/browser/window_groups_runtime_proxy.ts
+++ b/src/browser/window_groups_runtime_proxy.ts
@@ -9,7 +9,7 @@ import * as coreState from './core_state';
 import { _Window } from '../../js-adapter/src/api/window/window';
 import { EventEmitter } from 'events';
 import { writeToLog } from './log';
-import { WindowGroupChanged } from '../../js-adapter/src/api/events/window';
+import { WindowGroupChanged, WindowOptionsChanged, WindowOptionDiffObject } from '../../js-adapter/src/api/events/window';
 import { argo } from './core_state';
 
 //Only allow window proxies to >=.35 runtimes.
@@ -113,6 +113,7 @@ export class RuntimeProxyWindow {
             this.window.browserWindow.setExternalWindowNativeId('0x0');
             this.window.browserWindow.close();
             await this.wrappedWindow.removeListener('group-changed', this.onGroupChanged);
+            await this.wrappedWindow.removeListener('options-changed', this.onOptionsChanged);
         } catch (err) {
             writeToLog('info', 'Non Fatal error: remove all listeners failed for proxy window');
             writeToLog('info', err);
@@ -129,6 +130,7 @@ export class RuntimeProxyWindow {
 
     public wireUpEvents = async (): Promise<void> => {
         await this.wrappedWindow.on('group-changed', this.onGroupChanged);
+        await this.wrappedWindow.on('options-changed', this.onOptionsChanged);
         await this.hostRuntime.fin.once('disconnected', () => {
             this.raiseChangeEvents(this.wrappedWindow.identity, 'remove', []);
         });
@@ -170,31 +172,42 @@ export class RuntimeProxyWindow {
     }
 
     private onGroupChanged = (evt: WindowGroupChanged<'window', 'group-changed'>) => {
-            writeToLog('info', 'Group changed event');
-            writeToLog('info', evt);
-            if (this.window.uuid === evt.targetWindowAppUuid && this.window.name === evt.targetWindowName) {
-                if (evt.reason === 'leave') {
-                    this.raiseChangeEvents({
-                        uuid: evt.targetWindowAppUuid,
-                        name: evt.targetWindowName
-                    }, 'remove', []);
-                }
-                if (evt.reason === 'join' || evt.reason === 'merge') {
-                    this.raiseChangeEvents({
-                        uuid: evt.sourceWindowAppUuid,
-                        name: evt.sourceWindowName
-                    }, 'add', evt.sourceGroup);
-                }
-            } else if (this.window.uuid === evt.sourceWindowAppUuid && this.window.name === evt.sourceWindowName) {
-                if (evt.reason === 'merge') {
-                    this.raiseChangeEvents({
-                        uuid: evt.targetWindowAppUuid,
-                        name: evt.targetWindowName
-                    }, 'add', []);
-                }
+        writeToLog('info', 'Group changed event');
+        writeToLog('info', evt);
+        if (this.window.uuid === evt.targetWindowAppUuid && this.window.name === evt.targetWindowName) {
+            if (evt.reason === 'leave') {
+                this.raiseChangeEvents({
+                    uuid: evt.targetWindowAppUuid,
+                    name: evt.targetWindowName
+                }, 'remove', []);
             }
-        };
-    }
+            if (evt.reason === 'join' || evt.reason === 'merge') {
+                this.raiseChangeEvents({
+                    uuid: evt.sourceWindowAppUuid,
+                    name: evt.sourceWindowName
+                }, 'add', evt.sourceGroup);
+            }
+        } else if (this.window.uuid === evt.sourceWindowAppUuid && this.window.name === evt.sourceWindowName) {
+            if (evt.reason === 'merge') {
+                this.raiseChangeEvents({
+                    uuid: evt.targetWindowAppUuid,
+                    name: evt.targetWindowName
+                }, 'add', []);
+            }
+        }
+    };
+
+    private onOptionsChanged = (evt: WindowOptionsChanged<'window', 'group-changed'>) => {
+        if (this.window.uuid === evt.uuid && this.window.name === evt.name) {
+            const optionsToUpdate: {[name: string]: WindowOptionDiffObject} = {};
+            evt.diff.forEach(option => optionsToUpdate[option.optionName] = option.newVal);
+
+            this.window._options = Object.assign({}, this.window._options, optionsToUpdate);
+            writeToLog('info', 'Options changed event');
+            writeToLog('info', evt);
+        }
+    };
+}
 
 export async function getRuntimeProxyWindow(identity: Identity): Promise<RuntimeProxyWindow> {
     const { uuid, name } = identity;
@@ -222,6 +235,7 @@ export async function getRuntimeProxyWindow(identity: Identity): Promise<Runtime
         const windowOptions = await wrappedWindow.getOptions();
         const win = new RuntimeProxyWindow(hostRuntime, wrappedWindow, nativeId, windowOptions);
         win.wireUpEvents();
+        
         return win;
     }
 }

--- a/src/browser/window_groups_runtime_proxy.ts
+++ b/src/browser/window_groups_runtime_proxy.ts
@@ -9,8 +9,9 @@ import * as coreState from './core_state';
 import { _Window } from '../../js-adapter/src/api/window/window';
 import { EventEmitter } from 'events';
 import { writeToLog } from './log';
-import { WindowGroupChanged, WindowOptionsChanged, WindowOptionDiffObject } from '../../js-adapter/src/api/events/window';
+import { WindowGroupChanged, WindowOptionsChangedEvent} from '../../js-adapter/src/api/events/window';
 import { argo } from './core_state';
+import { WindowOption } from '../../js-adapter/src/api/window/windowOption';
 
 //Only allow window proxies to >=.35 runtimes.
 const MIN_API_VER = 37;
@@ -197,11 +198,15 @@ export class RuntimeProxyWindow {
         }
     };
 
-    private onOptionsChanged = (evt: WindowOptionsChanged<'window', 'group-changed'>) => {
+    private onOptionsChanged = (evt: WindowOptionsChangedEvent<'window', 'options-changed'>) => {
         if (this.window.uuid === evt.uuid && this.window.name === evt.name) {
-            const optionsToUpdate: {[name: string]: WindowOptionDiffObject} = {};
-            evt.diff.forEach(option => optionsToUpdate[option.optionName] = option.newVal);
+            const optionsToUpdate: {[name: string]: any} = {};
+            let option: keyof WindowOption;
 
+            for(option in evt.diff) {
+                optionsToUpdate[option] = evt.diff[option].newVal;
+            }
+            
             this.window._options = Object.assign({}, this.window._options, optionsToUpdate);
             writeToLog('info', 'Options changed event');
             writeToLog('info', evt);

--- a/src/browser/window_groups_runtime_proxy.ts
+++ b/src/browser/window_groups_runtime_proxy.ts
@@ -201,12 +201,12 @@ export class RuntimeProxyWindow {
     private onOptionsChanged = (evt: WindowOptionsChangedEvent<'window', 'options-changed'>) => {
         if (this.window.uuid === evt.uuid && this.window.name === evt.name) {
             const optionsToUpdate: {[name: string]: any} = {};
-            let option: keyof WindowOption;
 
-            for(option in evt.diff) {
+            Object.keys(evt.diff).forEach((option: keyof WindowOption) => {
                 optionsToUpdate[option] = evt.diff[option].newVal;
-            }
-            
+            });
+
+
             this.window._options = Object.assign({}, this.window._options, optionsToUpdate);
             writeToLog('info', 'Options changed event');
             writeToLog('info', evt);
@@ -240,7 +240,7 @@ export async function getRuntimeProxyWindow(identity: Identity): Promise<Runtime
         const windowOptions = await wrappedWindow.getOptions();
         const win = new RuntimeProxyWindow(hostRuntime, wrappedWindow, nativeId, windowOptions);
         win.wireUpEvents();
-        
+
         return win;
     }
 }


### PR DESCRIPTION
#### Description of Change
Proxy windows will now update their _options object once their proxied window's options change.

Would appreciate feedback on the [dashboard test](https://testing-dashboard.openfin.co/#/app/tests/5c9e80c0cb360141a7dfdf3d/edit)

This PR branched out of pull/754 and uses the 'options-changed' event introduced in it.
The PR is Dependent on [this js-adapter PR](https://github.com/HadoukenIO/js-adapter/pull/259)

#### Checklist
- [x] PR description included
- [x] `npm test` passes
- [x] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR release notes describe the change in a way relevant to app-developers