### PR TITLE
RUN-5200: Hide window on close-requested

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -444,6 +444,7 @@ Window.create = function(id, opts) {
     // Hack: Closing a window before content is finished loading can cause the renderer to crash.
     // TODO: Remove if/when we get a Chromium fix in place.
     const handleEarlyClose = () => {
+        browserWindow.hide();
         // Active iframes can cause crash. Flush DOM before close.
         browserWindow.webContents.executeJavaScript('document.removeChild(document.documentElement);').then(() => {
             Window.close({ uuid, name }, true);
@@ -902,7 +903,7 @@ Window.create = function(id, opts) {
         const subscription = Rx.Observable.zip(apiInjectionObserver, windowPositioningObserver).subscribe((event) => {
             const constructorCallbackMessage = event[0];
             if (_options.autoShow || _options.toShowOnRun) {
-                if (!browserWindow.isVisible()) {
+                if (!browserWindow.isVisible() && _options.waitForPageLoad) {
                     Window.show(identity);
                 }
             }


### PR DESCRIPTION
#### Description of Change
https://appoji.jira.com/browse/RUN-5263
Hide window when user attempts to close before initial load is finished. Prevent it from flashing when it finishes loading.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- x ] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [ ] manual tests are [changed or added](https://github.com/openfin/test_apps)
- [ ] relevant documentation is [changed or added](https://github.com/hadoukenio/js-adapter)
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [ ] PR release notes describe the change in a way relevant to app-developers


#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes. Examples and help on special cases: http://developer.openfin.co/versions/?product=Runtime&version=9.61.37.46 -->
