### PR TITLE
RVM-946 Adding GetInstalledRuntimes API

### DIFF
--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -301,6 +301,22 @@ export const System = {
             screenSaver: state.isScreenSaverRunning(),
         }, theme);
     },
+    getInstalledRuntimes: function(identity, callback, errorCallback) {
+        let getInstalledRuntimesOpts = {
+            sourceUrl: coreState.getConfigUrlByUuid(identity.uuid)
+        };
+
+        let handleResponse = function(dataObj) {
+            var failed = _.has(dataObj, 'time-to-live-expiration');
+            if (!failed) {
+                callback(dataObj.payload);
+            } else {
+                errorCallback(dataObj.payload);
+            }
+        };
+
+        rvmBus.getInstalledRuntimes(getInstalledRuntimesOpts, handleResponse);
+    },
     getLog: function(name, resolve) {
         // Prevent abuse of trying to read files with a path relative to cache directory
         var pathSafeName = path.basename(name);

--- a/src/browser/api_protocol/api_handlers/system.ts
+++ b/src/browser/api_protocol/api_handlers/system.ts
@@ -71,6 +71,7 @@ export const SystemApiMap: APIHandlerMap = {
     'get-focused-window': getFocusedWindow,
     'get-focused-external-window': getFocusedExternalWindow,
     'get-host-specs': { apiFunc: getHostSpecs, apiPath: '.getHostSpecs' },
+    'get-installed-runtimes': getInstalledRuntimes,
     'get-machine-id': { apiFunc: getMachineId, apiPath: '.getMachineId' },
     'get-min-log-level': getMinLogLevel,
     'get-monitor-info': { apiFunc: getMonitorInfo, apiPath: '.getMonitorInfo' },
@@ -448,6 +449,14 @@ function getRuntimeInfo(identity: Identity, message: APIMessage, ack: Acker, nac
 
 function getRvmInfo(identity: Identity, message: APIMessage, ack: Acker, nack: Nacker): void {
     System.getRvmInfo(identity, (data: any) => {
+        const dataAck = Object.assign({}, successAck);
+        dataAck.data = data;
+        ack(dataAck);
+    }, nack);
+}
+
+function getInstalledRuntimes(identity: Identity, message: APIMessage, ack: Acker, nack: Nacker) : void {
+    System.getInstalledRuntimes(identity, (data: any) => {
         const dataAck = Object.assign({}, successAck);
         dataAck.data = data;
         ack(dataAck);

--- a/src/browser/rvm/rvm_message_bus.ts
+++ b/src/browser/rvm/rvm_message_bus.ts
@@ -95,6 +95,11 @@ export interface AppCloseRequestedOptions {
     sourceUrl: string;
 }
 
+export interface GetInstalledRuntimesOptions {
+    uuid: string;
+    sourceUrl: string;
+}
+
 // topic: application (used only by the utils module)
 type getShortcutStateAction = 'get-shortcut-state';
 type setShortcutStateAction = 'set-shortcut-state';
@@ -174,6 +179,7 @@ export interface System extends RvmMsgBase {
     action: getRvmInfoAction;
     sourceUrl: string;
 }
+
 
 // topic: application-events -----
 type EventType = 'started'| 'closed' | 'ready' | 'run-requested' | 'crashed' | 'error' | 'not-responding';
@@ -398,7 +404,16 @@ export class RVMMessageBus extends EventEmitter  {
             }
         });
     }
-}
 
+    public getInstalledRuntimes(opts: GetInstalledRuntimesOptions, callback: (x: any) => any = () => undefined) {
+        const rvmPayload = {
+            topic: 'system',
+            action: 'get-installed-runtimes',
+            sourceUrl: opts.sourceUrl,
+            timeToLive: 5
+        };
+        this.publish(rvmPayload, callback);
+    }
+}
 const rvmMessageBus = new RVMMessageBus();
 export {rvmMessageBus};


### PR DESCRIPTION
Added API for user to query the RVM for the versions of all the runtimes installed. 
Compatible with RVM 5.2+

fin.system.getInstalledRuntimes( )
