### PR TITLE
RUN-5309 Task/reintroduce transactions

### DIFF
--- a/src/browser/disabled_frame_group_tracker.ts
+++ b/src/browser/disabled_frame_group_tracker.ts
@@ -115,7 +115,7 @@ function handleBatchedMove(moves: Move[]) {
             } else {
                 bounds = rect;
             }
-            // const bds =  (<any>ExternalWindow).addShadow(ofWin.browserWindow.nativeId, rect);
+
             (<any>wt.setWindowPos)(hwnd, { ...getTransactionBounds(bounds), flags, scale: false });
         });
         wt.commit();

--- a/src/browser/disabled_frame_group_tracker.ts
+++ b/src/browser/disabled_frame_group_tracker.ts
@@ -104,7 +104,7 @@ function handleApiMove(win: GroupWindow, delta: RectangleBase) {
 
 function handleBatchedMove(moves: Move[]) {
     if (isWin32) {
-        const { flag: { noZorder, noSize, noActivate } } = WindowTransaction;
+        const { flag: { noZorder, noActivate } } = WindowTransaction;
         const flags = noZorder + noActivate;
         const wt = new WindowTransaction.Transaction(0);
         moves.forEach(({ ofWin, rect }) => {


### PR DESCRIPTION
#### Description of Change
Reintroducing window transactions to group moves. This leverages the ability that we now have in the core to get raw window positions with the shadows factored out for win10 framed windows. 

The `any` casting will be removed once we introduce the proper types on the runtime side.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [ ] manual tests are [changed or added](https://github.com/openfin/test_apps)
- [ ] relevant documentation is [changed or added](https://github.com/hadoukenio/js-adapter)
- [ ] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [ ] PR release notes describe the change in a way relevant to app-developers
- [ ] Link to new tests added
- [ ] PR has assigned reviewers


#### Release Notes
n/a internal
Notes: <!-- Please add a one-line description for app developers to read in the release notes. Examples and help on special cases: http://developer.openfin.co/versions/?product=Runtime&version=9.61.37.46 -->
