### PR TITLE
[RUN-5208] Allow external connections to connect to a channel with a nameAlias field. Include the intendedTargetIdentity in dispatched messages so that external adapters can handle window addressing

### DIFF
--- a/src/browser/api/channel.ts
+++ b/src/browser/api/channel.ts
@@ -138,8 +138,8 @@ export module Channel {
         const connectingWindow = getExternalOrOfWindowIdentity(identity);
         const providerIdentity = Channel.getChannelByChannelName(channelName);
 
-        if (connectingWindow.isExternal && payload.customExternalWindowName) {
-            identity.name = payload.customExternalWindowName;
+        if (connectingWindow && connectingWindow.isExternal && payload.externalNameAlias) {
+            identity.name = payload.externalNameAlias;
         }
 
         if (providerIdentity) {
@@ -192,7 +192,8 @@ export module Channel {
                 providerIdentity,
                 action: channelAction,
                 senderIdentity: identity,
-                payload: {intendedTargetIdentity, ...messagePayload}
+                payload: messagePayload,
+                intendedTargetIdentity
             }
         });
     }

--- a/src/browser/api/channel.ts
+++ b/src/browser/api/channel.ts
@@ -138,8 +138,8 @@ export module Channel {
         const connectingWindow = getExternalOrOfWindowIdentity(identity);
         const providerIdentity = Channel.getChannelByChannelName(channelName);
 
-        if (connectingWindow && connectingWindow.isExternal && payload.externalNameAlias) {
-            identity.name = payload.externalNameAlias;
+        if (connectingWindow && connectingWindow.isExternal && connectionPayload.externalNameAlias) {
+            identity.name = connectionPayload.externalNameAlias;
         }
 
         if (providerIdentity) {

--- a/src/browser/api/channel.ts
+++ b/src/browser/api/channel.ts
@@ -134,9 +134,13 @@ export module Channel {
 
     export function connectToChannel(identity: Identity, payload: any, messageId: number, ack: AckFunc, nack: NackFunc): void {
         const { channelName, payload: connectionPayload } = payload;
-        const { uuid, name } = identity;
 
+        const connectingWindow = getExternalOrOfWindowIdentity(identity);
         const providerIdentity = Channel.getChannelByChannelName(channelName);
+
+        if (connectingWindow.isExternal && payload.customExternalWindowName) {
+            identity.name = payload.customExternalWindowName;
+        }
 
         if (providerIdentity) {
             const ackToSender = createAckToSender(identity, messageId, providerIdentity);
@@ -154,7 +158,7 @@ export module Channel {
 
             // handle client reload or navigatation events
             const disconnectedEvent = 'client-disconnected';
-            const unloadEvent = route.window('unload', uuid, name, false);
+            const unloadEvent = route.window('unload', identity.uuid, identity.name, false);
             const unloadListener = () => subscriptionManager.removeSubscription(identity, `${disconnectedEvent}-${channelName}`);
             ofEvents.once(unloadEvent, unloadListener);
 
@@ -177,18 +181,18 @@ export module Channel {
 
     export function sendChannelMessage(identity: Identity, payload: any, messageId: number, ack: AckFunc, nack: NackFunc): void {
         const { uuid, name, payload: messagePayload, action: channelAction, providerIdentity } = payload;
-        const targetIdentity = { uuid, name };
+        const intendedTargetIdentity = { uuid, name };
 
         const ackToSender = createAckToSender(identity, messageId, providerIdentity);
 
-        sendToIdentity(targetIdentity, {
+        sendToIdentity(intendedTargetIdentity, {
             action: CHANNEL_APP_ACTION,
             payload: {
                 ackToSender,
                 providerIdentity,
                 action: channelAction,
                 senderIdentity: identity,
-                payload: messagePayload
+                payload: {intendedTargetIdentity, ...messagePayload}
             }
         });
     }

--- a/src/browser/api/channel.ts
+++ b/src/browser/api/channel.ts
@@ -138,8 +138,8 @@ export module Channel {
         const connectingWindow = getExternalOrOfWindowIdentity(identity);
         const providerIdentity = Channel.getChannelByChannelName(channelName);
 
-        if (connectingWindow && connectingWindow.isExternal && connectionPayload.externalNameAlias) {
-            identity.name = connectionPayload.externalNameAlias;
+        if (connectingWindow && connectingWindow.isExternal && connectionPayload && connectionPayload.nameAlias) {
+            identity.name = connectionPayload.nameAlias;
         }
 
         if (providerIdentity) {


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Pull Request process: https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process
-->

Allow external connections to connect to a channel with a `nameAlias` field. Include the `intendedTargetIdentity` in dispatched messages so that external adapters can handle window addressing. All work is done within the core to avoid having to make adapter/API changes.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included and stakeholders cc'd
- [X] `npm test` passes
- [O] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [X] manual tests are [changed or added](https://github.com/openfin/test_apps)
- [ ] relevant documentation is [changed or added](https://github.com/hadoukenio/js-adapter)
- [X] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [O] PR release notes describe the change in a way relevant to app-developers


#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes. Examples and help on special cases: http://developer.openfin.co/versions/?product=Runtime&version=9.61.37.46 -->


QUESTIONS:
- Do we want to share this change in release notes?

JS-Adapter Test PR:
https://github.com/HadoukenIO/js-adapter/pull/299