### PR TITLE
RUN-5584 - Multi-runtime onDisconnection from ChannelProvider

### DIFF
--- a/src/browser/api/channel.ts
+++ b/src/browser/api/channel.ts
@@ -8,8 +8,7 @@ import { getEntityIdentity } from '../core_state';
 import SubscriptionManager from '../subscription_manager';
 
 const subscriptionManager = new SubscriptionManager();
-const channelMap: Map<string, ProviderIdentity> = new Map();
-const pendingChannelConnections: Map<string, any[]> = new Map();
+export const channelMap: Map<string, ProviderIdentity> = new Map();
 
 const CHANNEL_APP_ACTION = 'process-channel-message';
 const CHANNEL_ACK_ACTION = 'send-channel-result';
@@ -127,7 +126,6 @@ export module Channel {
     }
 
     export function disconnectFromChannel(identity: Identity, channelName: string): void {
-        // If a channel has already been created with that channelName
         const disconnectedEvent = 'client-disconnected';
         subscriptionManager.removeSubscription(identity, `${disconnectedEvent}-${channelName}`);
     }

--- a/src/browser/api/channel.ts
+++ b/src/browser/api/channel.ts
@@ -8,7 +8,7 @@ import { getEntityIdentity } from '../core_state';
 import SubscriptionManager from '../subscription_manager';
 
 const subscriptionManager = new SubscriptionManager();
-export const channelMap: Map<string, ProviderIdentity> = new Map();
+const channelMap: Map<string, ProviderIdentity> = new Map();
 
 const CHANNEL_APP_ACTION = 'process-channel-message';
 const CHANNEL_ACK_ACTION = 'send-channel-result';

--- a/src/browser/api_protocol/api_handlers/event_listener.ts
+++ b/src/browser/api_protocol/api_handlers/event_listener.ts
@@ -140,7 +140,14 @@ const subChannel = async (identity: Identity, eventName: string, payload: EventP
     const isExternalClient = ExternalApplication.isRuntimeClient(identity.uuid);
     let remoteUnSub = noop;
 
-    if (!islocalUuid && !isExternalClient && (eventName === 'connected' || eventName === 'disconnected')) {
+    const systemWideEvents: {[key: string]: boolean} = {
+        'connected': true,
+        'disconnected': true,
+        'client-disconnected': true
+    };
+
+    // these events act like system events
+    if (!islocalUuid && !isExternalClient && systemWideEvents[eventName]) {
         const subscription: RemoteSubscriptionProps = {
             className: 'channel',
             eventName,


### PR DESCRIPTION
#### Description of Change
Channel onDisconnection from the provider (on client disconnection) was not working multi-runtime. This PR makes it work.  The services team needs this for notifications.

Goes with [this js-adapter PR](https://github.com/HadoukenIO/js-adapter/pull/334)

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] automated tests are [added](https://testing-dashboard.openfin.co/#/app/tests/5d7129035cca4e5a7198d3b3/edit)
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR release notes describe the change in a way relevant to app-developers
- [x] PR has assigned reviewers

#### Release Notes

Notes: Fixed bug where channel onDisconnection from the provider was not working across runtimes.
