### PR TITLE
RUN-5472 - Application creation / run timing issue

### DIFF
--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -749,10 +749,9 @@ function run(identity, mainWindowOpts, userAppConfigArgs) {
     const { preloadScripts } = mainWindowOpts;
     const loadUrl = () => {
         app.mainWindow.loadURL(app._options.url);
-        coreState.setAppRunningState(uuid, true);
         ofEvents.emit(route.application('started', uuid), { topic: 'application', type: 'started', uuid });
     };
-
+    coreState.setAppRunningState(uuid, true);
     if (isValidChromePageUrl(app._options.url) || appWasAlreadyRunning) {
         loadUrl();
         // no API injection for chrome pages, so call .show here


### PR DESCRIPTION
#### Description of Change
When an app has preload scripts there is a chance for a timing issue on app creation / run.  The app is not set to running in corestate until after the downloading of the preload scripts.  In the app.create call, we check for app.isRunning, which synchronously will be true if there are no preload scripts.  If preloads need to be downloaded, however, it creates an async call where another app.create call can jump in. 

Example flow for bug:
1.) App1 create, and run.  main window of app1 is created, then preload scripts are downloaded.
2.) While waiting for the preload scripts promise to resolve, create app for "app2" with same uuid is called.  Since app1 is not yet "running" (not set to true until after preloads d/l), app1 is overwritten in corestate by app2 and the mainWindow created in the run call for app1 is now orphaned and not connected to the app in corestate.  After preloads download, app is running is set to true and the second run call nacks as expected.
3.) the mainWindow logic gets messed up and the main window is detached from the app in corestate so it can't be found in any API calls.  

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x ] PR description included and stakeholders cc'd
- [ x ] `npm test` passes
- [ x ] automated tests are [added](https://testing-dashboard.openfin.co/#/app/tests/5d49c259394bc65e455b9a93/edit)
- [ x ] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [ x ] PR release notes describe the change in a way relevant to app-developers
- [ x ] [Link to new tests added](https://testing-dashboard.openfin.co/#/app/tests/5d49c259394bc65e455b9a93/edit)
- [ x ] PR has assigned reviewers


#### Release Notes

Notes: Fixed timing issue when creating and running applications with the same UUID.
