### PR TITLE
RUN-5461  - v43 regressions fix

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -2480,7 +2480,10 @@ function restoreWindowPosition(identity, cb) {
             savedBounds.left = displayRoot.x;
         }
 
-        Window.setBounds(identity, savedBounds.left, savedBounds.top, savedBounds.width, savedBounds.height);
+        const browserWindow = getElectronBrowserWindow(identity);
+        const { left, right, width, height } = savedBounds;
+        NativeWindow.setBounds(browserWindow, { left, right, width, height });
+
         switch (savedBounds.windowState) {
             case 'maximized':
                 Window.maximize(identity);

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -861,7 +861,8 @@ Window.create = function(id, opts) {
                 //if saveWindowState:false and autoShow:true and waitForPageLoad:false are present
                 //we show as soon as we restore the window position instead of waiting for the connected event
                 if (_options.autoShow && (!_options.waitForPageLoad)) {
-                    browserWindow.show();
+                    // Need to go through Window.show here so that the show-requested logic comes into play
+                    Window.show(identity);
                 }
             } else if (_options.waitForPageLoad) {
                 browserWindow.once('ready-to-show', () => {
@@ -872,7 +873,8 @@ Window.create = function(id, opts) {
                     //if autoShow:true and waitForPageLoad:false are present we show as soon as we restore the window position
                     //instead of waiting for the connected event
                     if (_options.autoShow) {
-                        browserWindow.show();
+                        // Need to go through Window.show here so that the show-requested logic comes into play
+                        Window.show(identity);
                     }
                     observer.next();
                 });

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -2483,8 +2483,8 @@ function restoreWindowPosition(identity, cb) {
         }
 
         const browserWindow = getElectronBrowserWindow(identity);
-        const { left, right, width, height } = savedBounds;
-        NativeWindow.setBounds(browserWindow, { left, right, width, height });
+        const { left, top, width, height } = savedBounds;
+        NativeWindow.setBounds(browserWindow, { left, top, width, height });
 
         switch (savedBounds.windowState) {
             case 'maximized':


### PR DESCRIPTION
#### Description of Change
Window.setbounds was throwing an error out in restorewindowstate as it was changed to require a callback function in v43.  Due to the error, it was not going through the windowstate and zoomlevel restoration.

And another one:
Using browserview.show instead of window.show goes around our show-requested logic that is in window.show.  In order to have the show-requested logic work correctly, use Window.show in window startup.  

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x ] PR description included and stakeholders cc'd
- [  ] `npm test` passes
- [  ] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [ ] manual tests are [changed or added](https://github.com/openfin/test_apps) (need to add manual test??)
- [ ] relevant documentation is [changed or added](https://github.com/hadoukenio/js-adapter)
- [ x ] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [ ] PR release notes describe the change in a way relevant to app-developers
- [ ] Link to new tests added
- [ ] PR has assigned reviewers

