### PR TITLE
Run 5449/run 5192 multi browser view

### DIFF
--- a/src/browser/api/browser_view.ts
+++ b/src/browser/api/browser_view.ts
@@ -65,11 +65,9 @@ export async function attach(ofView: OfView, toIdentity: Identity) {
             throw new Error(`Could not locate target window ${toIdentity.uuid}/${toIdentity.name}`);
         }
         const bWin = ofWin.browserWindow;
-        ofWin.view = ofView;
         bWin.addBrowserView(view);
         const listener = () => {
             destroy(ofView);
-            ofWin.view = undefined;
             windowCloseListenerMap.delete(ofWin);
         };
         of_events.once(route.window('closed', toIdentity.uuid, toIdentity.name), listener);

--- a/src/browser/api/browser_view.ts
+++ b/src/browser/api/browser_view.ts
@@ -55,7 +55,9 @@ export async function attach(ofView: OfView, toIdentity: Identity) {
                 const oldwinMap = windowCloseListenerMap.get(oldWin);
                 if (oldwinMap) {
                     const listener = oldwinMap.get(ofView);
-                    of_events.removeListener(route.window('closed', ofView.target.uuid, ofView.target.name), listener);
+                    if (typeof listener === 'function') {
+                        of_events.removeListener(route.window('closed', ofView.target.uuid, ofView.target.name), listener);
+                    }
                     oldwinMap.delete(ofView);
                 }
             }

--- a/src/browser/api_protocol/api_handlers/browser_view.ts
+++ b/src/browser/api_protocol/api_handlers/browser_view.ts
@@ -1,8 +1,6 @@
 import * as apiProtocolBase from './api_protocol_base';
 import { ActionSpecMap } from '../shapes';
-import { Channel } from '../../api/channel';
-import { Identity, APIMessage, ProviderIdentity } from '../../../shapes';
-import { AckFunc, NackFunc } from '../transport_strategy/ack';
+import { Identity, APIMessage } from '../../../shapes';
 import * as browser_view from '../../api/browser_view';
 import { getBrowserViewByIdentity } from '../../core_state';
 
@@ -35,11 +33,26 @@ async function getInfo(identity: Identity, message: APIMessage) {
     const view = getBrowserViewByIdentity({ uuid, name });
     return browser_view.getInfo(view);
 }
+async function show(identity: Identity, message: APIMessage) {
+    const { payload } = message;
+    const { uuid, name } = payload;
+    const view = getBrowserViewByIdentity({ uuid, name });
+    await browser_view.show(view);
+    return successAck;
+} async function hide(identity: Identity, message: APIMessage) {
+    const { payload } = message;
+    const { uuid, name } = payload;
+    const view = getBrowserViewByIdentity({ uuid, name });
+    await browser_view.hide(view);
+    return successAck;
+}
 export const browserViewActionMap: ActionSpecMap = {
     'create-browser-view': create,
     'attach-browser-view': attach,
     'set-browser-view-bounds': setBounds,
-    'get-browser-view-info': getInfo
+    'get-browser-view-info': getInfo,
+    'hide-browser-view': hide,
+    'show-browser-view': show
 };
 
 export function init() {

--- a/src/browser/core_state.ts
+++ b/src/browser/core_state.ts
@@ -827,17 +827,24 @@ export interface OfView extends Identity {
     name: string;
     view: BrowserView;
     frames: Map<string, Shapes.ChildFrameInfo>;
+    target: Identity;
     _options: Shapes.WebOptions;
 }
 export function addBrowserView (opts: BrowserViewOpts, view: BrowserView) {
-    const {uuid, name} = opts;
-    const ofView = { frames: new Map(), uuid, _options: opts, name, view };
+    const {uuid, name, target} = opts;
+    const ofView = { frames: new Map(), uuid, _options: opts, name, view, target };
     views.push(ofView);
     const app = appByUuid(uuid);
     if (app) {
         app.views.push(ofView);
     }
     return ofView;
+}
+export function updateViewTarget(id: Identity, newTarget: Identity) {
+    const view = getBrowserViewByIdentity(id);
+    if (view) {
+        view.target = newTarget;
+    }
 }
 export function removeBrowserView (view: OfView) {
     const app = appByUuid(view.uuid);

--- a/src/browser/core_state.ts
+++ b/src/browser/core_state.ts
@@ -49,6 +49,7 @@ export const argv = app.getCommandLineArgv(); // arguments as an array
 export const argo = minimist(argv); // arguments as an object
 
 let apps: Shapes.App[] = [];
+let views: OfView[] = [];
 
 let startManifest = {};
 const manifests: Map <string, Shapes.Manifest> = new Map();
@@ -410,7 +411,9 @@ export function addApp(id: number, uuid: string): Shapes.App[] {
         id: id,
         isRunning: false,
         uuid,
-        views: [],
+        get views () {
+            return views.filter(v => v.uuid === uuid);
+        },
         // hide-splashscreen is sent to RVM on 1st window show &
         // immediately on subsequent app launches if already sent once
         sentHideSplashScreen: false
@@ -822,7 +825,6 @@ function getWinObjByWebcontentsId(webContentsId: number) {
     const win = getWinList().find(w => w.openfinWindow && w.openfinWindow.browserWindow.webContents.id === webContentsId);
     return win && win.openfinWindow;
 }
-let views: OfView[] = [];
 export interface OfView extends Identity {
     name: string;
     view: BrowserView;
@@ -834,10 +836,6 @@ export function addBrowserView (opts: BrowserViewOpts, view: BrowserView) {
     const {uuid, name, target} = opts;
     const ofView = { frames: new Map(), uuid, _options: opts, name, view, target };
     views.push(ofView);
-    const app = appByUuid(uuid);
-    if (app) {
-        app.views.push(ofView);
-    }
     return ofView;
 }
 export function updateViewTarget(id: Identity, newTarget: Identity) {
@@ -848,9 +846,6 @@ export function updateViewTarget(id: Identity, newTarget: Identity) {
 }
 export function removeBrowserView (view: OfView) {
     const app = appByUuid(view.uuid);
-    if (app) {
-        app.views = app.views.filter(v => v.name !== view.name);
-    }
     views = views.filter(v => v.uuid !== view.uuid && v.name !== view.name);
 }
 export function getBrowserViewByIdentity({uuid, name}: Identity) {

--- a/src/shapes.ts
+++ b/src/shapes.ts
@@ -87,7 +87,7 @@ export interface App {
     parentUuid?: string;
     sentHideSplashScreen: boolean;
     uuid: string;
-    views: OfView[];
+    readonly views: ReadonlyArray<OfView>;
 }
 
 export interface Window {
@@ -122,7 +122,6 @@ export interface OpenFinWindow extends InjectableContext {
     preloadScripts: PreloadScriptState[];
     mainFrameRoutingId: number;
     isProxy?: boolean;
-    view?: OfView;
 }
 
 export interface BrowserWindow extends BrowserWindowElectron {


### PR DESCRIPTION
#### Description of Change
Enable multiple browser views per window. Allow re-attaching views to different windows

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [ ] manual tests are [changed or added](https://github.com/openfin/test_apps)
- [ ] relevant documentation is [changed or added](https://github.com/hadoukenio/js-adapter)
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR release notes describe the change in a way relevant to app-developers
- [ ] Link to new tests added
- [ ] PR has assigned reviewers

[JS-adapter](https://github.com/HadoukenIO/js-adapter/pull/311)

#### Release Notes

Notes: Experimentally allow multiple browser views to be attached to one window.
