### PR TITLE
RUN-5200: Don't close window till content loaded - 10.66.41/staging

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -440,6 +440,22 @@ Window.create = function(id, opts) {
         ofEvents.emit(route.window('openfin-diagnostic/unload', uuid, name, true), url);
     };
 
+    // Hack: closing a window before content is finish loading in 10.66.40.* causes the renderer to crash.
+    // Hide the window instead, and close from the core when it's safe.
+    let wasCloseRequested = false;
+    const preventClose = (event) => {
+        wasCloseRequested = true;
+        browserWindow.hide();
+    };
+    ofEvents.on(route.window('close-requested', uuid, name), preventClose);
+    ofEvents.once(route.window('initialized', uuid, name), () => {
+        ofEvents.removeListener(route.window('close-requested', uuid, name), preventClose);
+        if (wasCloseRequested) {
+            Window.close({ uuid, name });
+        }
+    });
+    // End hack
+
     let _externalWindowEventAdapter;
 
     // we need to be able to handle the wrapped case, ie. don't try to

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -452,6 +452,9 @@ Window.create = function(id, opts) {
     ofEvents.once(route.window('initialized', uuid, name), () => {
         ofEvents.removeListener(route.window('close-requested', uuid, name), handleEarlyClose);
     });
+    ofEvents.on(route.window('closed', uuid, name), () => {
+        ofEvents.removeListener(route.window('close-requested', uuid, name), handleEarlyClose);
+    });
     // End hack
 
     let _externalWindowEventAdapter;


### PR DESCRIPTION
#### Description of Change
Duplicate of https://github.com/HadoukenIO/core/pull/781, but targeting 10.66.41/staging.

Jira ticket: https://appoji.jira.com/browse/RUN-5200

When user closes a window before it's safe, hide the window, but wait for the DOM `load` event is fired to actually close the window.

SIGNIFICANT CAVEAT: This works for most sites I tested, but NOT for cnn.com. I suspect iframe shenanigans, or possibly something caused by their very slow js event handlers. Further investigation needed

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [ ] manual tests are [changed or added](https://github.com/openfin/test_apps)
- [ ] relevant documentation is [changed or added](https://github.com/hadoukenio/js-adapter)
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [ ] PR release notes describe the change in a way relevant to app-developers


#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes. Examples and help on special cases: http://developer.openfin.co/versions/?product=Runtime&version=9.61.37.46 -->
