### PR TITLE
RUN-5206 Set up webcontents eventing

### DIFF
--- a/src/browser/api/webcontents.ts
+++ b/src/browser/api/webcontents.ts
@@ -1,4 +1,60 @@
 import * as url from 'url';
+import { Identity } from '../../shapes';
+import of_events from '../of_events';
+import { WindowRoute } from '../../common/route';
+
+export function hookWebContentsEvents(webContents: Electron.WebContents, { uuid, name }: Identity, topic: string, route: WindowRoute) {
+    webContents.on('did-get-response-details', (e,
+        status,
+        newUrl,
+        originalUrl,
+        httpResponseCode,
+        requestMethod,
+        referrer,
+        headers,
+        resourceType
+    ) => {
+        const type = 'resource-response-received';
+
+        const payload = {
+            name,
+            uuid,
+            topic,
+            type,
+            status,
+            newUrl,
+            originalUrl,
+            httpResponseCode,
+            requestMethod,
+            referrer,
+            headers,
+            resourceType
+        };
+        of_events.emit(route(type, uuid, name), payload);
+    });
+    webContents.on('did-fail-load', (e,
+        errorCode,
+        errorDescription,
+        validatedURL,
+        isMainFrame
+    ) => {
+        const type = 'resource-load-failed';
+        const payload = {
+            name,
+            uuid,
+            topic,
+            type,
+            errorCode,
+            errorDescription,
+            validatedURL,
+            isMainFrame
+        };
+        of_events.emit(route(type, uuid, name), payload);
+    });
+    webContents.once('destroyed', () => {
+        webContents.removeAllListeners();
+    });
+}
 
 export function executeJavascript(webContents: Electron.WebContents, code: string, callback: (e: any, result: any) => void): void {
     webContents.executeJavaScript(code, true, (result) => {
@@ -17,10 +73,10 @@ export function getInfo(webContents: Electron.WebContents) {
 
 export function getAbsolutePath(webContents: Electron.WebContents, path: string) {
     const windowURL = webContents.getURL();
-    return  url.resolve(windowURL, path);
+    return url.resolve(windowURL, path);
 }
 
-export function navigate (webContents: Electron.WebContents, url: string) {
+export function navigate(webContents: Electron.WebContents, url: string) {
     // todo: replace everything here with "return webContents.loadURL(url)" once we get to electron 5.*
     // reason: starting electron v5, loadUrl returns a promise that resolves according to the same logic we apply here
     const navigationEnd = createNavigationEndPromise(webContents);
@@ -28,13 +84,13 @@ export function navigate (webContents: Electron.WebContents, url: string) {
     return navigationEnd;
 }
 
-export async function navigateBack (webContents: Electron.WebContents) {
+export async function navigateBack(webContents: Electron.WebContents) {
     const navigationEnd = createNavigationEndPromise(webContents);
     webContents.goBack();
     return navigationEnd;
 }
 
-export async function navigateForward (webContents: Electron.WebContents) {
+export async function navigateForward(webContents: Electron.WebContents) {
     const navigationEnd = createNavigationEndPromise(webContents);
     webContents.goForward();
     return navigationEnd;

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -118,16 +118,6 @@ let browserWindowEventMap = {
     // }
 };
 
-let webContentsEventMap = {
-    'did-get-response-details': {
-        topic: 'resource-response-received',
-        decorator: responseReceivedDecorator
-    },
-    'did-fail-load': {
-        topic: 'resource-load-failed',
-        decorator: loadFailedDecorator
-    }
-};
 
 function genWindowKey(identity) {
     return `${identity.uuid}-${identity.name}`;
@@ -571,10 +561,6 @@ Window.create = function(id, opts) {
             ofEvents.emit(route.window(type, uuid, name), { topic: 'window', type: type, uuid, name });
         });
 
-        webContents.once('close', () => {
-            webContents.removeAllListeners();
-        });
-
         const isMainWindow = (uuid === name);
         const emitToAppIfMainWin = (type, payload) => {
             // Window crashed: inform Window "namespace"
@@ -675,8 +661,7 @@ Window.create = function(id, opts) {
         };
 
         mapEvents(browserWindowEventMap, browserWindow);
-        mapEvents(webContentsEventMap, webContents);
-
+        WebContents.hookWebContentsEvents(webContents, { uuid, name }, 'window', route.window);
         // hideOnClose is deprecated; treat it as if it's just another
         // listener on the 'close-requested' event
         if (getOptFromBrowserWin('hideOnClose', browserWindow, false)) {
@@ -2260,53 +2245,7 @@ function visibilityChangedDecorator(payload, args) {
     return propogate;
 }
 
-function responseReceivedDecorator(payload, args) {
-    var [
-        /*event*/
-        ,
-        status,
-        newUrl,
-        originalUrl,
-        httpResponseCode,
-        requestMethod,
-        referrer,
-        headers,
-        resourceType
-    ] = args;
 
-    Object.assign(payload, {
-        status,
-        newUrl,
-        originalUrl,
-        httpResponseCode,
-        requestMethod,
-        referrer,
-        headers,
-        resourceType
-    });
-
-    return true;
-}
-
-function loadFailedDecorator(payload, args) {
-    var [
-        /*event*/
-        ,
-        errorCode,
-        errorDescription,
-        validatedURL,
-        isMainFrame
-    ] = args;
-
-    Object.assign(payload, {
-        errorCode,
-        errorDescription,
-        validatedURL,
-        isMainFrame
-    });
-
-    return true;
-}
 
 function noOpDecorator( /*payload*/ ) {
 


### PR DESCRIPTION
#### Description of Change
Sets up webcontents event hooks for browserview

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [ ] manual tests are [changed or added](https://github.com/openfin/test_apps)
- [ ] relevant documentation is [changed or added](https://github.com/hadoukenio/js-adapter)
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR release notes describe the change in a way relevant to app-developers
- [ ] Link to new tests added
- [x] PR has assigned reviewers


#### Release Notes

Notes: n/a experimental