### PR TITLE
RUN-5461 - Window Restoration Regression

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -2475,7 +2475,10 @@ function restoreWindowPosition(identity, cb) {
             savedBounds.left = displayRoot.x;
         }
 
-        Window.setBounds(identity, savedBounds.left, savedBounds.top, savedBounds.width, savedBounds.height);
+        const browserWindow = getElectronBrowserWindow(identity);
+        const { left, right, width, height } = savedBounds;
+        NativeWindow.setBounds(browserWindow, { left, right, width, height });
+
         switch (savedBounds.windowState) {
             case 'maximized':
                 Window.maximize(identity);


### PR DESCRIPTION
#### Description of Change
Window.setbounds was throwing an error out in restorewindowstate as it was changed to require a callback function in v43.  Due to the error, it was not going through the windowstate and zoomlevel restoration.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x ] PR description included and stakeholders cc'd
- [  ] `npm test` passes
- [  ] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [ ] manual tests are [changed or added](https://github.com/openfin/test_apps) (need to add manual test??)
- [ ] relevant documentation is [changed or added](https://github.com/hadoukenio/js-adapter)
- [ x ] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [ ] PR release notes describe the change in a way relevant to app-developers
- [ ] Link to new tests added
- [ ] PR has assigned reviewers

