### PR TITLE
RUN-5470 Join Group should Nack if given an "Native Window"

### DIFF
--- a/src/browser/api_protocol/api_handlers/external_window.ts
+++ b/src/browser/api_protocol/api_handlers/external_window.ts
@@ -123,11 +123,10 @@ async function isExternalWindowShowing(identity: Identity, message: APIMessage) 
   return ExternalWindow.isExternalWindowShowing(targetIdentity);
 }
 
-async function joinExternalWindowGroup(identity: Identity, message: APIMessage) {
-  const { payload } = message;
-  const targetIdentity = getTargetExternalWindowIdentity(payload);
-  const groupingIdentity = getGroupingWindowIdentity(payload);
-  return ExternalWindow.joinExternalWindowGroup(targetIdentity, groupingIdentity);
+async function joinExternalWindowGroup(identity: Identity, message: APIMessage, ack: any, nack: any) {
+  // nack if joining an ExternalWindow since certain methods don't work without injection
+  nack(new Error('Joining a group with an ExternalWindow is not supported'));
+  return;
 }
 
 async function leaveExternalWindowGroup(identity: Identity, message: APIMessage) {


### PR DESCRIPTION
As per https://appoji.jira.com/browse/RUN-5470 , we currently don't support grouping External Windows since some of the group move behaviors are currently undefined

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [x] relevant documentation is [changed or added](https://github.com/hadoukenio/js-adapter)
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR release notes describe the change in a way relevant to app-developers
- [x] Link to new tests added
- [x] PR has assigned reviewers

Test: https://testing-dashboard.openfin.co/#/app/tests/5d48431aa18af715bfcc7146/edit
Docs Update: https://github.com/HadoukenIO/js-adapter/pull/313

#### Release Notes

Notes: Joining groups with external windows is currently not supported

@rdepena @datamadic 