### PR TITLE
RUN-5380 fixes window grouping regression

### DIFF
--- a/src/browser/api/external_window.ts
+++ b/src/browser/api/external_window.ts
@@ -206,9 +206,9 @@ function getKey(externalWindow: Shapes.ExternalWindow): string {
 }
 
 /*
-  Finds and returns registerd external window
+  Returns registerd external window
 */
-export function findExternalWindow(identity: Identity): Shapes.ExternalWindow | undefined {
+export function getRegisteredExternalWindow(identity: Identity): Shapes.ExternalWindow | undefined {
   const { uuid } = identity;
   return externalWindows.get(uuid);
 }

--- a/src/browser/api_protocol/api_handlers/grouped_window_moves.ts
+++ b/src/browser/api_protocol/api_handlers/grouped_window_moves.ts
@@ -5,7 +5,7 @@ import { getTargetWindowIdentity } from './api_protocol_base';
 import { RectangleBase } from '../../rectangle';
 import { APIMessage, GroupWindow } from '../../../shapes';
 import { AckFunc, AckPayload, NackFunc } from '../transport_strategy/ack';
-import { findExternalWindow } from '../../api/external_window';
+import { getRegisteredExternalWindow } from '../../api/external_window';
 
 const unsupported = (payload: any) => {
     throw new Error('This action is not supported while grouped');
@@ -52,7 +52,7 @@ export function hijackMovesForGroupedWindows(actions: ActionSpecMap) {
 
                     // Check if the missing window is an external window
                     if (!window) {
-                        window = findExternalWindow({ uuid });
+                        window = getRegisteredExternalWindow({ uuid });
                     }
 
                     const options = payload.options || { moveIndependently: false };

--- a/src/browser/window_groups.ts
+++ b/src/browser/window_groups.ts
@@ -7,7 +7,7 @@ import * as coreState from './core_state';
 import * as windowGroupsProxy from './window_groups_runtime_proxy';
 import * as groupTracker from './disabled_frame_group_tracker';
 import { argo } from './core_state';
-import { getExternalWindow } from './api/external_window';
+import { getRegisteredExternalWindow } from './api/external_window';
 
 let uuidSeed = 0;
 
@@ -83,27 +83,8 @@ export class WindowGroups extends EventEmitter {
     }
 
     public joinGroup = async (source: Identity, target: Identity): Promise<void> => {
-        let sourceWindow: GroupWindow;
-        let targetWindow: GroupWindow;
-
-        sourceWindow = <OpenFinWindow>coreState.getWindowByUuidName(source.uuid, source.name);
-        targetWindow = <OpenFinWindow>coreState.getWindowByUuidName(target.uuid, target.name);
-
-        // Identify if either the target or the source belong to a different runtime:
-        let runtimeProxyWindow;
-        if (!targetWindow) {
-            runtimeProxyWindow = await windowGroupsProxy.getRuntimeProxyWindow(target);
-            targetWindow = <OpenFinWindow>runtimeProxyWindow.window;
-        }
-
-        // Check if missing source and target windows are external windows
-        if (!sourceWindow) {
-            sourceWindow = <ExternalWindow>getExternalWindow(source);
-        }
-        if (!targetWindow) {
-            targetWindow = <ExternalWindow>getExternalWindow(target);
-        }
-
+        const [sourceWindow] = await findWindow(source);
+        const [targetWindow, targetProxyWindow] = await findWindow(target);
         const sourceGroupUuid = sourceWindow.groupUuid;
         let targetGroupUuid = targetWindow.groupUuid;
 
@@ -131,8 +112,8 @@ export class WindowGroups extends EventEmitter {
         }
 
         //we just added a proxy window, we need to take some additional actions.
-        if (runtimeProxyWindow) {
-            const windowGroup = await runtimeProxyWindow.register(source);
+        if (targetProxyWindow) {
+            const windowGroup = await targetProxyWindow.register(source);
             windowGroup.forEach(pWin => this._addWindowToGroup(sourceWindow.groupUuid, pWin.window));
         }
 
@@ -177,27 +158,8 @@ export class WindowGroups extends EventEmitter {
     };
 
     public mergeGroups = async (source: Identity, target: Identity): Promise<void> => {
-        let sourceWindow: GroupWindow;
-        let targetWindow: GroupWindow;
-
-        sourceWindow = <OpenFinWindow>coreState.getWindowByUuidName(source.uuid, source.name);
-        targetWindow = <OpenFinWindow>coreState.getWindowByUuidName(target.uuid, target.name);
-
-        // Identify if either the target or the source belong to a different runtime:
-        let runtimeProxyWindow;
-        if (!targetWindow) {
-            runtimeProxyWindow = await windowGroupsProxy.getRuntimeProxyWindow(target);
-            targetWindow = runtimeProxyWindow.window;
-        }
-
-        // Check if missing source and target windows are external windows
-        if (!sourceWindow) {
-            sourceWindow = <ExternalWindow>getExternalWindow(source);
-        }
-        if (!targetWindow) {
-            targetWindow = <ExternalWindow>getExternalWindow(target);
-        }
-
+        const [sourceWindow] = await findWindow(source);
+        const [targetWindow, targetProxyWindow] = await findWindow(target);
         let sourceGroupUuid = sourceWindow.groupUuid;
         let targetGroupUuid = targetWindow.groupUuid;
 
@@ -232,8 +194,8 @@ export class WindowGroups extends EventEmitter {
         delete this._windowGroups[sourceGroupUuid];
 
         //we just added a proxy window, we need to take some additional actions.
-        if (runtimeProxyWindow) {
-            const windowGroup = await runtimeProxyWindow.register(source);
+        if (targetProxyWindow) {
+            const windowGroup = await targetProxyWindow.register(source);
             windowGroup.forEach(pWin => this._addWindowToGroup(sourceWindow.groupUuid, pWin.window));
         }
 
@@ -378,6 +340,33 @@ function mapEventWindowGroups(group: GroupWindow[]): WindowIdentifier[] {
             windowName: win.name
         };
     });
+}
+
+/*
+    Attempt to find a window in:
+    1. Current runtime (core state)
+    2. Another runtime (multi-runtim)
+    3. Current runtime (map of registered external windows)
+*/
+async function findWindow(window: Identity): Promise<[GroupWindow, windowGroupsProxy.RuntimeProxyWindow | undefined]> {
+    let foundWindow;
+    let proxyWindow;
+
+    // Current runtime, OpenFin window
+    foundWindow = <OpenFinWindow>coreState.getWindowByUuidName(window.uuid, window.name);
+
+    if (!foundWindow) {
+        try {
+            // Multi-runtime, proxy window, OpenFin window
+            proxyWindow = <windowGroupsProxy.RuntimeProxyWindow>await windowGroupsProxy.getRuntimeProxyWindow(window);
+            foundWindow = <OpenFinWindow>proxyWindow.window;
+        } catch (error) {
+            // Current runtime, external window
+            foundWindow = <ExternalWindow>getRegisteredExternalWindow(window);
+        }
+    }
+
+    return [foundWindow, proxyWindow];
 }
 
 export default new WindowGroups();

--- a/src/browser/window_groups.ts
+++ b/src/browser/window_groups.ts
@@ -89,6 +89,13 @@ export class WindowGroups extends EventEmitter {
         sourceWindow = <OpenFinWindow>coreState.getWindowByUuidName(source.uuid, source.name);
         targetWindow = <OpenFinWindow>coreState.getWindowByUuidName(target.uuid, target.name);
 
+        // Identify if either the target or the source belong to a different runtime:
+        let runtimeProxyWindow;
+        if (!targetWindow) {
+            runtimeProxyWindow = await windowGroupsProxy.getRuntimeProxyWindow(target);
+            targetWindow = <OpenFinWindow>runtimeProxyWindow.window;
+        }
+
         // Check if missing source and target windows are external windows
         if (!sourceWindow) {
             sourceWindow = <ExternalWindow>getExternalWindow(source);
@@ -97,15 +104,9 @@ export class WindowGroups extends EventEmitter {
             targetWindow = <ExternalWindow>getExternalWindow(target);
         }
 
-        let runtimeProxyWindow;
         const sourceGroupUuid = sourceWindow.groupUuid;
-
-        //identify if either the target or the source belong to a different runtime:
-        if (!targetWindow) {
-            runtimeProxyWindow = await windowGroupsProxy.getRuntimeProxyWindow(target);
-            targetWindow = <OpenFinWindow>runtimeProxyWindow.window;
-        }
         let targetGroupUuid = targetWindow.groupUuid;
+
         // cannot join a group with yourself
         if (sourceWindow.uuid === targetWindow.uuid && sourceWindow.name === targetWindow.name) {
             return;
@@ -182,6 +183,13 @@ export class WindowGroups extends EventEmitter {
         sourceWindow = <OpenFinWindow>coreState.getWindowByUuidName(source.uuid, source.name);
         targetWindow = <OpenFinWindow>coreState.getWindowByUuidName(target.uuid, target.name);
 
+        // Identify if either the target or the source belong to a different runtime:
+        let runtimeProxyWindow;
+        if (!targetWindow) {
+            runtimeProxyWindow = await windowGroupsProxy.getRuntimeProxyWindow(target);
+            targetWindow = runtimeProxyWindow.window;
+        }
+
         // Check if missing source and target windows are external windows
         if (!sourceWindow) {
             sourceWindow = <ExternalWindow>getExternalWindow(source);
@@ -190,14 +198,7 @@ export class WindowGroups extends EventEmitter {
             targetWindow = <ExternalWindow>getExternalWindow(target);
         }
 
-        let runtimeProxyWindow;
         let sourceGroupUuid = sourceWindow.groupUuid;
-
-        //identify if either the target or the source belong to a different runtime:
-        if (!targetWindow) {
-            runtimeProxyWindow = await windowGroupsProxy.getRuntimeProxyWindow(target);
-            targetWindow = runtimeProxyWindow.window;
-        }
         let targetGroupUuid = targetWindow.groupUuid;
 
         // cannot merge a group with yourself


### PR DESCRIPTION
#### Description of Change
This PR fixes the regression where windows wouldn't join or merge a group in the multi-runtime environment.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] automated test [added](https://testing-dashboard.openfin.co/#/app/tests/5d1372a7cb360141a7dfe750/edit)
- [x] PR title starts with the JIRA ticket
- [x] PR release notes describe the change in a way relevant to app-developers

#### Release Notes
N/A

#### Test Results
- [Windows 7](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5d136e2bcb360141a7dfe74e) (1 failed test unrelated to this change)
- [Windows 10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5d136e4ccb360141a7dfe74f) (5 failed tests, unrelated to this change)