### PR TITLE
Fix readIntLE() call

### DIFF
--- a/src/browser/session.ts
+++ b/src/browser/session.ts
@@ -53,7 +53,7 @@ class Session extends EventEmitter {
             bw.hookWindowMessage(WM_WTSSESSION_CHANGE, (wParam: any) => {
                 let reason: string;
 
-                switch (wParam.readIntLE()) {
+                switch (wParam.readIntLE(0,1)) {
                     case 3:
                         reason = 'remote-connect';
                         break;


### PR DESCRIPTION
Evidently an offset of 0 and byteLength of 1 were defaults if not given,
but in this new version of Node 12.0.0, it's now an error.

Not an error in Node 10.11.0:
https://github.com/electron/node/blob/f0153d018bc33a05764427f4804d6a0b693ececb/lib/internal/buffer.js#L235

An error in Node 12.0.0:
https://github.com/electron/node/blob/842a35fbac5c29e8bb095fe3716375232ee0d0ce/lib/internal/buffer.js#L235