### PR TITLE
RUN-5364: Update error to describe more cases

### DIFF
--- a/src/browser/api/external_window.ts
+++ b/src/browser/api/external_window.ts
@@ -230,7 +230,7 @@ export function getExternalWindow(identity: Identity): Shapes.ExternalWindow {
 
   if (!externalWindow) {
     if (!doesExternalWindowExist(uuid)) {
-      throw new Error(`Attempted to wrap a non-existent external window using uuid: ${uuid}`);
+      throw new Error(`Attempted to interact with a nonexistent external window using uuid: ${uuid}`);
     }
     externalWindow = <Shapes.ExternalWindow>(new ExternalWindow({ hwnd: uuid }));
 


### PR DESCRIPTION
#### Description of Change
Jira: https://appoji.jira.com/browse/RUN-5364

This error will be thrown on any action that attempts to interact with a nonexistent ExternalWindow, not just `wrap` calls.

This includes both windows that used to exist, but have been closed since wrapping, and windows that never existed in the first place. So input welcome if anyone has an error message that might more fully communicate the situation without becoming overly verbose.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)