### PR TITLE
RUN-5265 cleaned up external window info object

### DIFF
--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -28,7 +28,7 @@ import { downloadScripts, loadScripts } from '../preload_scripts';
 import { fetchReadFile } from '../cached_resource_fetcher';
 import { createChromiumSocket, authenticateChromiumSocket } from '../transports/chromium_socket';
 import { authenticateFetch, clearCacheInvoked } from '../cached_resource_fetcher';
-import { extendNativeWindowInfo } from '../utils';
+import { getNativeWindowInfoLite } from '../utils';
 import { isValidExternalWindow } from './external_window';
 
 const defaultProc = {
@@ -706,8 +706,8 @@ export const System = {
         const externalWindows = [];
 
         allNativeWindows.forEach(e => {
-            const externalWindow = extendNativeWindowInfo(e);
-            const isValid = isValidExternalWindow(externalWindow);
+            const externalWindow = getNativeWindowInfoLite(e);
+            const isValid = isValidExternalWindow(e);
 
             if (isValid) {
                 externalWindows.push(externalWindow);

--- a/src/browser/utils.ts
+++ b/src/browser/utils.ts
@@ -74,9 +74,9 @@ function clamp(num: number, min: number = 0, max: number = Number.MAX_SAFE_INTEG
 }
 
 /*
-  Extends raw native window info.
+  Returns lite version of external window info object
 */
-export function extendNativeWindowInfo(rawNativeWindowInfo: NativeWindowInfo): Shapes.NativeWindowInfo {
+export function getNativeWindowInfoLite(rawNativeWindowInfo: NativeWindowInfo): Shapes.NativeWindowInfoLite {
   let name = capitalize(basename(rawNativeWindowInfo.process.imageName, '.exe'));
 
   if (name === 'ApplicationFrameHost') {
@@ -84,10 +84,34 @@ export function extendNativeWindowInfo(rawNativeWindowInfo: NativeWindowInfo): S
   }
 
   return {
-    ...rawNativeWindowInfo,
     name,
-    uuid: rawNativeWindowInfo.id
+    process: {
+      injected: rawNativeWindowInfo.process.injected,
+      pid: rawNativeWindowInfo.process.pid
+    },
+    title: rawNativeWindowInfo.title,
+    uuid: rawNativeWindowInfo.id,
+    visible: rawNativeWindowInfo.visible
   };
+}
+
+/*
+  Returns full version of external window info object
+*/
+export function getNativeWindowInfo(rawNativeWindowInfo: NativeWindowInfo): Shapes.NativeWindowInfo {
+  const liteInfoObject = getNativeWindowInfoLite(rawNativeWindowInfo);
+  const fullInfoObject = <Shapes.NativeWindowInfo>liteInfoObject;
+
+  fullInfoObject.alwaysOnTop = rawNativeWindowInfo.alwaysOnTop;
+  fullInfoObject.bounds = rawNativeWindowInfo.bounds;
+  fullInfoObject.className = rawNativeWindowInfo.className;
+  fullInfoObject.dpi = rawNativeWindowInfo.dpi;
+  fullInfoObject.dpiAwareness = rawNativeWindowInfo.dpiAwareness;
+  fullInfoObject.focused = rawNativeWindowInfo.focused;
+  fullInfoObject.maximized = rawNativeWindowInfo.maximized;
+  fullInfoObject.minimized = rawNativeWindowInfo.minimized;
+
+  return fullInfoObject;
 }
 
 /*

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -1,6 +1,10 @@
 
 import { PortInfo } from './browser/port_discovery';
-import { BrowserWindow as BrowserWindowElectron, NativeWindowInfo as NativeWindowInfoElectron } from 'electron';
+import {
+    BrowserWindow as BrowserWindowElectron,
+    NativeWindowInfo as NativeWindowInfoElectron,
+    Process as ProcessElectron
+} from 'electron';
 import { ERROR_BOX_TYPES } from './common/errors';
 import { AnchorType } from '../js-adapter/src/shapes';
 
@@ -427,12 +431,6 @@ export interface CoordinatesXY {
     y: number;
 }
 
-export interface ProcessInfo {
-    imageName: string;
-    injected: boolean;
-    pid: number;
-}
-
 // This mock is for window grouping accepting external windows
 interface BrowserWindowMock extends BrowserWindowElectron {
     _options: WindowOptions;
@@ -451,10 +449,18 @@ export interface ExternalWindow extends BrowserWindowElectron {
     uuid: string;
 }
 
-export interface NativeWindowInfo extends NativeWindowInfoElectron {
+export interface Process extends Omit<ProcessElectron, 'imageName'> {
+    injected: boolean;
+    pid: number;
+}
+
+export interface NativeWindowInfo extends Omit<NativeWindowInfoElectron, 'process'> {
+    process: Process;
     name: string;
     uuid: string;
 }
+
+export type NativeWindowInfoLite = Pick<NativeWindowInfo, 'name'|'process'|'title'|'uuid'|'visible'>;
 
 export type GroupWindow = (ExternalWindow | OpenFinWindow) & {
     isExternalWindow?: boolean;


### PR DESCRIPTION
### Description of Change
This PR changes **some** of external window info objects returned to the client.
The changes affect the following API/events (these were unnecessarily getting full info object / extra info).
 Other APIs / events return only needed info, similar in shape to regular OpenFin windows.
- `fin.System.getAllExternalWindows`
- `"external-window-closed"`
- `"external-window-created"`
- `"external-window-hidden"`
- `"external-window-shown"`

Info object **before**:
```
alwaysOnTop: false,
  bounds: {
    height: 265,
    width: 319,
    x: 150,
    y: 350,
  },
  className: 'Notepad',
  dpi: 96,
  dpiAwareness: -1,
  focused: false,
  id: '0x00040658',
  maximized: false,
  minimized: false,
  name: 'Notepad',
  process: {
    imageName: 'C:\Windows\System32\notepad.exe',
    injected: false,
    pid: 5924,
  },
  title: 'Untitled - Notepad',
  uuid: '0x00040658',
  visible: true,
```

Info object **now**:
```
{
  name: 'Notepad',
  process: {
    injected: false,
    pid: 5924,
  },
  title: 'Untitled - Notepad',
  uuid: '0x00040658',
  visible: true,
}
```

**Note:** `externalWindow.getInfo()` still returns full info, except `process.imageName`.

### Checklist
- [x] PR description included and stakeholders cc'd
- [x] PR title starts with the JIRA ticket
- [x] PR release notes describe the change in a way relevant to app-developers