### PR TITLE
RUN-5392 - group resize bugfix

### DIFF
--- a/src/browser/bounds_changed_state_tracker.ts
+++ b/src/browser/bounds_changed_state_tracker.ts
@@ -273,7 +273,7 @@ export default class BoundsChangedStateTracker {
         const thisRect = Rectangle.CREATE_FROM_BOUNDS(bounds);
         const currentBounds = this.getCurrentBounds();
         const cachedBounds = this.getCachedBounds();
-        const moved = thisRect.move(cachedBounds, currentBounds);
+        const moved = thisRect.propogateMoveToThisRect(cachedBounds, currentBounds);
         return clipBounds(moved, windowToUpdate.browserWindow);
     };
 

--- a/src/browser/bounds_changed_state_tracker.ts
+++ b/src/browser/bounds_changed_state_tracker.ts
@@ -273,7 +273,7 @@ export default class BoundsChangedStateTracker {
         const thisRect = Rectangle.CREATE_FROM_BOUNDS(bounds);
         const currentBounds = this.getCurrentBounds();
         const cachedBounds = this.getCachedBounds();
-        const moved = thisRect.propogateMoveToThisRect(cachedBounds, currentBounds);
+        const moved = thisRect.propagateMoveToThisRect(cachedBounds, currentBounds);
         return clipBounds(moved, windowToUpdate.browserWindow);
     };
 

--- a/src/browser/rectangle.ts
+++ b/src/browser/rectangle.ts
@@ -7,8 +7,6 @@ type SharedBounds = {
     left: SideName;
 };
 type SharedBound = Array<SideName>;
