### PR TITLE
RUN-5060: window.navigate should ack nack same as new fin...Window

### DIFF
--- a/src/browser/api/webcontents.ts
+++ b/src/browser/api/webcontents.ts
@@ -29,18 +29,12 @@ export function navigate (webContents: Electron.WebContents, url: string) {
 }
 
 export async function navigateBack (webContents: Electron.WebContents) {
-    if (!webContents.canGoBack()) {
-        throw new Error('Cannot navigate back');
-    }
     const navigationEnd = createNavigationEndPromise(webContents);
     webContents.goBack();
     return navigationEnd;
 }
 
 export async function navigateForward (webContents: Electron.WebContents) {
-    if (!webContents.canGoForward()) {
-        throw new Error('Cannot navigate forward');
-    }
     const navigationEnd = createNavigationEndPromise(webContents);
     webContents.goForward();
     return navigationEnd;


### PR DESCRIPTION
#### Description of Change
removing canGoBack\canGoForward checks from navigateBack and navigateForward due to non-consistent behavior

_note_: idk why canGoBack\Forward doesn't work, will investigate in the future... this is more of a hotfix to make sure navigate behaves as expected.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)