### PR TITLE
RUN-5518 - Only bring to front on first move of grouped move

### DIFF
--- a/src/browser/disabled_frame_group_tracker.ts
+++ b/src/browser/disabled_frame_group_tracker.ts
@@ -228,18 +228,19 @@ export function addWindowToGroup(win: GroupWindow) {
                 rawPayloadBounds = Rectangle.CREATE_FROM_BOUNDS(adjustedBounds);
             }
             const moves = generateWindowMoves(win, rawPayloadBounds, changeType);
-            handleBatchedMove(moves, changeType, true);
             // Keep track of which windows have moved in order to emit events
             moves.forEach(({ofWin}) => moved.add(ofWin));
             if (!boundsChanging) {
                 boundsChanging = true;
                 const endingEvent = isWin32 ? 'end-user-bounds-change' : 'disabled-frame-bounds-changed';
                 win.browserWindow.once(endingEvent, handleEndBoundsChanging);
+                moves.forEach(({ ofWin }) => ofWin.browserWindow.bringToFront());
             } else if (moves.length) {
                 // bounds-changing is not emitted for the leader, but is for the other windows
                 const leaderMove = moves.find(({ofWin}) => ofWin.uuid === win.uuid && ofWin.name === win.name);
                 emitChange('bounds-changing', leaderMove, changeType, 'self');
             }
+            handleBatchedMove(moves, changeType);
         } catch (error) {
             writeToLog('error', error);
         }


### PR DESCRIPTION
#### Description of Change
With new logic, happening on every user-generated group move, change to once.  Only bring to front on first move of a user-generated grouped window move.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR has assigned reviewers
