### PR TITLE
RUN-5112 Add the ability to get the desktop owner settings for services

### DIFF
--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -455,21 +455,19 @@ exports.System = {
         let RvmInfoFetcher = require('../rvm/runtime_initiated_topics/rvm_info.js');
         RvmInfoFetcher.fetch(sourceUrl, callback, errorCallback);
     },
-    getServiceConfiguration: function(serviceIdentifier) {
-
+    getServiceConfiguration: function() {
         const rvmMessage = {
             topic: 'application',
             action: 'get-service-settings',
             sourceUrl: 'https://openfin.co'
         };
 
-        return new Promise((resolve, reject) => {
+        return new Promise((resolve) => {
             rvmBus.publish(rvmMessage, response => {
                 if (!response || !response.payload) {
-                    reject('Bad Response from RVM');
-                }
-                if (response.payload.success === false) {
-                    reject(new Error(response.payload.error));
+                    resolve(new Error('Bad Response from RVM'));
+                } else if (response.payload.success === false) {
+                    resolve(new Error(response.payload.error || 'get-service-settings failed'));
                 } else {
                     resolve(response.payload.settings);
                 }

--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -455,6 +455,27 @@ exports.System = {
         let RvmInfoFetcher = require('../rvm/runtime_initiated_topics/rvm_info.js');
         RvmInfoFetcher.fetch(sourceUrl, callback, errorCallback);
     },
+    getServiceConfiguration: function(serviceIdentifier) {
+
+        const rvmMessage = {
+            topic: 'application',
+            action: 'get-service-settings',
+            sourceUrl: 'https://openfin.co'
+        };
+
+        return new Promise((resolve, reject) => {
+            rvmBus.publish(rvmMessage, response => {
+                if (!response || !response.payload) {
+                    reject('Bad Response from RVM');
+                }
+                if (response.payload.success === false) {
+                    reject(new Error(response.payload.error));
+                } else {
+                    resolve(response.payload.settings);
+                }
+            });
+        });
+    },
     launchExternalProcess: function(identity, options, errDataCallback) { // Node-style callback used here
         options.srcUrl = coreState.getConfigUrlByUuid(identity.uuid);
 

--- a/src/browser/api_protocol/api_handlers/api_policy_processor.ts
+++ b/src/browser/api_protocol/api_handlers/api_policy_processor.ts
@@ -296,7 +296,7 @@ function registerDelegate(apiPath: ApiPath, delegate: ApiPolicyDelegate) {
     delegateMap.set(apiPath, delegate);
 }
 
-function retrieveAPIPolicyContent(): Promise<any> {
+export function retrieveAPIPolicyContent(): Promise<any> {
     writeToLog(1, 'retrieveAPIPolicyContent', true);
     return new Promise((resolve, reject) => {
         const msg: GetDesktopOwnerSettings = {

--- a/src/browser/api_protocol/api_handlers/api_policy_processor.ts
+++ b/src/browser/api_protocol/api_handlers/api_policy_processor.ts
@@ -296,7 +296,7 @@ function registerDelegate(apiPath: ApiPath, delegate: ApiPolicyDelegate) {
     delegateMap.set(apiPath, delegate);
 }
 
-export function retrieveAPIPolicyContent(): Promise<any> {
+function retrieveAPIPolicyContent(): Promise<any> {
     writeToLog(1, 'retrieveAPIPolicyContent', true);
     return new Promise((resolve, reject) => {
         const msg: GetDesktopOwnerSettings = {

--- a/src/browser/api_protocol/api_handlers/system.ts
+++ b/src/browser/api_protocol/api_handlers/system.ts
@@ -78,6 +78,7 @@ export const SystemApiMap: APIHandlerMap = {
     'get-remote-config': { apiFunc: getRemoteConfig, apiPath: '.getRemoteConfig' },
     'get-runtime-info': getRuntimeInfo,
     'get-rvm-info': getRvmInfo,
+    'get-service-configuration': getServiceConfiguration,
     'get-preload-scripts': getPreloadScripts,
     'get-version': getVersion,
     'launch-external-process': { apiFunc: launchExternalProcess, apiPath: '.launchExternalProcess' },
@@ -113,6 +114,30 @@ export function init(): void {
 
 function didFail(e: any): boolean {
     return e !== undefined && e.constructor === Error;
+}
+
+const dosURL = 'https://openfin.co/documentation/desktop-owner-settings/';
+
+async function getServiceConfiguration(identity: Identity, message: APIMessage) {
+    const { name } = message.payload;
+    const response = await System.getServiceConfiguration(message);
+
+    if (!response) {
+        throw new Error('Services not configured in desktop owner settings');
+    }
+
+    if (!Array.isArray(response)) {
+        throw new Error(`Settings in desktop owner settings are not configured correctly, please see
+         ${dosURL} for configuration information`);
+    }
+
+    const config = response.find(service => service.name === name);
+
+    if (!config) {
+        throw new Error(`Service configuration for ${name} not available`);
+    }
+
+    return config;
 }
 
 function readRegistryValue(identity: Identity, message: APIMessage, ack: Acker): void {

--- a/src/browser/api_protocol/api_handlers/system.ts
+++ b/src/browser/api_protocol/api_handlers/system.ts
@@ -120,10 +120,10 @@ const dosURL = 'https://openfin.co/documentation/desktop-owner-settings/';
 
 async function getServiceConfiguration(identity: Identity, message: APIMessage) {
     const { name } = message.payload;
-    const response = await System.getServiceConfiguration(message);
+    const response = await System.getServiceConfiguration();
 
-    if (!response) {
-        throw new Error('Services not configured in desktop owner settings');
+    if (didFail(response)) {
+        throw response;
     }
 
     if (!Array.isArray(response)) {


### PR DESCRIPTION
#### Description of Change
Adds the ability to get the json blob that is associated with a service. As written you can get any configuration you'd like provided you know it's name. We can handle discovery and if these should be private to the service itself in later efforts.

A note about testing: currently it is not feasible to round-trip test a custom version of the runtime and rvm simultaneously. This change requires just that. It also requires setting custom a custom desktop owner settings file compounding the testing difficulties. For now, lets please just use our brains in review as best we can :)

@pjbroadbent  

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] relevant documentation is [changed or added](https://github.com/hadoukenio/js-adapter)
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)

Linked to [this js adapter pr](https://github.com/HadoukenIO/js-adapter/pull/275)

Note: this requires [this](https://github.com/openfin/openfinrvm/commit/57cc300a3989feb6e5324d53b8f13059f68b5328) RVM change to be released
