### PR TITLE
RUN-5201: NWI: add docs tutorials for new API / events (partial) 

### DIFF
--- a/src/browser/api/external_window.ts
+++ b/src/browser/api/external_window.ts
@@ -381,11 +381,11 @@ function subscribeToWinEventHooks(externalWindow: Shapes.ExternalWindow): void {
     }
 
     const {
-      frame, height, left, top, width, windowState, x, y
+      height, left, top, width, windowState
     } = getEventData(nativeWindowInfo);
 
     externalWindow.emit('begin-user-bounds-changing', {
-      frame, height, left, top, width, windowState, x, y
+      height, left, top, width, windowState
     });
   }));
 
@@ -395,11 +395,11 @@ function subscribeToWinEventHooks(externalWindow: Shapes.ExternalWindow): void {
     }
 
     const {
-      changeType, deferred, frame, height, left, reason, top, width, windowState, x, y
+      changeType, deferred, height, left, reason, top, width, windowState
     } = getEventData(nativeWindowInfo);
 
     externalWindow.emit('end-user-bounds-changing', {
-      frame, height, left, top, width, windowState, x, y
+      height, left, top, width, windowState
     });
 
     externalWindow.emit('bounds-changed', {
@@ -602,7 +602,7 @@ function externalWindowCloseCleanup(externalWindow: Shapes.ExternalWindow): void
 */
 function subscribeToWindowGroupEvents(externalWindow: Shapes.ExternalWindow): void {
   const key = getKey(externalWindow);
-  const { nativeId } = externalWindow;
+  const { nativeId, name } = externalWindow;
   const listener = (event: GroupChangedEvent) => {
     if (event.groupUuid !== externalWindow.groupUuid) {
       return;
@@ -611,7 +611,7 @@ function subscribeToWindowGroupEvents(externalWindow: Shapes.ExternalWindow): vo
     const payload: GroupEvent = {
       ...event.payload,
       memberOf: '',
-      name: nativeId,
+      name,
       uuid: nativeId
     };
     const { reason, sourceGroup, sourceWindowName } = payload;


### PR DESCRIPTION
#### Description of Change
* Making sure external window's events conform with window's events payload.

note: there are still some mismatches, they're commented in the code.

[JIRA](https://appoji.jira.com/browse/RUN-5201)
Related to [js-adapter pr](https://github.com/HadoukenIO/js-adapter/pull/289)
#### Checklist

- [x] PR description included and stakeholders cc'd
- [ ] `npm test` passes (need to figure out why failing Win10 tests)
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)