### PR TITLE
RUN-5503 Should also check external connection with duplicate UUID

### DIFF
--- a/index.js
+++ b/index.js
@@ -649,6 +649,13 @@ function launchApp(argo, startExternalAdapterServer) {
                 });
                 duplicateUuidTransport.broadcast({ argv: newArgv, uuid });
                 failedMutexCheck = true;
+
+                // close the runtime if it's only app.
+                if (coreState.shouldCloseRuntime()) {
+                    app.quit();
+                    return;
+                }
+
             } else {
                 passedMutexCheck = true;
             }
@@ -667,12 +674,6 @@ function launchApp(argo, startExternalAdapterServer) {
                 '',
                 argo['user-app-config-args']
             );
-        } else {
-            // close the runtime if it's only app
-            if (coreState.shouldCloseRuntime()) {
-                app.quit();
-                return;
-            }
         }
 
         if (startExternalAdapterServer && successfulInitialLaunch) {

--- a/src/browser/api_protocol/api_handlers/application.js
+++ b/src/browser/api_protocol/api_handlers/application.js
@@ -16,6 +16,7 @@ import { lockUuid } from '../../uuid_availability';
 import duplicateUuidTransport from '../../duplicate_uuid_delegation';
 import { writeToLog } from '../../log';
 import { WINDOWS_MESSAGE_MAP } from '../../../common/windows_messages';
+import { ExternalApplication } from '../../api/external_application';
 
 const SetWindowPosition = {
     SWP_HIDEWINDOW: 0x0080,
@@ -336,7 +337,7 @@ function runApplication(identity, message, ack, nack) {
         className: 'window',
         eventName: 'fire-constructor-callback'
     };
-    if (coreState.getAppRunningState(uuid)) {
+    if (coreState.getAppRunningState(uuid) || ExternalApplication.getExternalConnectionByUuid(uuid)) {
         Application.emitRunRequested(appIdentity);
         nack(`Application with specified UUID is already running: ${uuid}`);
         return;


### PR DESCRIPTION
This PR fixes two issues:
1) Check if external connection exists when run an app. Otherwise it will cause promise pending. 
2) uuid could be undefined in launchApp when calling launchAndConnect in node adapter. 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR release notes describe the change in a way relevant to app-developers
- [x] PR has assigned reviewers


#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes. Examples and help on special cases: http://developer.openfin.co/versions/?product=Runtime&version=9.61.37.46 -->
