### PR TITLE
RUN-5223 added the args object to the getRuntimeInfo call

### DIFF
--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -446,7 +446,7 @@ exports.System = {
         const cachePath = electronApp.getPath('userData');
         const args = Object.assign({}, coreState.argo);
         args._ = undefined;
-        return { manifestUrl, port, securityRealm, version, architecture, cachePath, arguments: args };
+        return { manifestUrl, port, securityRealm, version, architecture, cachePath, args };
     },
     getRvmInfo: function(identity, callback, errorCallback) {
         let appObject = coreState.getAppObjByUuid(identity.uuid);

--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -444,7 +444,9 @@ exports.System = {
         const manifestUrl = coreState.getConfigUrlByUuid(identity.uuid);
         const architecture = process.arch;
         const cachePath = electronApp.getPath('userData');
-        return { manifestUrl, port, securityRealm, version, architecture, cachePath };
+        const args = Object.assign({}, coreState.argo);
+        args._ = undefined;
+        return { manifestUrl, port, securityRealm, version, architecture, cachePath, arguments: args };
     },
     getRvmInfo: function(identity, callback, errorCallback) {
         let appObject = coreState.getAppObjByUuid(identity.uuid);


### PR DESCRIPTION
#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] [new test](https://testing-dashboard.openfin.co/#/app/tests/5cc31f49cb360141a7dfe1a1/edit)
- [x] relevant documentation is [changed or added](https://github.com/hadoukenio/js-adapter)
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR release notes describe the change in a way relevant to app-developers


#### Release Notes

System.getRuntimeInfo now includes the command line argument used to start the Runtime in the form of an Object 
