### PR TITLE
RUN-5420: Keep reference to created context menu

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -10,6 +10,7 @@ let BrowserWindow = electron.BrowserWindow;
 let electronApp = electron.app;
 let Menu = electron.Menu;
 let nativeImage = electron.nativeImage;
+let currentContextMenu = null;
 
 // npm modules
 let _ = require('underscore');
@@ -1770,9 +1771,13 @@ Window.showMenu = function(identity, x, y, editable, hasSelectedText) {
         accelerator: 'CommandOrControl+Shift+I'
     });
 
-    const currentMenu = Menu.buildFromTemplate(menuTemplate);
-    currentMenu.popup(browserWindow, {
-        async: true
+    currentContextMenu = Menu.buildFromTemplate(menuTemplate);
+    currentContextMenu.popup({
+        window: browserWindow,
+        async: true,
+        callback: () => {
+            currentContextMenu = null;
+        }
     });
 };
 


### PR DESCRIPTION
Without it context menu will be destroyed after first launch of
javascript's garbage collector even when menu is still displayed.

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Pull Request process: https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [ ] manual tests are [changed or added](https://github.com/openfin/test_apps)
- [ ] relevant documentation is [changed or added](https://github.com/hadoukenio/js-adapter)
- [ ] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [ ] PR release notes describe the change in a way relevant to app-developers
- [ ] Link to new tests added
- [ ] PR has assigned reviewers


#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes. Examples and help on special cases: http://developer.openfin.co/versions/?product=Runtime&version=9.61.37.46 -->
