### PR TITLE
Fix Channels API iFrame bug

### DIFF
--- a/src/browser/api/channel.ts
+++ b/src/browser/api/channel.ts
@@ -4,7 +4,7 @@ import ofEvents from '../of_events';
 import route from '../../common/route';
 import { AckFunc, NackFunc, AckMessage, AckPayload, NackPayload } from '../api_protocol/transport_strategy/ack';
 import { sendToIdentity } from '../api_protocol/api_handlers/api_protocol_base';
-import { getExternalOrOfWindowIdentity } from '../core_state';
+import { getEntityIdentity } from '../core_state';
 import SubscriptionManager from '../subscription_manager';
 
 const subscriptionManager = new SubscriptionManager();
@@ -79,7 +79,7 @@ export module Channel {
             throw new Error(nackString);
         }
 
-        const providerApp = getExternalOrOfWindowIdentity(identity);
+        const providerApp = getEntityIdentity(identity);
         const channelId = getChannelId(identity, channelName);
         const providerIdentity = { ...providerApp, channelName, channelId };
         channelMap.set(channelId, providerIdentity);
@@ -135,7 +135,7 @@ export module Channel {
     export function connectToChannel(identity: Identity, payload: any, messageId: number, ack: AckFunc, nack: NackFunc): void {
         const { channelName, payload: connectionPayload } = payload;
 
-        const connectingWindow = getExternalOrOfWindowIdentity(identity);
+        const connectingWindow = getEntityIdentity(identity);
         const providerIdentity = Channel.getChannelByChannelName(channelName);
 
         if (connectingWindow && connectingWindow.isExternal && connectionPayload && connectionPayload.nameAlias) {

--- a/src/browser/core_state.ts
+++ b/src/browser/core_state.ts
@@ -125,7 +125,7 @@ export function getEntityInfo(identity: Shapes.Identity) {
 }
 
 export function getExternalOrOfWindowIdentity(identity: Shapes.Identity): Shapes.ProviderIdentity|undefined {
-    const { uuid, name } = identity;
+    const { uuid, name, entityType, parentFrame } = identity;
     const externalConn = getExternalAppObjByUuid(uuid);
     if (externalConn) {
         return {...externalConn, isExternal: true };
@@ -135,6 +135,13 @@ export function getExternalOrOfWindowIdentity(identity: Shapes.Identity): Shapes
     const browserWindow = ofWindow && ofWindow.browserWindow;
     if (browserWindow && !browserWindow.isDestroyed()) {
         return { uuid, name, isExternal: false };
+    }
+
+    if (entityType && entityType === 'iframe' && parentFrame) {
+        const hostWindow = getWindowByUuidName(uuid, parentFrame);
+        if (hostWindow && !hostWindow.browserWindow.isDestroyed() && hostWindow.frames.has(name)) {
+            return { uuid, name, isExternal: false };
+        }
     }
 }
 
@@ -847,7 +854,7 @@ export function removeBrowserView (view: OfView) {
     views = views.filter(v => v.uuid !== view.uuid && v.name !== view.name);
 }
 export function getBrowserViewByIdentity({uuid, name}: Identity) {
-   return views.find(v => v.uuid === uuid && v.name === name);
+    return views.find(v => v.uuid === uuid && v.name === name);
 }
 function getBrowserViewByWebContentsId(webContentsId: number) {
     return views.find(v => v.view.webContents.id === webContentsId);

--- a/src/browser/core_state.ts
+++ b/src/browser/core_state.ts
@@ -124,7 +124,7 @@ export function getEntityInfo(identity: Shapes.Identity) {
     }
 }
 
-export function getExternalOrOfWindowIdentity(identity: Shapes.Identity): Shapes.ProviderIdentity|undefined {
+export function getEntityIdentity(identity: Shapes.Identity): Shapes.ProviderIdentity|undefined {
     const { uuid, name, entityType, parentFrame } = identity;
     const externalConn = getExternalAppObjByUuid(uuid);
     if (externalConn) {

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -15,6 +15,7 @@ export interface Identity {
     name?: string;
     runtimeUuid?: string;
     entityType?: EntityType;
+    parentFrame?: string;
 }
 
 export interface ProviderIdentity extends Identity {


### PR DESCRIPTION
The PR fixes a bug where if both channel provider creation and client connection happen in two different iframes of the same window, the provider promise resolves but the client promise never does.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR release notes describe the change in a way relevant to app-developers
- [x] PR has assigned reviewers

@rdepena @datamadic @dhamberlin 
#### Release Notes
This allows to create channels from iframe entities.
