### PR TITLE
RUN-5475 - Expose Electron's Window Centering API

### DIFF
--- a/src/browser/api/native_window.ts
+++ b/src/browser/api/native_window.ts
@@ -12,6 +12,10 @@ export function bringToFront(browserWindow: BrowserWindow): void {
   browserWindow.bringToFront();
 }
 
+export function center(browserWindow: BrowserWindow): void {
+    browserWindow.center();
+}
+
 export function close(browserWindow: BrowserWindow): void {
   browserWindow.close();
 }

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -1098,6 +1098,14 @@ Window.bringToFront = function(identity) {
     NativeWindow.bringToFront(browserWindow);
 };
 
+Window.center = function(identity) {
+    const browserWindow = getElectronBrowserWindow(identity);
+    if (!browserWindow) {
+        return;
+    }
+    NativeWindow.center(browserWindow);
+};
+
 
 // TODO investigate the close sequence, there appears to be a case were you
 // try to wrap and close an already closed window

--- a/src/browser/api_protocol/api_handlers/window.ts
+++ b/src/browser/api_protocol/api_handlers/window.ts
@@ -26,6 +26,7 @@ export const windowApiMap = {
     'animate-window': animateWindow,
     'blur-window': blurWindow,
     'bring-window-to-front': bringWindowToFront,
+    'center-window': centerWindow,
     'close-window': closeWindow,
     'disable-window-frame': disableUserMovement,
     'dock-window': dockWindow,
@@ -464,5 +465,13 @@ function registerWindowName(identity: Identity, message: APIMessage, ack: Acker)
     const windowIdentity = getTargetWindowIdentity(payload);
 
     Window.registerWindowName(windowIdentity);
+    ack(successAck);
+}
+
+function centerWindow(identity: Identity, message: APIMessage, ack: Acker): void {
+    const { payload } = message;
+    const windowIdentity = getTargetWindowIdentity(payload);
+
+    Window.center(windowIdentity);
     ack(successAck);
 }


### PR DESCRIPTION
#### Description of Change

Expose Electron's BrowserWindow.center
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Pull Request process: https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included and stakeholders cc'd
- [X] `npm test` passes
- [X] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [X] relevant documentation is [changed or added](https://github.com/hadoukenio/js-adapter)
- [X] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [X] PR release notes describe the change in a way relevant to app-developers
- [X] Link to new tests added
- [X] PR has assigned reviewers


#### Release Notes

Added API to center windows

Notes: <!-- Please add a one-line description for app developers to read in the release notes. Examples and help on special cases: http://developer.openfin.co/versions/?product=Runtime&version=9.61.37.46 -->