### PR TITLE
RUN-5508: Reduce noise - only emit main win events

### DIFF
--- a/src/browser/api/external_window.ts
+++ b/src/browser/api/external_window.ts
@@ -345,11 +345,14 @@ function subToGlobalWinEventHooks(): void {
     parser: (nativeWindowInfo: Shapes.NativeWindowInfoLite) => void,
     sender: Event,
     rawNativeWindowInfo: NativeWindowInfo,
-    timestamp: number
+    timestamp: number,
+    idObject: string,
+    idChild: string
   ): void => {
     const nativeWindowInfo = getNativeWindowInfoLite(rawNativeWindowInfo);
     const ignoreVisibility = true;
-    const isValid = isValidExternalWindow(rawNativeWindowInfo, ignoreVisibility);
+    // idChild === '0' indicates that event is from main window, not a subcomponent.
+    const isValid = isValidExternalWindow(rawNativeWindowInfo, ignoreVisibility) && idChild === '0';
 
     if (isValid) {
       parser(nativeWindowInfo);
@@ -424,16 +427,17 @@ function subscribeToWinEventHooks(externalWindow: Shapes.ExternalWindow): void {
     parser: (nativeWindowInfo: Shapes.NativeWindowInfo) => void,
     sender: Event,
     rawNativeWindowInfo: NativeWindowInfo,
-    timestamp: number
+    timestamp: number,
+    idObject: string,
+    idChild: string
   ): void => {
     const nativeWindowInfo = getNativeWindowInfo(rawNativeWindowInfo);
 
-    // Since we are subscribing to a process, we are only interested in a
-    // specific window.
-    if (nativeWindowInfo.uuid !== nativeId) {
+    // We are subscribing to a process, so we only care about a specific window.
+    // idChild === '0' indicates that event is from main window, not a subcomponent.
+    if (nativeWindowInfo.uuid !== nativeId || idChild !== '0') {
       return;
     }
-
     parser(nativeWindowInfo);
     previousNativeWindowInfo = nativeWindowInfo;
   };


### PR DESCRIPTION
#### Description of Change
Jira: https://appoji.jira.com/projects/RUN/issues/RUN-5508

As of 13.76.44.12, the runtime exposes the idChild property on native window events passed to the core. By only propagating events with `idChild === '0'` (indicating that the event is from the main window), we filter out some eventing from subcomponents that are not currently filtered out by the runtime.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR has assigned reviewers


#### Release Notes
N/A
