### PR TITLE
RUN-5414 browser process not exit when starting an app with duplicate UUID 

### DIFF
--- a/index.js
+++ b/index.js
@@ -641,10 +641,6 @@ function launchApp(argo, startExternalAdapterServer) {
                 deleteApp(uuid);
                 duplicateUuidTransport.broadcast({ argv, uuid });
                 failedMutexCheck = true;
-                // close the runtime if it's only app
-                if (coreState.shouldCloseRuntime()) {
-                    app.quit();
-                }
             } else {
                 passedMutexCheck = true;
             }
@@ -663,6 +659,12 @@ function launchApp(argo, startExternalAdapterServer) {
                 '',
                 argo['user-app-config-args']
             );
+        } else {
+            // close the runtime if it's only app
+            if (coreState.shouldCloseRuntime()) {
+                app.quit();
+                return;
+            }
         }
 
         if (startExternalAdapterServer && successfulInitialLaunch) {

--- a/index.js
+++ b/index.js
@@ -641,6 +641,10 @@ function launchApp(argo, startExternalAdapterServer) {
                 deleteApp(uuid);
                 duplicateUuidTransport.broadcast({ argv, uuid });
                 failedMutexCheck = true;
+                // close the runtime if it's only app
+                if (coreState.shouldCloseRuntime()) {
+                    app.quit();
+                }
             } else {
                 passedMutexCheck = true;
             }


### PR DESCRIPTION
This PR is to fix the browser process not exiting issue when starting another app with duplicate uuid in different runtime. 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR release notes describe the change in a way relevant to app-developers
- [x] PR has assigned reviewers


#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes. Examples and help on special cases: http://developer.openfin.co/versions/?product=Runtime&version=9.61.37.46 -->
