### PR TITLE
Run 5463 nwi api security

### DIFF
--- a/src/browser/api_protocol/api_handlers/external_window.ts
+++ b/src/browser/api_protocol/api_handlers/external_window.ts
@@ -25,7 +25,11 @@ export const ExternalWindowApiMap: APIHandlerMap = {
   'minimize-external-window': minimizeExternalWindow,
   'move-external-window-by': moveExternalWindowBy,
   'move-external-window': moveExternalWindow,
-  'register-native-external-window': registerNativeExternalWindow,
+  'register-native-external-window': {
+    apiFunc: registerNativeExternalWindow,
+    apiPath: '.registerNativeExternalWindow',
+    defaultPermission: false
+  },
   'resize-external-window-by': resizeExternalWindowBy,
   'resize-external-window': resizeExternalWindowTo,
   'restore-external-window': restoreExternalWindow,
@@ -42,7 +46,7 @@ export function init(): void {
     ? ExternalWindowApiMap
     : hijackMovesForGroupedWindows(ExternalWindowApiMap);
 
-  registerActionMap(registrationMap);
+  registerActionMap(registrationMap, 'ExternalWindow');
 }
 
 async function bringExternalWindowToFront(identity: Identity, message: APIMessage) {

--- a/src/browser/api_protocol/api_handlers/external_window.ts
+++ b/src/browser/api_protocol/api_handlers/external_window.ts
@@ -27,7 +27,7 @@ export const ExternalWindowApiMap: APIHandlerMap = {
   'move-external-window': moveExternalWindow,
   'register-native-external-window': {
     apiFunc: registerNativeExternalWindow,
-    apiPath: '.registerNativeExternalWindow',
+    apiPath: '.wrap',
     defaultPermission: false
   },
   'resize-external-window-by': resizeExternalWindowBy,
@@ -46,7 +46,7 @@ export function init(): void {
     ? ExternalWindowApiMap
     : hijackMovesForGroupedWindows(ExternalWindowApiMap);
 
-  registerActionMap(registrationMap);
+  registerActionMap(registrationMap, 'ExternalWindow');
 }
 
 async function bringExternalWindowToFront(identity: Identity, message: APIMessage) {

--- a/src/browser/api_protocol/api_handlers/external_window.ts
+++ b/src/browser/api_protocol/api_handlers/external_window.ts
@@ -46,7 +46,7 @@ export function init(): void {
     ? ExternalWindowApiMap
     : hijackMovesForGroupedWindows(ExternalWindowApiMap);
 
-  registerActionMap(registrationMap, 'ExternalWindow');
+  registerActionMap(registrationMap);
 }
 
 async function bringExternalWindowToFront(identity: Identity, message: APIMessage) {

--- a/src/browser/api_protocol/api_handlers/system.ts
+++ b/src/browser/api_protocol/api_handlers/system.ts
@@ -58,7 +58,11 @@ export const SystemApiMap: APIHandlerMap = {
     'generate-guid': generateGuid,
     'get-all-applications': getAllApplications,
     'get-all-external-applications': getAllExternalApplications,
-    'get-all-external-windows': getAllExternalWindows,
+    'get-all-external-windows': {
+        apiFunc: getAllExternalWindows,
+        apiPath: '.getAllExternalWindows',
+        defaultPermission: false
+    },
     'get-all-windows': getAllWindows,
     'get-app-asset-info': getAppAssetInfo,
     'get-command-line-arguments': { apiFunc: getCommandLineArguments, apiPath: '.getCommandLineArguments' },


### PR DESCRIPTION
#### Description of Change
Jira: https://appoji.jira.com/browse/RUN-5463

This change places `System.getAllExternalWindows` and `ExternalWindow.wrap` (sent to core as `register-native-external-window`) behind API security. I've opted to just place these two methods behind security in the interest of simplicity / ease of use:
- These are the two entry points to "doing stuff with native windows". If both are disallowed, it should, to the best of my analysis, be impossible to get info about or do anything to non-OpenFin windows.
- Current changeset uses the same exact flow as other restricted API methods, so we don't need extra explanation or code to make it work. (As opposed to an `ExternalWindow`-level boolean setting, which would require additional code changes and counterintuitively also control `System.getAllExternalWindows`)

@aziz512 (tagging you cause github won't let me assign you as a reviewer)

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard) PENDING WILL UPDATE SHORTLY
- [ ] relevant documentation is [changed or added](https://github.com/hadoukenio/js-adapter) PENDING WILL UPDATE SHORTLY
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR release notes describe the change in a way relevant to app-developers
- [x] PR has assigned reviewers
- [ ] Relevant changes to schemastore JSON schema submitted - PENDING


#### Release Notes

Notes: ExternalWindow functionality has been placed behind API security. To allow its use, `System.getAllExternalWindows` and `ExternalWindow.wrap` should be enabled via desktop owner settings or app manifest. 
