### PR TITLE
RUN-5242 Show a false warning message when there is a valid license key

### DIFF
--- a/src/renderer/main.js
+++ b/src/renderer/main.js
@@ -40,7 +40,7 @@ const api = (windowId, initialOptions) => {
     const v2AdapterShim = (!enableV2Api ? '' : jsAdapterV2);
     const { uuid, name } = mainWindowOptions;
     windowOptionSet.runtimeArguments = JSON.stringify(coreState.args);
-    windowOptionSet.licenseKey = coreState.getManifest({ uuid, name }).licenseKey;
+    windowOptionSet.licenseKey = coreState.getLicenseKey({ uuid, name });
 
     return [
         `global.__startOptions = ${JSON.stringify(windowOptionSet)}`,


### PR DESCRIPTION
This PR is to fix the false warning message when a license key is valid.

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR release notes describe the change in a way relevant to app-developers

