### PR TITLE
RUN-5456 There’s no way of programmatically telling if a window has enabled or disabled user movement

### DIFF
--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -1308,8 +1308,11 @@ Window.getGroup = function(identity) {
 Window.getWindowInfo = function(identity) {
     const browserWindow = getElectronBrowserWindow(identity, 'get info for');
     const { preloadScripts } = Window.wrap(identity.uuid, identity.name);
+    const windowKey = genWindowKey(identity);
+    const isUserMovementEnabled = !disabledFrameRef.has(windowKey) || disabledFrameRef.get(windowKey) === 0;
     const windowInfo = Object.assign({
         preloadScripts,
+        isUserMovementEnabled
     }, WebContents.getInfo(browserWindow.webContents));
     return windowInfo;
 };


### PR DESCRIPTION
#### Description of Change
The PR adds a `isUserMovementEnabled` bool field to `window.getInfo()` for users to be able to tell programmatically whether user movement is enabled

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [x] relevant documentation is [changed or added](https://github.com/hadoukenio/js-adapter)
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR release notes describe the change in a way relevant to app-developers
- [x] Link to new tests added
- [x] PR has assigned reviewers

Test: https://testing-dashboard.openfin.co/#/app/tests/5d48843a394bc65e455b9a6e/edit
Docs update: https://github.com/HadoukenIO/js-adapter/pull/315

#### Release Notes

Notes: Added `isUserMovementEnabled` property to `window.getInfo()` that allows to programmatically discover whether user movement is enabled

@rdepena @tgoc99 @pbaize @datamadic 