### PR TITLE
fix(api-decorator): Make 'window/performance-report' ASYNC. 

### DIFF
--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -153,6 +153,13 @@
         });
     }
 
+    function raiseEventAsync(eventName, eventArgs) {
+        return asyncApiCall('raise-event', {
+            eventName,
+            eventArgs
+        });
+    }
+
     ///THESE CALLS NEED TO BE DONE WITH REMOTE, AS THEY ARE DONE BEFORE THE CORE HAS ID's
     function getWindowId() {
         if (!windowId) {
@@ -328,7 +335,7 @@
                 name: initialOptions.name,
                 uuid: initialOptions.uuid
             };
-            raiseEventSync(`window/performance-report/${initialOptions.uuid}-${initialOptions.name}`, Object.assign(payload, performance.toJSON()));
+            raiseEventAsync(`window/performance-report/${initialOptions.uuid}-${initialOptions.name}`, Object.assign(payload, performance.toJSON()));
             asyncApiCall('write-to-log', {
                 level: 'info',
                 message: `[Performance] [${initialOptions.uuid} - ${initialOptions.name}]: ${JSON.stringify(performance)}`


### PR DESCRIPTION
Sync calls on window load are known to introduce a race condition with MOJO

General testing has been performed while investigating a MOJO timing issue introduced with Electron v5
