### PR TITLE
RUN-5218 [Regression 10.66.41.*] Updating contextMenu window option has no effect

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -161,6 +161,7 @@ let optionSetters = {
         const val = Object.assign({}, getOptFromBrowserWin('contextMenuSettings', browserWin),
             newVal);
         setOptOnBrowserWin('contextMenuSettings', val, browserWin);
+        setOptOnBrowserWin('contextMenu', val.enable, browserWin); // support for old api
         browserWin.setMenu(null);
         browserWin.webContents.updateContextMenuSettings(val);
     },
@@ -1700,7 +1701,7 @@ Window.updateOptions = function(identity, updateObj) {
     let { uuid, name } = identity;
     let diff = {},
         invalidOptions = [];
-    let clone = obj => JSON.parse(JSON.stringify(obj)); // this works here, but has limitations; reuse with caution.
+    let clone = obj => typeof obj === 'undefined' ? obj : JSON.parse(JSON.stringify(obj)); // this works here, but has limitations; reuse with caution.
 
     try {
         for (var opt in updateObj) {


### PR DESCRIPTION
#### Description of Change

- fixed a bug that caused contextMenu to not update
- added contextMenu to getOptions payload

#### Checklist
- [x] PR description included
- [x] `npm test` passes
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
