### PR TITLE
RUN-5238 added missing info to "disabled-movement-bounds-changed"

### DIFF
--- a/src/browser/api/external_window.ts
+++ b/src/browser/api/external_window.ts
@@ -521,7 +521,8 @@ async function subscribeToInjectionEvents(externalWindow: Shapes.ExternalWindow)
   });
 
   injectionBus.on('WM_EXITSIZEMOVE', (data: any) => {
-    const { changeType, deferred, userMovement, height, left, top, width } = parseEvent(data);
+    const { changeType, deferred, userMovement } = parseEvent(data);
+    const { height, left, top, width } = getExternalWindowBounds(externalWindow);
     const routeName = route.externalWindow(OF_EVENT_FROM_WINDOWS_MESSAGE.WM_EXITSIZEMOVE, uuid, name);
     if (!userMovement) {
       ofEvents.emit(routeName);


### PR DESCRIPTION
#### Description of Change
This PR adds missing payload properties for external window's "disabled-movement-bounds-changed" event.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] PR title starts with the JIRA ticket
- [x] PR release notes describe the change in a way relevant to app-developers

#### Release Notes
N/A
