### PR TITLE
RUN-5288 Force lower case for username on getDeviceUserId

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4330,6 +4330,7 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.7.1.tgz",
       "integrity": "sha512-OV8Bq1OrPh6z+Y4dqwo05HqrRL9YNF7QVMRfq1/pguwKLG+q9UB/Lk0x5qXjO23JjJg+/jqCHSTaG1P3tfKfuw==",
+      "dev": true,
       "requires": {
         "semver": "^5.4.1"
       }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4330,7 +4330,6 @@
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.7.1.tgz",
       "integrity": "sha512-OV8Bq1OrPh6z+Y4dqwo05HqrRL9YNF7QVMRfq1/pguwKLG+q9UB/Lk0x5qXjO23JjJg+/jqCHSTaG1P3tfKfuw==",
-      "dev": true,
       "requires": {
         "semver": "^5.4.1"
       }

--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -246,7 +246,7 @@ exports.System = {
         }
 
         hash.update(hostToken);
-        hash.update(username);
+        hash.update(username.toLowerCase());
 
         return hash.digest('hex');
     },


### PR DESCRIPTION
#### Description of Change

If the machine's username changes case on reboot, getDeviceUserId will return a different value each time. We should change it so we always lower case this value to handle this situation.

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Pull Request process: https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ X] PR description included and stakeholders cc'd
- [ X] `npm test` passes
- [ ] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [ ] manual tests are [changed or added](https://github.com/openfin/test_apps)
- [ ] relevant documentation is [changed or added](https://github.com/hadoukenio/js-adapter)
- [ X] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [ ] PR release notes describe the change in a way relevant to app-developers


#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes. Examples and help on special cases: http://developer.openfin.co/versions/?product=Runtime&version=9.61.37.46 -->

Fixed issue where getDeviceUserId returned a different value if the machine's username switched between upper and lower case.