### PR TITLE
RUN-5350: Free app uuids on disconnect, not runtime

### DIFF
--- a/src/browser/api_protocol/api_handlers/authorization.js
+++ b/src/browser/api_protocol/api_handlers/authorization.js
@@ -203,7 +203,9 @@ export const init = function() {
         externalConnection = ExternalApplication.getExternalConnectionById(id);
         if (externalConnection) {
             ExternalApplication.removeExternalConnection(externalConnection);
-            releaseUuid(externalConnection.uuid);
+            if (!externalConnection.runtimeClient) {
+                releaseUuid(externalConnection.uuid);
+            }
             ofEvents.emit(route('externalconn', 'closed'), externalConnection);
         }
 


### PR DESCRIPTION
#### Description of Change
Jira ticket: https://appoji.jira.com/browse/RUN-5350

@wenjunche was seeing some runtime issues when runtime uuids were prematurely released. This change should fix.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
