### PR TITLE
RUN-5363: Enable Electron's unittests

### DIFF
--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -43,6 +43,8 @@ const rendererBatchingBaseSettings = {
 
 // this is the 5.0 base to be sure that we are only extending what is already expected
 function five0BaseOptions() {
+    const enableNode = process.argv.indexOf('--enable-electron-apis') !== -1 &&
+        process.buildFlags.enableElectronAPIs;
     return {
         'accelerator': {
             'devtools': false,
@@ -87,7 +89,7 @@ function five0BaseOptions() {
                 'iframe': iframeBaseSettings
             },
             'disableInitialReload': false,
-            'node': false,
+            'node': enableNode,
             'v2Api': true
         },
         'frame': true,


### PR DESCRIPTION
Goal of this task is to add possibility to launch Electron's unittests located in directory electron/spec on OpenFin's application. It will allow us to check if our chages break their apis or cause any regressions. These tests - in the future - could also be used as integration criteria for our tasks/bugfixes.