### PR TITLE
RUN-5507 Switch to using webcontents id rather than browserwindow id

### DIFF
--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -22,7 +22,7 @@ let _ = require('underscore');
 let System = require('./system.js').System;
 import { Window } from './window';
 let convertOpts = require('../convert_options.js');
-let coreState = require('../core_state.js');
+import * as coreState from '../core_state';
 let externalApiBase = require('../api_protocol/api_handlers/api_protocol_base');
 import { cachedFetch, fetchReadFile } from '../cached_resource_fetcher';
 import ofEvents from '../of_events';
@@ -1163,7 +1163,7 @@ function createAppObj(uuid, opts, configUrl = '') {
 
         appObj.mainWindow = new BrowserWindow(eOpts);
         appObj.mainWindow.setFrameConnectStrategy(eOpts.frameConnect || 'last');
-        appObj.id = appObj.mainWindow.id;
+        appObj.id = appObj.mainWindow.webContents.id;
 
         appObj.mainWindow.webContents.on('did-fail-load', (event, errorCode, errorDescription, validatedUrl, isMainFrame) => {
             if (isMainFrame) {

--- a/src/browser/api/file_download.ts
+++ b/src/browser/api/file_download.ts
@@ -125,8 +125,8 @@ export function createWillDownloadEventListener(identity: Identity): (event: any
                     );
 
                     const fileDownloadBrowserWindow = BrowserWindow.fromWebContents(webContents);
-                    const browserWindowId = fileDownloadBrowserWindow.id;
-                    const { url: urlFromDownloadWindow } = <WindowOptions> coreState.getWindowOptionsById(browserWindowId);
+                    const webcontentsId = webContents.id;
+                    const { url: urlFromDownloadWindow } = <WindowOptions> coreState.getWindowOptionsById(webcontentsId);
 
                     // Windows that are created from a window.open that trigger a file download have their url set to
                     // "" here no matter what the requested url was. This is not true if the file download was triggered

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -1317,13 +1317,6 @@ Window.getOptions = function(identity) {
     }
 };
 
-Window.getParentApplication = function() {
-    let app = coreState.getAppByWin(this.id);
-
-    return app && app.appObj;
-};
-
-
 Window.getParentWindow = function() {};
 
 /**

--- a/src/browser/api/window.js
+++ b/src/browser/api/window.js
@@ -8,6 +8,7 @@ let path = require('path');
 let electron = require('electron');
 let BrowserWindow = electron.BrowserWindow;
 let electronApp = electron.app;
+const webContents = electron.webContents;
 let Menu = electron.Menu;
 let nativeImage = electron.nativeImage;
 let currentContextMenu = null;
@@ -22,7 +23,7 @@ import animations from '../animations';
 import { deletePendingAuthRequest, getPendingAuthRequest } from '../authentication_delegate';
 import BoundsChangedStateTracker from '../bounds_changed_state_tracker';
 let convertOptions = require('../convert_options.js');
-let coreState = require('../core_state.js');
+import * as coreState from '../core_state';
 import ExternalWindowEventAdapter from '../external_window_event_adapter';
 import { cachedFetch } from '../cached_resource_fetcher';
 let log = require('../log');
@@ -410,7 +411,7 @@ Window.create = function(id, opts) {
     };
     let baseOpts;
     let browserWindow;
-    let webContents;
+    let winWebContents;
     let _options;
     let _boundsChangedHandler;
     let groupUuid = null; // windows by default don't belong to any groups
@@ -442,9 +443,8 @@ Window.create = function(id, opts) {
     // grab the browser window instance because it may not exist, or
     // perhaps just try ...
     if (!opts._noregister) {
-
-        browserWindow = BrowserWindow.fromId(id);
-        webContents = browserWindow.webContents;
+        winWebContents = webContents.fromId(id);
+        browserWindow = BrowserWindow.fromWebContents(winWebContents);
 
         //Legacy 5.0 feature, if customWindowAlert flag is found all alerts will be suppresed,
         //instead we will raise application event : 'window-alert-requested'.
@@ -540,8 +540,8 @@ Window.create = function(id, opts) {
             ofEvents.emit(route.window(type, uuid, name), { topic: 'window', type: type, uuid, name });
         });
 
-        webContents.once('close', () => {
-            webContents.removeAllListeners();
+        winWebContents.once('close', () => {
+            winWebContents.removeAllListeners();
         });
 
         const isMainWindow = (uuid === name);
@@ -555,7 +555,7 @@ Window.create = function(id, opts) {
             }
         };
 
-        webContents.on('crashed', (event, killed, terminationStatus) => {
+        winWebContents.on('crashed', (event, killed, terminationStatus) => {
             emitToAppIfMainWin('crashed', {
                 reason: terminationStatus
             });
@@ -644,7 +644,7 @@ Window.create = function(id, opts) {
         };
 
         mapEvents(browserWindowEventMap, browserWindow);
-        mapEvents(webContentsEventMap, webContents);
+        mapEvents(webContentsEventMap, winWebContents);
 
         // hideOnClose is deprecated; treat it as if it's just another
         // listener on the 'close-requested' event
@@ -691,7 +691,7 @@ Window.create = function(id, opts) {
 
         // will-navigate URL for white/black listing
         const navValidator = navigationValidator(uuid, name, id);
-        validateNavigation(webContents, identity, navValidator);
+        validateNavigation(winWebContents, identity, navValidator);
 
         let startLoadingSubscribe = (event, url) => {
             ofEvents.emit(route.application('window-start-load', uuid), {
@@ -701,9 +701,9 @@ Window.create = function(id, opts) {
             });
         };
         let startLoadingString = 'did-start-loading';
-        webContents.on(startLoadingString, startLoadingSubscribe);
+        winWebContents.on(startLoadingString, startLoadingSubscribe);
         let startLoadingUnsubscribe = () => {
-            webContents.removeListener(startLoadingString, startLoadingSubscribe);
+            winWebContents.removeListener(startLoadingString, startLoadingSubscribe);
         };
         subscriptionManager.registerSubscription(startLoadingUnsubscribe, identity, startLoadingString);
 
@@ -722,9 +722,9 @@ Window.create = function(id, opts) {
             });
         };
         let documentLoadedString = 'document-loaded';
-        webContents.on(documentLoadedString, documentLoadedSubscribe);
+        winWebContents.on(documentLoadedString, documentLoadedSubscribe);
         let documentLoadedUnsubscribe = () => {
-            webContents.removeListener(documentLoadedString, documentLoadedSubscribe);
+            winWebContents.removeListener(documentLoadedString, documentLoadedSubscribe);
         };
         subscriptionManager.registerSubscription(documentLoadedUnsubscribe, identity, documentLoadedString);
 
@@ -776,8 +776,8 @@ Window.create = function(id, opts) {
         //Legacy logic where we wait for the API to 'connect' before we invoke the callback method.
         const apiInjectionObserver = Rx.Observable.create((observer) => {
             if (opts.url === 'about:blank') {
-                webContents.once('did-finish-load', () => {
-                    webContents.on(OF_WINDOW_UNLOADED, ofUnloadedHandler);
+                winWebContents.once('did-finish-load', () => {
+                    winWebContents.on(OF_WINDOW_UNLOADED, ofUnloadedHandler);
                     constructorCallbackMessage.data = {
                         httpResponseCode
                     };
@@ -788,7 +788,7 @@ Window.create = function(id, opts) {
                 ofEvents.once(resourceResponseReceivedEventString, resourceResponseReceivedHandler);
                 ofEvents.once(resourceLoadFailedEventString, resourceLoadFailedHandler);
                 ofEvents.once(route.window('connected', uuid, name), () => {
-                    webContents.on(OF_WINDOW_UNLOADED, ofUnloadedHandler);
+                    winWebContents.on(OF_WINDOW_UNLOADED, ofUnloadedHandler);
                     constructorCallbackMessage.data = {
                         httpResponseCode,
                         apiInjected: true
@@ -956,7 +956,7 @@ Window.create = function(id, opts) {
         }, 1);
     };
 
-    webContents.on('console-message', prepareConsoleMessageForRVM);
+    winWebContents.on('console-message', prepareConsoleMessageForRVM);
 
     // Set preload scripts' final loading states
     winObj.preloadScripts = (_options.preloadScripts || []);
@@ -1519,7 +1519,7 @@ Window.stopNavigation = function(identity) {
 
 Window.removeEventListener = function(identity, type, listener) {
     let browserWindow = getElectronBrowserWindow(identity, 'remove event listener for');
-    ofEvents.removeListener(route.window(type, browserWindow.id), listener);
+    ofEvents.removeListener(route.window(type, browserWindow.webContents.id), listener);
 };
 
 function areNewBoundsWithinConstraints(options, width, height) {
@@ -2312,7 +2312,7 @@ function setTaskbar(browserWindow, forceFetch = false) {
         setTaskbarIcon(browserWindow, _url, () => {
             if (!browserWindow.isDestroyed()) {
                 // if not, try using the main window's icon
-                setTaskbarIcon(browserWindow, getMainWinIconUrl(browserWindow.id));
+                setTaskbarIcon(browserWindow, getMainWinIconUrl(browserWindow.webContents.id));
             }
         });
 
@@ -2335,7 +2335,7 @@ function setTaskbar(browserWindow, forceFetch = false) {
                 setTaskbarIcon(browserWindow, _url, () => {
                     if (!browserWindow.isDestroyed()) {
                         // if not, try using the main window's icon
-                        setTaskbarIcon(browserWindow, getMainWinIconUrl(browserWindow.id));
+                        setTaskbarIcon(browserWindow, getMainWinIconUrl(browserWindow.webContents.id));
                     }
                 });
             }
@@ -2347,7 +2347,7 @@ function setTaskbar(browserWindow, forceFetch = false) {
         setTaskbarIcon(browserWindow, getWinOptsIconUrl(options), () => {
             if (!browserWindow.isDestroyed()) {
                 // if not, try using the main window's icon
-                setTaskbarIcon(browserWindow, getMainWinIconUrl(browserWindow.id));
+                setTaskbarIcon(browserWindow, getMainWinIconUrl(browserWindow.webContents.id));
             }
         });
     }
@@ -2391,7 +2391,8 @@ function getWinOptsIconUrl(options) {
 
 //This is a legacy 5.0 feature used from embedded.
 function handleCustomAlerts(id, opts) {
-    let browserWindow = BrowserWindow.fromId(id);
+    const wc = webContents.fromId(id);
+    let browserWindow = BrowserWindow.fromWebContents(wc);
     let subTopic = 'alert';
     let type = 'window-alert-requested';
     let topic = 'application';

--- a/src/browser/api_protocol/api_handlers/api_policy_processor.ts
+++ b/src/browser/api_protocol/api_handlers/api_policy_processor.ts
@@ -1,6 +1,6 @@
 
 import { MessagePackage } from '../transport_strategy/api_transport_base';
-const coreState = require('../../core_state');
+import * as coreState from '../../core_state';
 import { getDefaultRequestHandler, actionMap } from './api_protocol_base';
 import {ApiPath, ApiPolicyDelegate, Endpoint} from '../shapes';
 import {OpenFinWindow} from '../../../shapes';
@@ -238,7 +238,7 @@ function apiPolicyPreProcessor(msg: MessagePackage, next: () => void): void {
 
         writeToLog(1, `apiPolicyPreProcessor ${logSuffix}`, true);
 
-        let originWindow : OpenFinWindow = coreState.getWindowByUuidName(uuid, name);
+        let originWindow = coreState.getWindowByUuidName(uuid, name);
         if (!originWindow && identity.entityType === 'iframe') {
             const info = coreState.getInfoByUuidFrame(identity);
             if (info && info.parent) {
@@ -249,7 +249,8 @@ function apiPolicyPreProcessor(msg: MessagePackage, next: () => void): void {
             const appObject = coreState.getAppByUuid(uuid);
             // parentUuid for child windows is uuid of the app
             const parentUuid = uuid === name ? appObject.parentUuid : uuid;
-            authorizeActionFromPolicy(coreState.getWindowOptionsById(originWindow.id), action, payload).
+            const windowId = originWindow.id;
+            authorizeActionFromPolicy(coreState.getWindowOptionsById(windowId), action, payload).
               then((result: POLICY_AUTH_RESULT) => {
                 if (result === POLICY_AUTH_RESULT.Denied) {
                     writeToLog(1, `apiPolicyPreProcessor rejecting from policy ${logSuffix}`, true);
@@ -258,7 +259,7 @@ function apiPolicyPreProcessor(msg: MessagePackage, next: () => void): void {
                     if (result === POLICY_AUTH_RESULT.Allowed) {
                         writeToLog(1, `apiPolicyPreProcessor allowed from policy, still need to check window options ${logSuffix}`, true);
                     }
-                    if (authorizeActionFromWindowOptions(coreState.getWindowOptionsById(originWindow.id), parentUuid, action, payload)) {
+                    if (authorizeActionFromWindowOptions(coreState.getWindowOptionsById(windowId), parentUuid, action, payload)) {
                         next();
                     } else {
                         writeToLog(1, `apiPolicyPreProcessor rejecting from win opts ${logSuffix}`, true);

--- a/src/browser/api_protocol/api_handlers/application.js
+++ b/src/browser/api_protocol/api_handlers/application.js
@@ -8,7 +8,7 @@ let _ = require('underscore');
 // local modules
 let Application = require('../../api/application.js').Application;
 let apiProtocolBase = require('./api_protocol_base.js');
-let coreState = require('../../core_state.js');
+import * as coreState from '../../core_state';
 import ofEvents from '../../of_events';
 import { addRemoteSubscription } from '../../remote_subscriptions';
 import route from '../../../common/route';

--- a/src/browser/api_protocol/api_handlers/authorization.js
+++ b/src/browser/api_protocol/api_handlers/authorization.js
@@ -3,7 +3,7 @@ let apiProtocolBase = require('./api_protocol_base.js');
 import {
     ExternalApplication
 } from '../../api/external_application';
-let coreState = require('../../core_state.js');
+import * as coreState from '../../core_state';
 import ofEvents from '../../of_events';
 let _ = require('underscore');
 let log = require('../../log');

--- a/src/browser/api_protocol/api_handlers/deprecated_external_windowing_middleware.ts
+++ b/src/browser/api_protocol/api_handlers/deprecated_external_windowing_middleware.ts
@@ -4,7 +4,7 @@ import { MessagePackage } from '../transport_strategy/api_transport_base';
 import { sendToIdentity } from './api_protocol_base';
 import { RemoteAck } from '../transport_strategy/ack';
 
-const coreState = require('../../core_state');
+import * as coreState from '../../core_state';
 
 const validExternalAPIActions: any = {
    'blur-window': true,

--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -10,7 +10,7 @@ let queryString = require('querystring');
 let _ = require('underscore');
 
 // local modules
-let coreState = require('./core_state.js');
+import * as coreState from './core_state';
 let log = require('./log');
 import { fetchReadFile, readFile } from './cached_resource_fetcher';
 

--- a/src/browser/core_state.ts
+++ b/src/browser/core_state.ts
@@ -276,7 +276,7 @@ export function setAppId(uuid: string, id: number): void {
     }];
 }
 
-export function getAppObjByUuid(uuid: string): Shapes.AppObj|boolean {
+export function getAppObjByUuid(uuid: string): Shapes.AppObj|false {
     const app = appByUuid(uuid);
     return app && app.appObj;
 }
@@ -480,8 +480,13 @@ export function deleteApp(uuid: string): void {
     apps = apps.filter(app => app.uuid !== uuid);
 }
 
-export function getWindowOptionsById(id: number): Shapes.WindowOptions|boolean {
+export function getWindowOptionsById(id: number): Shapes.WindowOptions|false {
     const win = getWinById(id);
+    return win && win.openfinWindow && win.openfinWindow._options;
+}
+export function getWindowOptionsByBrowserWindowId(id: number): Shapes.WindowOptions|false {
+    const win =  getWinList().find(win =>
+         win.openfinWindow && win.openfinWindow.browserWindow && win.openfinWindow.browserWindow.id === id);
     return win && win.openfinWindow && win.openfinWindow._options;
 }
 

--- a/src/browser/navigation_validation.ts
+++ b/src/browser/navigation_validation.ts
@@ -1,4 +1,4 @@
-const coreState = require('./core_state');
+import * as coreState from './core_state';
 const electronApp = require('electron').app;
 import SubscriptionManager from './subscription_manager';
 import ofEvents from './of_events';
@@ -52,8 +52,8 @@ export function navigationValidator(uuid: string, name: string, id: number) {
         const appObject = coreState.getAppObjByUuid(uuid);
         const appMetaInfo = coreState.appByUuid(uuid);
         const isMailTo = /^mailto:/i.test(url);
-        const allowed = isMailTo || validateNavigationRules(uuid, url, appMetaInfo.parentUuid, appObject._options) &&
-                                    isURLAllowed(url);
+        const allowed = isMailTo || (appObject && validateNavigationRules(uuid, url, appMetaInfo.parentUuid, appObject._options) &&
+                                    isURLAllowed(url));
         if (!allowed) {
             electronApp.vlog(1, 'Navigation is blocked ' + url);
             const self = coreState.getWinById(id);

--- a/src/browser/web_request_handler.ts
+++ b/src/browser/web_request_handler.ts
@@ -6,7 +6,7 @@
     v1: handler for onBeforeSendHeaders
  */
 
-const coreState = require('./core_state');
+import * as coreState from './core_state';
 const electronApp = require('electron').app;
 const { session, webContents } = require('electron');
 
@@ -56,9 +56,8 @@ function beforeSendHeadersHandler(details: RequestDetails, callback: (response: 
         const wc = webContents.fromProcessAndFrameIds(details.renderProcessId, details.renderFrameId);
         if (wc) {
             electronApp.vlog(1, `${moduleName}:beforeSendHeadersHandler got webcontents ${wc.id}`);
-            const bw = wc.getOwnerBrowserWindow();
-            if (bw && typeof bw.id === 'number') {
-                const opts: Shapes.WindowOptions = coreState.getWindowOptionsById(bw.id);
+            if (typeof wc.id === 'number') {
+                const opts = coreState.getWindowOptionsById(wc.id);
                 electronApp.vlog(1, `${moduleName}:beforeSendHeadersHandler window opts ${JSON.stringify(opts)}`);
                 if (opts && opts.customRequestHeaders) {
                     for (const rhItem of opts.customRequestHeaders) {

--- a/src/modules.d.ts
+++ b/src/modules.d.ts
@@ -38,7 +38,6 @@ declare namespace Electron {
     }
 
     export interface BrowserWindow {
-        id: number;
         nativeId: string;
 
         activate(): void;

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -436,10 +436,8 @@
                 ipc.once(popResponseChannel, (sender, meta) => {
                     setTimeout(() => {
                         try {
-                            let returnMeta = JSON.parse(meta);
                             cb({
                                 nativeWindow,
-                                id: returnMeta.windowId
                             });
                         } catch (e) {}
                     }, 1);


### PR DESCRIPTION
#### Description of Change
Switch to using webcontents id rather than browserwindow id for core ids.

#### Checklist

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR release notes describe the change in a way relevant to app-developers
- [x] PR has assigned reviewers


#### Release Notes

Notes: n/a pre-req for browser-view support