### PR TITLE
RUN-5420: Keep reference to created context menu (#870)

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -10,6 +10,7 @@ let BrowserWindow = electron.BrowserWindow;
 let electronApp = electron.app;
 let Menu = electron.Menu;
 let nativeImage = electron.nativeImage;
+let currentContextMenu = null;
 
 // npm modules
 let _ = require('underscore');
@@ -1774,9 +1775,13 @@ Window.showMenu = function(identity, x, y, editable, hasSelectedText) {
         accelerator: 'CommandOrControl+Shift+I'
     });
 
-    const currentMenu = Menu.buildFromTemplate(menuTemplate);
-    currentMenu.popup(browserWindow, {
-        async: true
+    currentContextMenu = Menu.buildFromTemplate(menuTemplate);
+    currentContextMenu.popup({
+        window: browserWindow,
+        async: true,
+        callback: () => {
+            currentContextMenu = null;
+        }
     });
 };
 


### PR DESCRIPTION
Without it context menu will be destroyed after first launch of
javascript's garbage collector even when menu is still displayed.

This is a backport of a fix from of-master.