-type BoundIdentifier = [Rectangle, SideName];
-type RectangleBaseKeys = 'x' | 'y' | 'width' | 'height';
 export type SharedBoundsList = Array<SharedBound>;
 type Graph = [number[], number[][]];
 export interface Opts {
@@ -53,17 +51,6 @@ export class Rectangle {
         return new Rectangle(x, y, width, height, new RectOptionsOpts(options));
     }
     public static BOUND_SHARE_THRESHOLD = 5;
-
-    private static readonly EDGE_CROSSINGS: SideName[][] = [
-        ['top', 'top'],
-        ['top', 'bottom'],
-        ['bottom', 'top'],
-        ['bottom', 'bottom'],
-        ['right', 'left'],
-        ['right', 'right'],
-        ['left', 'left'],
-        ['left', 'right']
-    ];
 
     public x: number;
     public y: number;
@@ -355,12 +342,14 @@ export class Rectangle {
         return new Rectangle(this.x + delta.x, this.y + delta.y, this.width + delta.width, this.height + delta.height, this.opts);
     }
 
-    public move = (cachedBounds: RectangleBase, currentBounds: RectangleBase): Rectangle => {
+    public propogateMoveToThisRect = (leaderStartBounds: RectangleBase, proposedLeaderMove: RectangleBase): Rectangle => {
         
-        const sharedBoundsList = this.sharedBoundsList(Rectangle.CREATE_FROM_BOUNDS(cachedBounds));
-        const currLeader = Rectangle.CREATE_FROM_BOUNDS(currentBounds);
-        const delta = Rectangle.CREATE_FROM_BOUNDS(cachedBounds).delta(currLeader);
+        const sharedBoundsList = this.sharedBoundsList(Rectangle.CREATE_FROM_BOUNDS(leaderStartBounds));
+        const currLeader = Rectangle.CREATE_FROM_BOUNDS(proposedLeaderMove);
+        // This is the delta of the leader, which may or may not be `this` rect
+        const delta = Rectangle.CREATE_FROM_BOUNDS(leaderStartBounds).delta(currLeader);
         let rect: Rectangle = this;
+        // Check if any sides of this rect would be moved by the leader move represented by delta
         for (const [thisRectSharedSide, otherRectSharedSide] of sharedBoundsList) {
             if (rect.edgeMoved([thisRectSharedSide, otherRectSharedSide], delta)) {
                 rect = rect.alignSide(thisRectSharedSide, currLeader, otherRectSharedSide);
@@ -600,9 +589,11 @@ function propMoveThroughGraph (
     let movedRef = rects[refVertex];
 
     if (movedRef.hasIdenticalBounds( cachedBounds)) {
+        // This is the leader, move it to the proposed bounds
         movedRef = Rectangle.CREATE_FROM_BOUNDS(proposedBounds);
     } else {
-        movedRef = movedRef.move(cachedBounds, proposedBounds);
+        // This rect is not the leader, see if it needs to be move and if so, move it
+        movedRef = movedRef.propogateMoveToThisRect(cachedBounds, proposedBounds);
     }
 
     for (let v in vertices) {
@@ -612,16 +603,13 @@ function propMoveThroughGraph (
     distances.set(refVertex, 0);
     visited.push(refVertex);
 
-    const toVisit = [refVertex];
-
-    while (toVisit.length) {
-        const u = toVisit.shift();
-        const e = (<number [][]>edges).filter(([uu]): boolean => uu === u);
+    // If this rect has been moved, need to propagate the move to any touching edges
+    if(!rects[refVertex].hasIdenticalBounds(movedRef)) {
+        const e = (<number [][]>edges).filter(([uu]): boolean => uu === refVertex);
 
         e.forEach(([u, v]) => {
             if (!visited.includes(v)) {
                 if (distances.get(v) === Infinity) {
-                    toVisit.push(v);
                     distances.set(v, distances.get(u) + 1);
                     
                     propMoveThroughGraph(rects, v, rects[refVertex], movedRef, visited);
@@ -629,9 +617,8 @@ function propMoveThroughGraph (
                 }
             }
         });
+        rects[refVertex] = movedRef;
     }
-
-    rects[refVertex] = movedRef;
     return rects;
 }
 

--- a/src/browser/rectangle.ts
+++ b/src/browser/rectangle.ts
@@ -608,13 +608,11 @@ function propMoveThroughGraph (
         const e = (<number [][]>edges).filter(([uu]): boolean => uu === refVertex);
 
         e.forEach(([u, v]) => {
-            if (!visited.includes(v)) {
-                if (distances.get(v) === Infinity) {
-                    distances.set(v, distances.get(u) + 1);
-                    
-                    propMoveThroughGraph(rects, v, rects[refVertex], movedRef, visited);
-                    visited.push(v);
-                }
+            if (distances.get(v) === Infinity && !visited.includes(v)) {
+                distances.set(v, distances.get(u) + 1);
+                
+                propMoveThroughGraph(rects, v, rects[refVertex], movedRef, visited);
+                visited.push(v);
             }
         });
         rects[refVertex] = movedRef;

--- a/src/browser/rectangle.ts
+++ b/src/browser/rectangle.ts
@@ -342,7 +342,7 @@ export class Rectangle {
         return new Rectangle(this.x + delta.x, this.y + delta.y, this.width + delta.width, this.height + delta.height, this.opts);
     }
 
-    public propogateMoveToThisRect = (leaderStartBounds: RectangleBase, proposedLeaderMove: RectangleBase): Rectangle => {
+    public propagateMoveToThisRect = (leaderStartBounds: RectangleBase, proposedLeaderMove: RectangleBase): Rectangle => {
         
         const sharedBoundsList = this.sharedBoundsList(Rectangle.CREATE_FROM_BOUNDS(leaderStartBounds));
         const currLeader = Rectangle.CREATE_FROM_BOUNDS(proposedLeaderMove);
@@ -593,7 +593,7 @@ function propMoveThroughGraph (
         movedRef = Rectangle.CREATE_FROM_BOUNDS(proposedBounds);
     } else {
         // This rect is not the leader, see if it needs to be move and if so, move it
-        movedRef = movedRef.propogateMoveToThisRect(cachedBounds, proposedBounds);
+        movedRef = movedRef.propagateMoveToThisRect(cachedBounds, proposedBounds);
     }
 
     for (let v in vertices) {

--- a/src/browser/rectangle.ts
+++ b/src/browser/rectangle.ts
@@ -588,7 +588,7 @@ function propMoveThroughGraph (
     const distances = new Map();
     let movedRef = rects[refVertex];
 
-    if (movedRef.hasIdenticalBounds( cachedBounds)) {
+    if (movedRef.hasIdenticalBounds(cachedBounds)) {
         // This is the leader, move it to the proposed bounds
         movedRef = Rectangle.CREATE_FROM_BOUNDS(proposedBounds);
     } else {

--- a/src/browser/rectangle.ts
+++ b/src/browser/rectangle.ts
@@ -588,7 +588,7 @@ function propMoveThroughGraph (
     const distances = new Map();
     let movedRef = rects[refVertex];
 
-    if (movedRef.hasIdenticalBounds( cachedBounds)) {
+    if (movedRef.hasIdenticalBounds(cachedBounds)) {
         // This is the leader, move it to the proposed bounds
         movedRef = Rectangle.CREATE_FROM_BOUNDS(proposedBounds);
     } else {
@@ -615,7 +615,7 @@ function propMoveThroughGraph (
                     toVisit.push(v);
                     distances.set(v, distances.get(u) + 1);
                     
-                    const visitedClone = JSON.parse(JSON.stringify(visited));
+                    const visitedClone = [...visited];
                     propMoveThroughGraph(rects, v, rects[refVertex], movedRef, visitedClone);
                     visited.push(v);
                 }

--- a/src/browser/rectangle.ts
+++ b/src/browser/rectangle.ts
@@ -588,7 +588,7 @@ function propMoveThroughGraph (
     const distances = new Map();
     let movedRef = rects[refVertex];
 
-    if (movedRef.hasIdenticalBounds(cachedBounds)) {
+    if (movedRef.hasIdenticalBounds( cachedBounds)) {
         // This is the leader, move it to the proposed bounds
         movedRef = Rectangle.CREATE_FROM_BOUNDS(proposedBounds);
     } else {
@@ -603,20 +603,26 @@ function propMoveThroughGraph (
     distances.set(refVertex, 0);
     visited.push(refVertex);
 
+    const toVisit = [refVertex];
     // If this rect has been moved, need to propagate the move to any touching edges
     if(!rects[refVertex].hasIdenticalBounds(movedRef)) {
-        const e = (<number [][]>edges).filter(([uu]): boolean => uu === refVertex);
+        while (toVisit.length) {
+            const u = toVisit.shift();
+            const e = (<number [][]>edges).filter(([uu]): boolean => uu === u);
 
-        e.forEach(([u, v]) => {
-            if (distances.get(v) === Infinity && !visited.includes(v)) {
-                distances.set(v, distances.get(u) + 1);
-                
-                propMoveThroughGraph(rects, v, rects[refVertex], movedRef, visited);
-                visited.push(v);
-            }
-        });
-        rects[refVertex] = movedRef;
+            e.forEach(([u, v]) => {
+                if (!visited.includes(v) && distances.get(v) === Infinity) {
+                    toVisit.push(v);
+                    distances.set(v, distances.get(u) + 1);
+                    
+                    const visitedClone = JSON.parse(JSON.stringify(visited));
+                    propMoveThroughGraph(rects, v, rects[refVertex], movedRef, visitedClone);
+                    visited.push(v);
+                }
+            });
+        }
     }
+    rects[refVertex] = movedRef;
     return rects;
 }
 

--- a/test/rectangle.ts
+++ b/test/rectangle.ts
@@ -142,62 +142,62 @@ describe('Rectangle', () => {
 
     it('should not move if no shared edges', () => {
         const rect = new Rectangle(0, 0, 100, 100);
-        const move = rect.move({x: 200, y: 0, width: 100, height: 100}, {x: 300, y: 0, width: 100, height: 100});
+        const move = rect.propogateMoveToThisRect({x: 200, y: 0, width: 100, height: 100}, {x: 300, y: 0, width: 100, height: 100});
         assert.deepStrictEqual(move.bounds, {x: 0, y: 0, width: 100, height: 100});
     });
 
     it('should not move if the resizing edge is not a shared one, (leader right, leader grows not shared)', () => {
         const rect = new Rectangle(0, 0, 100, 100);
-        const move = rect.move({x: 100, y: 0, width: 100, height: 100}, {x: 100, y: 0, width: 110, height: 100});
+        const move = rect.propogateMoveToThisRect({x: 100, y: 0, width: 100, height: 100}, {x: 100, y: 0, width: 110, height: 100});
         assert.deepStrictEqual(move.bounds, {x: 0, y: 0, width: 100, height: 100});
     });
 
 
     it('should move with just the leader window move (leader top, leader grows)', () => {
         const rect = new Rectangle(100, 100, 100, 100);
-        const move = rect.move({x: 0, y: 0, width: 100, height: 100}, {x: 0, y: 0, width: 100, height: 110});
+        const move = rect.propogateMoveToThisRect({x: 0, y: 0, width: 100, height: 100}, {x: 0, y: 0, width: 100, height: 110});
         assert.deepStrictEqual(move.bounds, {x: 100, y: 110, width: 100, height: 90});
     });
 
     it('should move with just the leader window move (leader top, leader shrinks)', () => {
         const rect = new Rectangle(100, 100, 100, 100);
-        const move = rect.move({x: 0, y: 0, width: 100, height: 100}, {x: 0, y: 0, width: 100, height: 90});
+        const move = rect.propogateMoveToThisRect({x: 0, y: 0, width: 100, height: 100}, {x: 0, y: 0, width: 100, height: 90});
         assert.deepStrictEqual(move.bounds, {x: 100, y: 90, width: 100, height: 110});
     });
 
     it('should move with just the leader window move (leader bottom, leader grows)', () => {
         const rect = new Rectangle(100, 100, 100, 100);
-        const move = rect.move({x: 0, y: 200, width: 100, height: 100}, {x: 0, y: 190, width: 100, height: 110});
+        const move = rect.propogateMoveToThisRect({x: 0, y: 200, width: 100, height: 100}, {x: 0, y: 190, width: 100, height: 110});
         assert.deepStrictEqual(move.bounds, {x: 100, y: 100, width: 100, height: 90});
     });
 
     it('should move with just the leader window move (leader bottom, leader shrinks)', () => {
         const rect = new Rectangle(100, 100, 100, 100);
-        const move = rect.move({x: 0, y: 200, width: 100, height: 100}, {x: 0, y: 210, width: 100, height: 90});
+        const move = rect.propogateMoveToThisRect({x: 0, y: 200, width: 100, height: 100}, {x: 0, y: 210, width: 100, height: 90});
         assert.deepStrictEqual(move.bounds, {x: 100, y: 100, width: 100, height: 110});
     });
 
     it('should move with just the leader window move (leader left, leader grows)', () => {
         const rect = new Rectangle(100, 0, 100, 100);
-        const move = rect.move({x: 0, y: 0, width: 100, height: 100}, {x: 0, y: 0, width: 110, height: 100});
+        const move = rect.propogateMoveToThisRect({x: 0, y: 0, width: 100, height: 100}, {x: 0, y: 0, width: 110, height: 100});
         assert.deepStrictEqual(move.bounds, {x: 110, y: 0, width: 90, height: 100});
     });
 
     it('should move with just the leader window move (leader left, leader shrinks)', () => {
         const rect = new Rectangle(100, 0, 100, 100);
-        const move = rect.move({x: 0, y: 0, width: 100, height: 100}, {x: 0, y: 0, width: 90, height: 100});
+        const move = rect.propogateMoveToThisRect({x: 0, y: 0, width: 100, height: 100}, {x: 0, y: 0, width: 90, height: 100});
         assert.deepStrictEqual(move.bounds, {x: 90, y: 0, width: 110, height: 100});
     });
 
     it('should move with just the leader window move (leader right, leader grows)', () => {
         const rect = new Rectangle(0, 0, 100, 100);
-        const move = rect.move({x: 100, y: 0, width: 100, height: 100}, {x: 90, y: 0, width: 110, height: 100});
+        const move = rect.propogateMoveToThisRect({x: 100, y: 0, width: 100, height: 100}, {x: 90, y: 0, width: 110, height: 100});
         assert.deepStrictEqual(move.bounds, {x: 0, y: 0, width: 90, height: 100});
     });
 
     it('should move with just the leader window move (leader right, leader shrinks)', () => {
         const rect = new Rectangle(0, 0, 100, 100);
-        const move = rect.move({x: 100, y: 0, width: 100, height: 100}, {x: 110, y: 0, width: 90, height: 100});
+        const move = rect.propogateMoveToThisRect({x: 100, y: 0, width: 100, height: 100}, {x: 110, y: 0, width: 90, height: 100});
         assert.deepStrictEqual(move.bounds, {x: 0, y: 0, width: 110, height: 100});
     });
 
@@ -266,14 +266,14 @@ describe('Rectangle', () => {
         const rect1From = Rectangle.CREATE_FROM_BOUNDS({ 'x': 5104, 'y': -560, 'width': 340, 'height': 349 });
         const rect1To = Rectangle.CREATE_FROM_BOUNDS({'x': 5104, 'y': -908, 'width': 306, 'height': 697});
         const rect = Rectangle.CREATE_FROM_BOUNDS({ 'x': 5104, 'y': -686, 'width': 340, 'height': 126 });
-        const result = rect.move(rect1From, rect1To);
+        const result = rect.propogateMoveToThisRect(rect1From, rect1To);
         assert(result.height === 38);
     });
     it('doesnt move to negative height2', () => {
         const rect1From = Rectangle.CREATE_FROM_BOUNDS({ 'x': 0, 'y': -100, 'width': 100, 'height': 100 });
         const rect1To = Rectangle.CREATE_FROM_BOUNDS({ 'x': 0, 'y': -200, 'width': 100, 'height': 200 });
         const rect = Rectangle.CREATE_FROM_BOUNDS({ 'x': 0, 'y': -150, 'width': 100, 'height': 50 });
-        const result = rect.move(rect1From, rect1To);
+        const result = rect.propogateMoveToThisRect(rect1From, rect1To);
         assert(result.height === 38);
     });
     it('should recognize if another window shares the same bounds', () => {
@@ -400,6 +400,27 @@ describe('Rectangle', () => {
         const delta = startRect.delta(endRect);
 
         const propagatedMoves = Rectangle.PROPAGATE_MOVE(0, startRect, delta, rectsInit);
+        assert.deepEqual(propagatedMoves.map(x => x.bounds), rectsFinal.map(x => x.bounds));
+    });
+
+    it('should propagate a move through the window graph correctly when there are 3 windows and 2 have the same bounds', () => {
+        const startRect = Rectangle.CREATE_FROM_BOUNDS({x: 0, y: 100, width: 100, height: 100});
+        const endRect = Rectangle.CREATE_FROM_BOUNDS({x: 0, y: 100, width: 100, height: 101});
+        const rectsInit = [
+            Rectangle.CREATE_FROM_BOUNDS({x: 0, y: 0, width: 100, height: 100}),
+            Rectangle.CREATE_FROM_BOUNDS({x: 0, y: 100, width: 100, height: 100}),
+            startRect
+        ];
+
+        const rectsFinal = [
+            Rectangle.CREATE_FROM_BOUNDS({x: 0, y: 0, width: 100, height: 100}),
+            Rectangle.CREATE_FROM_BOUNDS({x: 0, y: 100, width: 100, height: 101}),
+            endRect
+        ];
+
+        const delta = startRect.delta(endRect);
+
+        const propagatedMoves = Rectangle.PROPAGATE_MOVE(2, startRect, delta, rectsInit);
         assert.deepEqual(propagatedMoves.map(x => x.bounds), rectsFinal.map(x => x.bounds));
     });
 });

--- a/test/rectangle.ts
+++ b/test/rectangle.ts
@@ -142,62 +142,62 @@ describe('Rectangle', () => {
 
     it('should not move if no shared edges', () => {
         const rect = new Rectangle(0, 0, 100, 100);
-        const move = rect.propogateMoveToThisRect({x: 200, y: 0, width: 100, height: 100}, {x: 300, y: 0, width: 100, height: 100});
+        const move = rect.propagateMoveToThisRect({x: 200, y: 0, width: 100, height: 100}, {x: 300, y: 0, width: 100, height: 100});
         assert.deepStrictEqual(move.bounds, {x: 0, y: 0, width: 100, height: 100});
     });
 
     it('should not move if the resizing edge is not a shared one, (leader right, leader grows not shared)', () => {
         const rect = new Rectangle(0, 0, 100, 100);
-        const move = rect.propogateMoveToThisRect({x: 100, y: 0, width: 100, height: 100}, {x: 100, y: 0, width: 110, height: 100});
+        const move = rect.propagateMoveToThisRect({x: 100, y: 0, width: 100, height: 100}, {x: 100, y: 0, width: 110, height: 100});
         assert.deepStrictEqual(move.bounds, {x: 0, y: 0, width: 100, height: 100});
     });
 
 
     it('should move with just the leader window move (leader top, leader grows)', () => {
         const rect = new Rectangle(100, 100, 100, 100);
-        const move = rect.propogateMoveToThisRect({x: 0, y: 0, width: 100, height: 100}, {x: 0, y: 0, width: 100, height: 110});
+        const move = rect.propagateMoveToThisRect({x: 0, y: 0, width: 100, height: 100}, {x: 0, y: 0, width: 100, height: 110});
         assert.deepStrictEqual(move.bounds, {x: 100, y: 110, width: 100, height: 90});
     });
 
     it('should move with just the leader window move (leader top, leader shrinks)', () => {
         const rect = new Rectangle(100, 100, 100, 100);
-        const move = rect.propogateMoveToThisRect({x: 0, y: 0, width: 100, height: 100}, {x: 0, y: 0, width: 100, height: 90});
+        const move = rect.propagateMoveToThisRect({x: 0, y: 0, width: 100, height: 100}, {x: 0, y: 0, width: 100, height: 90});
         assert.deepStrictEqual(move.bounds, {x: 100, y: 90, width: 100, height: 110});
     });
 
     it('should move with just the leader window move (leader bottom, leader grows)', () => {
         const rect = new Rectangle(100, 100, 100, 100);
-        const move = rect.propogateMoveToThisRect({x: 0, y: 200, width: 100, height: 100}, {x: 0, y: 190, width: 100, height: 110});
+        const move = rect.propagateMoveToThisRect({x: 0, y: 200, width: 100, height: 100}, {x: 0, y: 190, width: 100, height: 110});
         assert.deepStrictEqual(move.bounds, {x: 100, y: 100, width: 100, height: 90});
     });
 
     it('should move with just the leader window move (leader bottom, leader shrinks)', () => {
         const rect = new Rectangle(100, 100, 100, 100);
-        const move = rect.propogateMoveToThisRect({x: 0, y: 200, width: 100, height: 100}, {x: 0, y: 210, width: 100, height: 90});
+        const move = rect.propagateMoveToThisRect({x: 0, y: 200, width: 100, height: 100}, {x: 0, y: 210, width: 100, height: 90});
         assert.deepStrictEqual(move.bounds, {x: 100, y: 100, width: 100, height: 110});
     });
 
     it('should move with just the leader window move (leader left, leader grows)', () => {
         const rect = new Rectangle(100, 0, 100, 100);
-        const move = rect.propogateMoveToThisRect({x: 0, y: 0, width: 100, height: 100}, {x: 0, y: 0, width: 110, height: 100});
+        const move = rect.propagateMoveToThisRect({x: 0, y: 0, width: 100, height: 100}, {x: 0, y: 0, width: 110, height: 100});
         assert.deepStrictEqual(move.bounds, {x: 110, y: 0, width: 90, height: 100});
     });
 
     it('should move with just the leader window move (leader left, leader shrinks)', () => {
         const rect = new Rectangle(100, 0, 100, 100);
-        const move = rect.propogateMoveToThisRect({x: 0, y: 0, width: 100, height: 100}, {x: 0, y: 0, width: 90, height: 100});
+        const move = rect.propagateMoveToThisRect({x: 0, y: 0, width: 100, height: 100}, {x: 0, y: 0, width: 90, height: 100});
         assert.deepStrictEqual(move.bounds, {x: 90, y: 0, width: 110, height: 100});
     });
 
     it('should move with just the leader window move (leader right, leader grows)', () => {
         const rect = new Rectangle(0, 0, 100, 100);
-        const move = rect.propogateMoveToThisRect({x: 100, y: 0, width: 100, height: 100}, {x: 90, y: 0, width: 110, height: 100});
+        const move = rect.propagateMoveToThisRect({x: 100, y: 0, width: 100, height: 100}, {x: 90, y: 0, width: 110, height: 100});
         assert.deepStrictEqual(move.bounds, {x: 0, y: 0, width: 90, height: 100});
     });
 
     it('should move with just the leader window move (leader right, leader shrinks)', () => {
         const rect = new Rectangle(0, 0, 100, 100);
-        const move = rect.propogateMoveToThisRect({x: 100, y: 0, width: 100, height: 100}, {x: 110, y: 0, width: 90, height: 100});
+        const move = rect.propagateMoveToThisRect({x: 100, y: 0, width: 100, height: 100}, {x: 110, y: 0, width: 90, height: 100});
         assert.deepStrictEqual(move.bounds, {x: 0, y: 0, width: 110, height: 100});
     });
 
@@ -266,14 +266,14 @@ describe('Rectangle', () => {
         const rect1From = Rectangle.CREATE_FROM_BOUNDS({ 'x': 5104, 'y': -560, 'width': 340, 'height': 349 });
         const rect1To = Rectangle.CREATE_FROM_BOUNDS({'x': 5104, 'y': -908, 'width': 306, 'height': 697});
         const rect = Rectangle.CREATE_FROM_BOUNDS({ 'x': 5104, 'y': -686, 'width': 340, 'height': 126 });
-        const result = rect.propogateMoveToThisRect(rect1From, rect1To);
+        const result = rect.propagateMoveToThisRect(rect1From, rect1To);
         assert(result.height === 38);
     });
     it('doesnt move to negative height2', () => {
         const rect1From = Rectangle.CREATE_FROM_BOUNDS({ 'x': 0, 'y': -100, 'width': 100, 'height': 100 });
         const rect1To = Rectangle.CREATE_FROM_BOUNDS({ 'x': 0, 'y': -200, 'width': 100, 'height': 200 });
         const rect = Rectangle.CREATE_FROM_BOUNDS({ 'x': 0, 'y': -150, 'width': 100, 'height': 50 });
-        const result = rect.propogateMoveToThisRect(rect1From, rect1To);
+        const result = rect.propagateMoveToThisRect(rect1From, rect1To);
         assert(result.height === 38);
     });
     it('should recognize if another window shares the same bounds', () => {


### PR DESCRIPTION
#### Description of Change
When RTv10 windows are tabbed by the Layout Service they can't be resized vertically from the top or the bottom.  The bottom is a bug that will affect not only tabbed windows.  There is a bug where when there are 3+ windows, the move will not get propagated to all of the windows.  This has been replicated with two windows on top of each other (same bounds), then a third window on any side of the window.  Try to resize either of the windows with identical bounds - in the direction towards or away from the third window and it will fail to resize.  

This is related to this [JIRA](https://appoji.jira.com/browse/RUN-5348) but only fixes half the issue.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x ] PR description included and stakeholders cc'd
- [ x ] `npm test` passes
- [ x ] automated tests are added (see unit test in PR)
- [ x ] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [ ] PR release notes describe the change in a way relevant to app-developers (need to fully fix problem first)


#### Release Notes

Notes: NA - need to fully fix problem first.  Probably more so a layouts release not but if we have a runtime one would be on the JIRA linked to above.
