### PR TITLE
Add performance-report event

### DIFF
--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -317,14 +317,16 @@
         }
 
         // Collect performance data and send it as an event
-        let payload = {
-            name: initialOptions.name,
-            uuid: initialOptions.uuid
-        };
-        raiseEventSync(`window/performance-report/${initialOptions.uuid}-${initialOptions.name}`, Object.assign(payload, performance.toJSON()));
-        asyncApiCall('write-to-log', {
-            level: 'info',
-            message: `[Performance] [${initialOptions.uuid} - ${initialOptions.name}]: ${JSON.stringify(performance)}`
+        deferByTick(() => {
+            let payload = {
+                name: initialOptions.name,
+                uuid: initialOptions.uuid
+            };
+            raiseEventSync(`window/performance-report/${initialOptions.uuid}-${initialOptions.name}`, Object.assign(payload, performance.toJSON()));
+            asyncApiCall('write-to-log', {
+                level: 'info',
+                message: `[Performance] [${initialOptions.uuid} - ${initialOptions.name}]: ${JSON.stringify(performance)}`
+            });
         });
     });
 

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -315,6 +315,17 @@
                 });
             });
         }
+
+        // Collect performance data and send it as an event
+        let payload = {
+            name: initialOptions.name,
+            uuid: initialOptions.uuid
+        };
+        raiseEventSync(`window/performance-report/${initialOptions.uuid}-${initialOptions.name}`, Object.assign(payload, performance.toJSON()));
+        asyncApiCall('write-to-log', {
+            level: 'info',
+            message: `[Performance] [${initialOptions.uuid} - ${initialOptions.name}]: ${JSON.stringify(performance)}`
+        });
     });
 
     // check if a license key is valid or not


### PR DESCRIPTION
#### Description of Change
Adds a `performance-report` event which provides timing and navigation data from Performance API.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] automated tests are added
- [x] relevant documentation is added
- [x] PR release notes describe the change in a way relevant to app-developers

Tests:
https://testing-dashboard.openfin.co/#/app/tests/5d167362cb360141a7dfe78e/edit
https://testing-dashboard.openfin.co/#/app/tests/5d16860dcb360141a7dfe78f/edit
https://testing-dashboard.openfin.co/#/app/tests/5d166f6fcb360141a7dfe78d/edit

#### Release Notes

Developers can subscribe to  `performance-report` event to benchmark window creation and conveniently collect data to analyze and track performance of their applications.

@rdepena @datamadic 