### PR TITLE
RVM-906: Rvm Core Analytics Pipeline

### DIFF
--- a/src/browser/rvm/rvm_message_bus.ts
+++ b/src/browser/rvm/rvm_message_bus.ts
@@ -173,6 +173,7 @@ export interface Cleanup extends RvmMsgBase {
 // topic: system -----
 type systemTopic = 'system';
 type getRvmInfoAction = 'get-rvm-info';
+type sendCoreAnalyticsEvent = 'send-core-analytics-event';
 
 export interface System extends RvmMsgBase {
     topic: systemTopic;
@@ -180,6 +181,19 @@ export interface System extends RvmMsgBase {
     sourceUrl: string;
 }
 
+interface CoreAnalytics extends RvmMsgBase {
+    topic: systemTopic;
+    action: sendCoreAnalyticsEvent;
+    sourceUrl: string;
+    diagnosticsEvent: AnalyticsEvent;
+}
+
+interface AnalyticsEvent {
+    topic: string;
+    event: string;
+    createdAt: string;
+    payload?: any;
+}
 
 // topic: application-events -----
 type EventType = 'started'| 'closed' | 'ready' | 'run-requested' | 'crashed' | 'error' | 'not-responding';
@@ -414,6 +428,28 @@ export class RVMMessageBus extends EventEmitter  {
             timeToLive: 5
         };
         this.publish(rvmPayload, callback);
+    }
+
+    public sendCoreAnalyticsEvent(event: string, payload: any): Promise<boolean> {
+        return new Promise((resolve, reject) => {
+            try {
+                const rvmMsg: CoreAnalytics = {
+                    topic: 'system',
+                    action: 'send-core-analytics-event',
+                    sourceUrl: '',
+
+                    diagnosticsEvent: {
+                        event,
+                        topic: 'analytics.core.event',
+                        createdAt: new Date().toISOString(),
+                        payload
+                    }
+                };
+                this.publish(rvmMsg, resolve);
+            } catch (err) {
+                 reject(err);
+            }
+        });
     }
 }
 const rvmMessageBus = new RVMMessageBus();


### PR DESCRIPTION
#### Description of Change

Added a member function to the rvmBus that communicates with the RVM analytics pipeline. Not being used for anything at the moment, but able to be leveraged. 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [ ] manual tests are [changed or added](https://github.com/openfin/test_apps)
- [ ] relevant documentation is [changed or added](https://github.com/hadoukenio/js-adapter)
- [ ] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [ ] PR release notes describe the change in a way relevant to app-developers
- [ ] Link to new tests added
- [ ] PR has assigned reviewers


#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes. Examples and help on special cases: http://developer.openfin.co/versions/?product=Runtime&version=9.61.37.46 -->
