### PR TITLE
[RUN-5033] Windowing API calls nack if size constraints would be violated

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -1609,6 +1609,8 @@ function areNewBoundsWithinConstraints(options, width, height) {
 
     const acceptableWidth = (width >= minWidth) && (maxWidth === -1 || width <= maxWidth);
     const acceptableHeight = (height >= minHeight) && (maxHeight === -1 || height <= maxHeight);
+
+    // Check what the new aspect ratio would be at the proposed width/height. Precise to two decimal places.
     const roundedProposedRatio = Math.round(100 * (width / height)) / 100;
     const roundedAspectRatio = Math.round(100 * aspectRatio) / 100;
 

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -1595,15 +1595,15 @@ function areNewBoundsWithinConstraints(options, width, height) {
         aspectRatio
     } = options;
 
-    if (width === undefined && height === undefined) {
+    if (typeof width !== 'number' && typeof height !== 'number') {
         return true;
     }
 
-    if (height === undefined) {
+    if (typeof height !== 'number') {
         return (width >= minWidth) && (maxWidth === -1 || width <= maxWidth);
     }
 
-    if (width === undefined) {
+    if (typeof width !== 'number') {
         return (height >= minHeight) && (maxHeight === -1 || height <= maxHeight);
     }
 

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -1078,7 +1078,6 @@ Window.animate = function(identity, transitions, options = {}, callback = () => 
 
     if (!size) {
         animations.getAnimationHandler().add(browserWindow, animationMeta, animationTween, callback, errorCallback);
-        callback();
         return;
     }
 
@@ -1101,7 +1100,6 @@ Window.animate = function(identity, transitions, options = {}, callback = () => 
 
     if (newBoundsWithinConstraints) {
         animations.getAnimationHandler().add(browserWindow, animationMeta, animationTween, callback, errorCallback);
-        callback();
     } else {
         errorCallback(new Error(`Proposed window bounds violate size constraints for uuid: ${identity.uuid} name: ${identity.name}`));
     }
@@ -1597,8 +1595,20 @@ function areNewBoundsWithinConstraints(options, width, height) {
         aspectRatio
     } = options;
 
-    const acceptableWidth = width >= minWidth && width <= maxWidth;
-    const acceptableHeight = height >= minHeight && height <= maxHeight;
+    if (width === undefined && height === undefined) {
+        return true;
+    }
+
+    if (height === undefined) {
+        return (width >= minWidth) && (maxWidth === -1 || width <= maxWidth);
+    }
+
+    if (width === undefined) {
+        return (height >= minHeight) && (maxHeight === -1 || height <= maxHeight);
+    }
+
+    const acceptableWidth = (width >= minWidth) && (maxWidth === -1 || width <= maxWidth);
+    const acceptableHeight = (height >= minHeight) && (maxHeight === -1 || height <= maxHeight);
     const roundedProposedRatio = Math.round(100 * (width / height)) / 100;
     const roundedAspectRatio = Math.round(100 * aspectRatio) / 100;
 

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -1067,6 +1067,11 @@ Window.animate = function(identity, transitions, options = {}, callback = () => 
         return;
     }
 
+    if (!('_options' in browserWindow)) {
+        errorCallback(new Error(`No window options present for uuid: ${identity.uuid} name: ${identity.name}`));
+        return;
+    }
+
     let animationMeta = transitions || {};
     let animationTween = (options && options.tween) || 'ease-in-out';
     animationMeta.interrupt = (options || {}).interrupt;
@@ -1074,7 +1079,14 @@ Window.animate = function(identity, transitions, options = {}, callback = () => 
         animationMeta.interrupt = true;
     }
 
-    animations.getAnimationHandler().add(browserWindow, animationMeta, animationTween, callback, errorCallback);
+    const newBoundsAcceptable = areNewBoundsWithinConstraints(browserWindow._options, transitions.size.width, transitions.size.width);
+
+    if (newBoundsAcceptable) {
+        animations.getAnimationHandler().add(browserWindow, animationMeta, animationTween, callback, errorCallback);
+        callback();
+    } else {
+        errorCallback(new Error(`Proposed window bounds violate size constraints for uuid: ${identity.uuid} name: ${identity.name}`));
+    }
 };
 
 Window.blur = function(identity) {
@@ -1594,7 +1606,7 @@ Window.resizeBy = function(identity, deltaWidth, deltaHeight, anchor, callback, 
 
     if (newBoundsAcceptable) {
         NativeWindow.resizeBy(browserWindow, opts);
-        callback({ success: true });
+        callback();
     } else {
         errorCallback(new Error(`Proposed window bounds violate size constraints for uuid: ${identity.uuid} name: ${identity.name}`));
     }
@@ -1617,7 +1629,7 @@ Window.resizeTo = function(identity, width, height, anchor, callback, errorCallb
 
     if (newBoundsAcceptable) {
         NativeWindow.resizeTo(browserWindow, opts);
-        callback({ success: true });
+        callback();
     } else {
         errorCallback(new Error(`Proposed window bounds violate size constraints for uuid: ${identity.uuid} name: ${identity.name}`));
     }
@@ -1655,7 +1667,7 @@ Window.setBounds = function(identity, left, top, width, height, callback, errorC
 
     if (newBoundsAcceptable) {
         NativeWindow.setBounds(browserWindow, opts);
-        callback({ success: true });
+        callback();
     } else {
         errorCallback(new Error(`Proposed window bounds violate size constraints for uuid: ${identity.uuid} name: ${identity.name}`));
     }

--- a/src/browser/api_protocol/api_handlers/window.ts
+++ b/src/browser/api_protocol/api_handlers/window.ts
@@ -129,7 +129,7 @@ function setWindowBounds(identity: Identity, message: APIMessage, ack: Acker, na
     const { payload } = message;
     const { top, left, width, height } = payload;
     const {uuid, name} = getTargetWindowIdentity(payload);
-    Window.setBounds({uuid, name}, left, top, width, height, ack, nack);
+    Window.setBounds({ uuid, name }, left, top, width, height, () => ack(successAck), nack);
 }
 
 function setWindowPreloadState(identity: Identity, message: APIMessage, ack: Acker): void {
@@ -188,7 +188,7 @@ function resizeWindow(identity: Identity, message: APIMessage, ack: Acker, nack:
     const { width, height, anchor } = payload;
     const windowIdentity = getTargetWindowIdentity(payload);
 
-    Window.resizeTo(windowIdentity, width, height, anchor, ack, nack);
+    Window.resizeTo(windowIdentity, width, height, anchor, () => ack(successAck), nack);
 }
 
 function resizeWindowBy(identity: Identity, message: APIMessage, ack: Acker, nack: Nacker): void {
@@ -196,7 +196,7 @@ function resizeWindowBy(identity: Identity, message: APIMessage, ack: Acker, nac
     const { deltaHeight, deltaWidth, anchor } = payload;
     const windowIdentity = getTargetWindowIdentity(payload);
 
-    Window.resizeBy(windowIdentity, deltaWidth, deltaHeight, anchor, ack, nack);
+    Window.resizeBy(windowIdentity, deltaWidth, deltaHeight, anchor, () => ack(successAck), nack);
 }
 
 function undockWindow(identity: Identity, message: APIMessage, ack: Acker): void {
@@ -501,14 +501,12 @@ function blurWindow(identity: Identity, message: APIMessage, ack: Acker): void {
     ack(successAck);
 }
 
-function animateWindow(identity: Identity, message: APIMessage, ack: Acker): void {
+function animateWindow(identity: Identity, message: APIMessage, ack: Acker, nack: Nacker): void {
     const { payload } = message;
     const { options, transitions } = payload;
     const windowIdentity = getTargetWindowIdentity(payload);
 
-    Window.animate(windowIdentity, transitions, options, () => {
-        ack(successAck);
-    });
+    Window.animate(windowIdentity, transitions, options, () => ack(successAck), nack);
 }
 
 function dockWindow(identity: Identity, message: APIMessage, ack: Acker): void {

--- a/src/browser/api_protocol/api_handlers/window.ts
+++ b/src/browser/api_protocol/api_handlers/window.ts
@@ -125,12 +125,11 @@ function stopFlashWindow(identity: Identity, message: APIMessage, ack: Acker): v
     ack(successAck);
 }
 
-function setWindowBounds(identity: Identity, message: APIMessage, ack: Acker): void {
+function setWindowBounds(identity: Identity, message: APIMessage, ack: Acker, nack: Nacker): void {
     const { payload } = message;
     const { top, left, width, height } = payload;
     const {uuid, name} = getTargetWindowIdentity(payload);
-    Window.setBounds({uuid, name}, left, top, width, height);
-    ack(successAck);
+    Window.setBounds({uuid, name}, left, top, width, height, ack, nack);
 }
 
 function setWindowPreloadState(identity: Identity, message: APIMessage, ack: Acker): void {
@@ -184,22 +183,20 @@ function restoreWindow(identity: Identity, message: APIMessage, ack: Acker): voi
     ack(successAck);
 }
 
-function resizeWindow(identity: Identity, message: APIMessage, ack: Acker): void {
+function resizeWindow(identity: Identity, message: APIMessage, ack: Acker, nack: Nacker): void {
     const { payload } = message;
     const { width, height, anchor } = payload;
     const windowIdentity = getTargetWindowIdentity(payload);
 
-    Window.resizeTo(windowIdentity, width, height, anchor);
-    ack(successAck);
+    Window.resizeTo(windowIdentity, width, height, anchor, ack, nack);
 }
 
-function resizeWindowBy(identity: Identity, message: APIMessage, ack: Acker): void {
+function resizeWindowBy(identity: Identity, message: APIMessage, ack: Acker, nack: Nacker): void {
     const { payload } = message;
     const { deltaHeight, deltaWidth, anchor } = payload;
     const windowIdentity = getTargetWindowIdentity(payload);
 
-    Window.resizeBy(windowIdentity, deltaWidth, deltaHeight, anchor);
-    ack(successAck);
+    Window.resizeBy(windowIdentity, deltaWidth, deltaHeight, anchor, ack, nack);
 }
 
 function undockWindow(identity: Identity, message: APIMessage, ack: Acker): void {


### PR DESCRIPTION
#### Description of Change
This PR modifies Windowing APIs that resize windows. If a Windowing API call attempts to resize a window outside of its `maxHeight`/`maxWidth`/`minHeight`/`minWidth` constraints, the function will nack. 

Affected functions:
`Window.animate`
`Window.resizeBy`
`Window.resizeTo`
`Window.setBounds`

**This PR will change the behavior of these API calls. Previously, the windows would resize up to their constraints, and the functions would ack. Now, we prevent all resizing, and nack instead**

The following tests will need to have a Max Version set @whyn07m3 :
https://testing-dashboard.openfin.co/#/app/tests/55897c432517bd926e4a257b/edit
https://testing-dashboard.openfin.co/#/app/tests/55897c432517bd926e4a257c/edit

The following tests will need to have a Min Version set (once this PR is merged and we've got a build number):
https://testing-dashboard.openfin.co/#/app/tests/5cf15765cb360141a7dfe572/edit
https://testing-dashboard.openfin.co/#/app/tests/5cf1515ecb360141a7dfe571/edit
https://testing-dashboard.openfin.co/#/app/tests/5ce46a6bcb360141a7dfe43a/edit
https://testing-dashboard.openfin.co/#/app/tests/5ce44742cb360141a7dfe42d/edit
https://testing-dashboard.openfin.co/#/app/tests/5ce441cecb360141a7dfe427/edit
https://testing-dashboard.openfin.co/#/app/tests/5ce44129cb360141a7dfe426/edit
https://testing-dashboard.openfin.co/#/app/tests/5ce31e0fcb360141a7dfe411/edit


<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Pull Request process: https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included and stakeholders cc'd
- [X] `npm test` passes
- [X] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [?] manual tests are [changed or added](https://github.com/openfin/test_apps)
- [?] relevant documentation is [changed or added](https://github.com/hadoukenio/js-adapter)
- [X] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [ ] PR release notes describe the change in a way relevant to app-developers


#### Release Notes
Windowing APIs that affect window size will now nack if that resize action would violate the window's size constraints.

Notes: <!-- Please add a one-line description for app developers to read in the release notes. Examples and help on special cases: http://developer.openfin.co/versions/?product=Runtime&version=9.61.37.46 -->
