### PR TITLE
RUN-5189 Inject based on webcontents Id

### DIFF
--- a/src/browser/core_state.ts
+++ b/src/browser/core_state.ts
@@ -797,6 +797,10 @@ export function getRoutingInfoByUuidFrame(uuid: string, frame: string) {
 
 export function getWindowInitialOptionSet(windowId: number): Shapes.WindowInitialOptionSet {
     const ofWin = <Shapes.OpenFinWindow>getWinObjById(windowId);
+    return getOptionsFromOpenFinWindow(ofWin);
+}
+
+function getOptionsFromOpenFinWindow(ofWin: Shapes.OpenFinWindow) {
     const options = ofWin._options;
     const { uuid, name } = options;
     const entityInfo = getEntityInfo({ uuid, name });
@@ -805,7 +809,6 @@ export function getWindowInitialOptionSet(windowId: number): Shapes.WindowInitia
     };
     const socketServerState = <PortInfo>getSocketServerState();
     const enableChromiumBuild = isEnableChromiumBuild();
-
     return {
         options,
         entityInfo,

--- a/src/browser/core_state.ts
+++ b/src/browser/core_state.ts
@@ -794,9 +794,17 @@ export function getRoutingInfoByUuidFrame(uuid: string, frame: string) {
         }
     }
 }
+function getWinObjByWebcontentsId(webContentsId: number) {
+    const win = getWinList().find(w => w.openfinWindow && w.openfinWindow.browserWindow.webContents.id === webContentsId);
+    return win.openfinWindow;
+}
 
 export function getWindowInitialOptionSet(windowId: number): Shapes.WindowInitialOptionSet {
     const ofWin = <Shapes.OpenFinWindow>getWinObjById(windowId);
+    return getOptionsFromOpenFinWindow(ofWin);
+}
+export function getWebContentsInitialOptionSet(webContentsId: number) {
+    const ofWin = getWinObjByWebcontentsId(webContentsId);
     return getOptionsFromOpenFinWindow(ofWin);
 }
 

--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -33,8 +33,8 @@ const jsAdapterV2 = readAdapterFromSearchPaths(searchPathsV2Api, 'js-adapter.js'
 let me = fs.readFileSync(path.join(__dirname, 'api-decorator.js'), 'utf8');
 me = me.slice(13);
 
-const api = (windowId, initialOptions) => {
-    const windowOptionSet = initialOptions || coreState.getWindowInitialOptionSet(windowId);
+const api = (webContentsId, initialOptions) => {
+    const windowOptionSet = initialOptions || coreState.getWebContentsInitialOptionSet(webContentsId);
     const mainWindowOptions = windowOptionSet.options || {};
     const enableV2Api = (mainWindowOptions.experimental || {}).v2Api;
     const v2AdapterShim = (!enableV2Api ? '' : jsAdapterV2);
@@ -53,12 +53,12 @@ const api = (windowId, initialOptions) => {
 
 module.exports.api = api;
 
-module.exports.apiWithOptions = (windowId) => {
-    const initialOptions = coreState.getWindowInitialOptionSet(windowId);
+module.exports.apiWithOptions = (webContentsId) => {
+    const initialOptions = coreState.getWebContentsInitialOptionSet(webContentsId);
 
     // break the remote link
     return JSON.stringify({
-        apiString: api(windowId, initialOptions),
+        apiString: api(webContentsId, initialOptions),
         initialOptions: initialOptions
     });
 };

--- a/src/renderer/node-less.js
+++ b/src/renderer/node-less.js
@@ -26,8 +26,8 @@ process.versions.openfin = electron.remote.app.getRuntimeVersion();
 process.versions.mainFrameRoutingId = electron.ipcRenderer.getFrameRoutingID();
 process.versions.cachePath = electron.remote.app.getPath('userData');
 
-const mainWindowId = electron.remote.getCurrentWindow(process.versions.mainFrameRoutingId).id;
-const apiInfo = electron.remote.require('./src/renderer/main').apiWithOptions(mainWindowId);
+const webContentsId = electron.remote.getCurrentWebContents().id;
+const apiInfo = electron.remote.require('./src/renderer/main').apiWithOptions(webContentsId);
 const { apiString, initialOptions } = JSON.parse(apiInfo);
 
 // let chromiumWindowAlertEnabled = electron.remote.app.getCommandLineArguments().includes('--enable-chromium-window-alert');
@@ -143,4 +143,4 @@ const registerAPI = (w, routingId, isMainFrame, isSameOriginIframe, isCrossOrigi
     susbcribeForTeardown(routingId, teardownHandlers);
 };
 
-registerAPI(window, routingId, isMainFrame, isSameOriginIframe, isCrossOriginIframe, isChildMainFrame, initialOptions);
+registerAPI(window, routingId, isMainFrame, isSameOriginIframe, isCrossOriginIframe, isChildMainFrame);


### PR DESCRIPTION
#### Description of Change
Changes api injection to rely on webcontents id rather than browserWindow id

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR release notes describe the change in a way relevant to app-developers


#### Release Notes

Notes: N/a legwork for browserView support