### PR TITLE
RUN-5358 Use webcontents id in ELIPC Strategy

### DIFF
--- a/src/browser/api_protocol/api_handlers/api_protocol_base.ts
+++ b/src/browser/api_protocol/api_handlers/api_protocol_base.ts
@@ -1,7 +1,7 @@
 import { ExternalApplication } from '../../api/external_application';
 import SubscriptionManager from '../../subscription_manager';
 const WebSocketStrategy = require('../transport_strategy/ws_strategy').WebSocketStrategy;
-const ElipcStrategy = require('../transport_strategy/elipc_strategy').ElipcStrategy;
+import { ElipcStrategy } from '../transport_strategy/elipc_strategy';
 
 import { default as RequestHandler } from '../transport_strategy/base_handler';
 import { MessagePackage } from '../transport_strategy/api_transport_base';

--- a/src/browser/api_protocol/transport_strategy/api_transport_base.ts
+++ b/src/browser/api_protocol/transport_strategy/api_transport_base.ts
@@ -42,7 +42,7 @@ export abstract class ApiTransportBase<T> {
 
     public abstract onClientDisconnect(cb: Function): void;
 
-    protected abstract onMessage(id: number, data: any, ackDelegate: any): void;
+    protected abstract onMessage(id: any, data: any, ackDelegate: any): void;
 
     protected abstract ackDecorator(id: number, messageId: number, originalPayload: any, configuration: MessageConfiguration): AckFunc;
 

--- a/src/browser/api_protocol/transport_strategy/elipc_strategy.ts
+++ b/src/browser/api_protocol/transport_strategy/elipc_strategy.ts
@@ -7,7 +7,7 @@ declare var require: any;
 
 import * as coreState from '../../core_state';
 import {ipc, channels} from '../../transports/electron_ipc';
-import { getWebContentsInitialOptionSet } from '../../core_state';
+import { getWebContentsInitialOptionSet, RoutingInfo } from '../../core_state';
 import { WebContents } from 'electron';
 const system = require('../../api/system').System;
 
@@ -111,12 +111,11 @@ export class ElipcStrategy extends ApiTransportBase<MessagePackage> {
 
     // Dispatch a message
     private innerSend(payload: string,
-                      frameRoutingId: number,
-                      mainFrameRoutingId: number,
-                      webContents: WebContents): void {
+                      routingInfo: RoutingInfo): void {
+        const { webContents, frameRoutingId, mainFrameRoutingId, _options} = routingInfo;
         if (frameRoutingId === mainFrameRoutingId) {
             // this is the main window frame
-            if (coreState.argo.framestrategy === 'frames') {
+            if (_options.api.iframe.enableDeprecatedSharedName) {
                 webContents.sendToFrame(frameRoutingId, channels.CORE_MESSAGE, payload);
             } else {
                 webContents.send(channels.CORE_MESSAGE, payload);
@@ -146,7 +145,7 @@ export class ElipcStrategy extends ApiTransportBase<MessagePackage> {
         if (!this.canTrySend(routingInfo)) {
             system.debugLog(1, `uuid:${uuid} name:${name} frameRoutingId:${frameRoutingId} not reachable, payload:${payload}`);
         } else {
-            this.innerSend(payload, frameRoutingId, mainFrameRoutingId, webContents);
+            this.innerSend(payload, routingInfo);
         }
     }
 

--- a/src/browser/api_protocol/transport_strategy/elipc_strategy.ts
+++ b/src/browser/api_protocol/transport_strategy/elipc_strategy.ts
@@ -2,11 +2,13 @@ import { AckMessage, AckFunc, AckPayload, NackPayload } from './ack';
 import { ApiTransportBase, MessagePackage, MessageConfiguration } from './api_transport_base';
 import { default as RequestHandler } from './base_handler';
 import { Endpoint, ActionMap } from '../shapes';
-import { Identity } from '../../../shapes';
+import { Identity, AppObj } from '../../../shapes';
 declare var require: any;
 
-const coreState = require('../../core_state');
-const electronIpc = require('../../transports/electron_ipc');
+import * as coreState from '../../core_state';
+import {ipc, channels} from '../../transports/electron_ipc';
+import { getWebContentsInitialOptionSet } from '../../core_state';
+import { WebContents } from 'electron';
 const system = require('../../api/system').System;
 
 class RendererBatchConfiguration {
@@ -100,33 +102,33 @@ export class ElipcStrategy extends ApiTransportBase<MessagePackage> {
     }
 
     private canTrySend(routingInfo: any): boolean {
-        const { browserWindow, frameRoutingId } = routingInfo;
-        const browserWindowLocated = browserWindow;
-        const browserWindowExists = !browserWindow.isDestroyed();
+        const { webContents, frameRoutingId } = routingInfo;
+        const webContentsLocated = webContents;
+        const webContentsExists = !webContents.isDestroyed();
         const validRoutingId = typeof frameRoutingId === 'number';
-        return browserWindowLocated && browserWindowExists && validRoutingId;
+        return webContentsLocated && webContentsExists && validRoutingId;
     }
 
     // Dispatch a message
     private innerSend(payload: string,
                       frameRoutingId: number,
                       mainFrameRoutingId: number,
-                      browserWindow: any): void {
+                      webContents: WebContents): void {
         if (frameRoutingId === mainFrameRoutingId) {
             // this is the main window frame
             if (coreState.argo.framestrategy === 'frames') {
-                browserWindow.webContents.sendToFrame(frameRoutingId, electronIpc.channels.CORE_MESSAGE, payload);
+                webContents.sendToFrame(frameRoutingId, channels.CORE_MESSAGE, payload);
             } else {
-                browserWindow.send(electronIpc.channels.CORE_MESSAGE, payload);
+                webContents.send(channels.CORE_MESSAGE, payload);
             }
         } else {
-            // frameRoutingId != browserWindow.webContents.mainFrameRoutingId implies a frame
-            browserWindow.webContents.sendToFrame(frameRoutingId, electronIpc.channels.CORE_MESSAGE, payload);
+            // frameRoutingId != webContents.mainFrameRoutingId implies a frame
+            webContents.sendToFrame(frameRoutingId, channels.CORE_MESSAGE, payload);
         }
     }
 
     public registerMessageHandlers(): void {
-        electronIpc.ipc.on(electronIpc.channels.WINDOW_MESSAGE, this.onMessage.bind(this));
+        ipc.on(channels.WINDOW_MESSAGE, this.onMessage.bind(this));
     }
 
     public send(identity: Identity, payloadObj: any): void {
@@ -138,13 +140,13 @@ export class ElipcStrategy extends ApiTransportBase<MessagePackage> {
             return;
         }
 
-        const { browserWindow, mainFrameRoutingId, frameRoutingId } = routingInfo;
+        const { webContents, mainFrameRoutingId, frameRoutingId } = routingInfo;
         const payload = JSON.stringify(payloadObj);
 
         if (!this.canTrySend(routingInfo)) {
             system.debugLog(1, `uuid:${uuid} name:${name} frameRoutingId:${frameRoutingId} not reachable, payload:${payload}`);
         } else {
-            this.innerSend(payload, frameRoutingId, mainFrameRoutingId, browserWindow);
+            this.innerSend(payload, frameRoutingId, mainFrameRoutingId, webContents);
         }
     }
 
@@ -161,13 +163,12 @@ export class ElipcStrategy extends ApiTransportBase<MessagePackage> {
     protected onMessage(e: any, rawData: any, ackFactoryDelegate: any): void {
 
         try {
-            const browserWindow = e.sender.getOwnerBrowserWindow();
-            const currWindow = browserWindow ? coreState.getWinById(browserWindow.id) : null;
-            const openfinWindow = currWindow && currWindow.openfinWindow;
-            const opts = openfinWindow && openfinWindow._options;
+            const webContentsId = e.sender.id;
+
+            const opts: any = getWebContentsInitialOptionSet(webContentsId).options;
 
             if (!opts) {
-                throw new Error(`Unable to locate window information for endpoint with window id ${browserWindow.id}`);
+                throw new Error(`Unable to locate window information for endpoint with window id ${webContentsId}`);
             }
 
             const data = JSON.parse(JSON.stringify(rawData));
@@ -184,11 +185,11 @@ export class ElipcStrategy extends ApiTransportBase<MessagePackage> {
             const nack = this.nackDecorator(ack);
 
             const entityType = e.sender.getEntityType(e.frameRoutingId);
-            const isWindow  = ! e.sender.isIframe(e.frameRoutingId);
+            const isIframe  = e.sender.isIframe(e.frameRoutingId);
             const { api: { iframe: { enableDeprecatedSharedName } } } = opts;
             let subFrameName;
 
-            if (isWindow || enableDeprecatedSharedName) {
+            if (!isIframe || enableDeprecatedSharedName) {
                 subFrameName = opts.name;
             } else {
                 subFrameName = e.sender.getFrameName(e.frameRoutingId);
@@ -204,7 +205,7 @@ export class ElipcStrategy extends ApiTransportBase<MessagePackage> {
 
             /* tslint:disable: max-line-length */
             //message payload might contain sensitive data, mask it.
-            const disableIabSecureLogging = coreState.getAppObjByUuid(opts.uuid)._options.disableIabSecureLogging;
+            const disableIabSecureLogging = (<AppObj>coreState.getAppObjByUuid(opts.uuid))._options.disableIabSecureLogging;
             let replacer = (!disableIabSecureLogging && (data.action === 'publish-message' || data.action === 'send-message')) ? this.payloadReplacer : null;
             if (data.action === 'window-authenticate') { // not log password
                 replacer = this.passwordReplacer;
@@ -287,7 +288,7 @@ export class ElipcStrategy extends ApiTransportBase<MessagePackage> {
                     ackObj.addBreadcrumb('core/ACK');
                 }
 
-                e.sender.sendToFrame(e.frameRoutingId, electronIpc.channels.CORE_MESSAGE, JSON.stringify(ackObj));
+                e.sender.sendToFrame(e.frameRoutingId, channels.CORE_MESSAGE, JSON.stringify(ackObj));
             }
         };
 

--- a/src/browser/api_protocol/transport_strategy/elipc_strategy.ts
+++ b/src/browser/api_protocol/transport_strategy/elipc_strategy.ts
@@ -115,7 +115,7 @@ export class ElipcStrategy extends ApiTransportBase<MessagePackage> {
         const { webContents, frameRoutingId, mainFrameRoutingId, _options} = routingInfo;
         if (frameRoutingId === mainFrameRoutingId) {
             // this is the main window frame
-            if (_options.api.iframe.enableDeprecatedSharedName) {
+            if (!_options.api.iframe.enableDeprecatedSharedName) {
                 webContents.sendToFrame(frameRoutingId, channels.CORE_MESSAGE, payload);
             } else {
                 webContents.send(channels.CORE_MESSAGE, payload);

--- a/src/browser/api_protocol/transport_strategy/elipc_strategy.ts
+++ b/src/browser/api_protocol/transport_strategy/elipc_strategy.ts
@@ -8,7 +8,6 @@ declare var require: any;
 import * as coreState from '../../core_state';
 import {ipc, channels} from '../../transports/electron_ipc';
 import { getWebContentsInitialOptionSet, RoutingInfo } from '../../core_state';
-import { WebContents } from 'electron';
 const system = require('../../api/system').System;
 
 class RendererBatchConfiguration {
@@ -64,7 +63,7 @@ export class ElipcStrategy extends ApiTransportBase<MessagePackage> {
         super(actionMap, requestHandler);
 
         this.requestHandler.addHandler((mp: MessagePackage, next: () => void) => {
-            const { identity, data, ack, nack, e, strategyName } = mp;
+            const { identity, data, ack, nack, strategyName } = mp;
 
             if (strategyName !== this.constructor.name) {
                 next();
@@ -139,7 +138,7 @@ export class ElipcStrategy extends ApiTransportBase<MessagePackage> {
             return;
         }
 
-        const { webContents, mainFrameRoutingId, frameRoutingId } = routingInfo;
+        const { frameRoutingId } = routingInfo;
         const payload = JSON.stringify(payloadObj);
 
         if (!this.canTrySend(routingInfo)) {

--- a/src/browser/core_state.ts
+++ b/src/browser/core_state.ts
@@ -775,6 +775,7 @@ export function getRoutingInfoByUuidFrame(uuid: string, frame: string) {
                 return {
                     name,
                     browserWindow,
+                    webContents: browserWindow.webContents,
                     frameRoutingId: openfinWindow.mainFrameRoutingId,
                     mainFrameRoutingId: openfinWindow.mainFrameRoutingId,
                     frameName: name
@@ -784,6 +785,7 @@ export function getRoutingInfoByUuidFrame(uuid: string, frame: string) {
                 return {
                     name,
                     browserWindow,
+                    webContents: browserWindow.webContents,
                     frameRoutingId,
                     mainFrameRoutingId: openfinWindow.mainFrameRoutingId,
                     frameName: name

--- a/src/browser/core_state.ts
+++ b/src/browser/core_state.ts
@@ -10,7 +10,7 @@
 * */
 
 import * as minimist from 'minimist';
-import { app, webContents, session, Session, WebContents } from 'electron';
+import { app, webContents, session, Session, WebContents, BrowserWindow } from 'electron';
 import { ExternalApplication } from './api/external_application';
 import { PortInfo } from './port_discovery';
 import * as Shapes from '../shapes';
@@ -746,8 +746,16 @@ export function getInfoByUuidFrame(targetIdentity: Shapes.Identity): Shapes.Fram
         }
     }
 }
-
-export function getRoutingInfoByUuidFrame(uuid: string, frame: string) {
+export interface RoutingInfo {
+    name: string;
+    browserWindow?: BrowserWindow;
+    webContents: WebContents;
+    frameRoutingId: number;
+    mainFrameRoutingId: number;
+    frameName: string;
+    _options: Shapes.WindowOptions;
+}
+export function getRoutingInfoByUuidFrame(uuid: string, frame: string): RoutingInfo {
     const app = appByUuid(uuid);
 
     if (!app) {
@@ -775,6 +783,7 @@ export function getRoutingInfoByUuidFrame(uuid: string, frame: string) {
                 return {
                     name,
                     browserWindow,
+                    _options: openfinWindow._options,
                     webContents: browserWindow.webContents,
                     frameRoutingId: openfinWindow.mainFrameRoutingId,
                     mainFrameRoutingId: openfinWindow.mainFrameRoutingId,
@@ -785,6 +794,7 @@ export function getRoutingInfoByUuidFrame(uuid: string, frame: string) {
                 return {
                     name,
                     browserWindow,
+                    _options: openfinWindow._options,
                     webContents: browserWindow.webContents,
                     frameRoutingId,
                     mainFrameRoutingId: openfinWindow.mainFrameRoutingId,

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -89,6 +89,8 @@ declare namespace Electron {
         getOwnerBrowserWindow: () => BrowserWindow | void;
         mainFrameRoutingId: number;
         session: Session;
+        //DELETE IN v13
+        sendToFrame(frameId: number, channel: string, ...args: any[]): void;
     }
 
     export interface BrowserWindowConstructorOptions {

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -153,6 +153,7 @@ export interface WindowOptions {
     };
     alwaysOnBottom?: boolean;
     alwaysOnTop?: boolean;
+    api?: any;
     applicationIcon?: string;
     appLogFlushInterval?: number;
     aspectRatio?: number;


### PR DESCRIPTION
#### Description of Change
Use webcontents id to resolve sender identity so browser view can subscribe to iab/events

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR release notes describe the change in a way relevant to app-developers


#### Release Notes

Notes: N/A underlying work for browser view