### PR TITLE
RUN-5270: Append meshUuis to injection bus msgs

### DIFF
--- a/src/browser/transports/injection_bus.ts
+++ b/src/browser/transports/injection_bus.ts
@@ -1,10 +1,10 @@
 import { adjustCoordsScaling } from '../../common/main';
 import { app as electronApp } from 'electron';
 import { EventEmitter } from 'events';
+import { getMeshUuid } from '../connection_manager';
 import { WINDOWS_MESSAGE_MAP } from '../../common/windows_messages';
 import { writeToLog } from '../log';
 import WMCopyData from './wm_copydata';
-import { getMeshUuid } from '../connection_manager';
 
 const copyDataTransport = new WMCopyData('OpenFin-NativeWindowManager-Client', '');
 
@@ -59,21 +59,21 @@ interface PendingRequest {
 }
 
 export default class NativeWindowInjectionBus extends EventEmitter {
+  private _meshUuid: string; // ID of core instance
   private _messageListener: (sender: number, rawMessage: string) => void;
   private _nativeId: string; // HWND of the external window
   private _pendingRequests: Map<string, PendingRequest>;
   private _pid: number; // process ID of the external window
   private _senderId: string; // ID of the injected DLL
-  private _meshUuid: string; // ID of core instance
 
   constructor(params: ConstructorParams) {
     super();
 
     const { nativeId, pid } = params;
+    this._meshUuid = getMeshUuid();
     this._nativeId = nativeId;
     this._pendingRequests = new Map();
     this._pid = pid;
-    this._meshUuid = getMeshUuid();
 
     // Subscribe to all events
     this.send({

--- a/src/browser/transports/injection_bus.ts
+++ b/src/browser/transports/injection_bus.ts
@@ -4,6 +4,7 @@ import { EventEmitter } from 'events';
 import { WINDOWS_MESSAGE_MAP } from '../../common/windows_messages';
 import { writeToLog } from '../log';
 import WMCopyData from './wm_copydata';
+import { getMeshUuid } from '../connection_manager';
 
 const copyDataTransport = new WMCopyData('OpenFin-NativeWindowManager-Client', '');
 
@@ -63,6 +64,7 @@ export default class NativeWindowInjectionBus extends EventEmitter {
   private _pendingRequests: Map<string, PendingRequest>;
   private _pid: number; // process ID of the external window
   private _senderId: string; // ID of the injected DLL
+  private _meshUuid: string; // ID of core instance
 
   constructor(params: ConstructorParams) {
     super();
@@ -71,6 +73,7 @@ export default class NativeWindowInjectionBus extends EventEmitter {
     this._nativeId = nativeId;
     this._pendingRequests = new Map();
     this._pid = pid;
+    this._meshUuid = getMeshUuid();
 
     // Subscribe to all events
     this.send({
@@ -135,7 +138,7 @@ export default class NativeWindowInjectionBus extends EventEmitter {
           action,
           messageId,
           payload,
-          senderId: '0x0000',
+          senderId: this._meshUuid,
           sequence: 0,
           time: 0
         },


### PR DESCRIPTION
#### Description of Change
Jira ticket: https://appoji.jira.com/browse/RUN-5270

Include the core instance's mesh uuid as `senderID` on send calls, instead of using a hard-coded value.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
