### PR TITLE
RUN-5349 bug fix for disabled frames with alive requestors

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -1208,8 +1208,12 @@ Window.enableUserMovement = function(identity) {
     if (!browserWindow) {
         return;
     }
-    let dframeRefCount = disabledFrameRef.get(windowKey) || 0;
-    disabledFrameRef.set(windowKey, --dframeRefCount);
+
+    if (disabledFrameRef.has(windowKey)) {
+        let dframeRefCount = disabledFrameRef.get(windowKey) || 0;
+        disabledFrameRef.set(windowKey, --dframeRefCount);
+    }
+
     browserWindow.setUserMovementEnabled(true);
 };
 


### PR DESCRIPTION
#### Description of Change
This PR fixes the bug where if you use `enableFrame()` before using `disableFrame()`, the count of the disabled frame requestors would be wrong and that would cause the frame to be enabled while there is still at least one requestor alive.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] new automated test [created](https://testing-dashboard.openfin.co/#/app/tests/5d122547cb360141a7dfe728/edit)
- [x] PR title starts with the JIRA ticket
- [x] PR release notes describe the change in a way relevant to app-developers

#### Release Notes
Fixed a bug relating to disabled frames and incorrect number of requestors
