### PR TITLE
RUN-5134: Release uuid's on websocket disconnect

### DIFF
--- a/src/browser/api_protocol/api_handlers/authorization.js
+++ b/src/browser/api_protocol/api_handlers/authorization.js
@@ -11,7 +11,7 @@ import socketServer from '../../transports/socket_server';
 let ProcessTracker = require('../../process_tracker.js');
 const rvmMessageBus = require('../../rvm/rvm_message_bus').rvmMessageBus;
 import route from '../../../common/route';
-import { lockUuid } from '../../uuid_availability';
+import { lockUuid, releaseUuid } from '../../uuid_availability';
 const successAck = {
     success: true
 };
@@ -203,6 +203,7 @@ module.exports.init = function() {
         externalConnection = ExternalApplication.getExternalConnectionById(id);
         if (externalConnection) {
             ExternalApplication.removeExternalConnection(externalConnection);
+            releaseUuid(externalConnection.uuid);
             ofEvents.emit(route('externalconn', 'closed'), externalConnection);
         }
 


### PR DESCRIPTION
#### Description of Change
Releases the lock on a uuid when the corresponding process disconnec
JIRA ticket: https://appoji.jira.com/browse/RUN-5134

Test PR in js-adapter: https://github.com/HadoukenIO/js-adapter/pull/268

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [ ] manual tests are [changed or added](https://github.com/openfin/test_apps)
- [ ] relevant documentation is [changed or added](https://github.com/hadoukenio/js-adapter)
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [ ] PR release notes describe the change in a way relevant to app-developers


#### Release Notes

Notes: Resolved issue where locked uuid's were not released on termination of an external connection.
