### PR TITLE
RUN-5605 - Fixed grouped eventing bounds when scaled

### DIFF
--- a/src/browser/disabled_frame_group_tracker.ts
+++ b/src/browser/disabled_frame_group_tracker.ts
@@ -99,9 +99,7 @@ function handleApiMove(win: GroupWindow, delta: RectangleBase) {
     }
     handleBatchedMove(moves);
     emitChange('bounds-changed', win, changeType, 'self');
-    otherWindows.map(({ofWin}) => {
-        emitChange('bounds-changed', ofWin, changeType, 'group');
-    });
+    otherWindows.map(({ofWin}) => emitChange('bounds-changed', ofWin, changeType, 'group'));
     return leader.rect;
 }
 


### PR DESCRIPTION
#### Description of Change
Bug in new grouping logic, need to emit scaled bounds to match the rest of the events for bounds-changed and bounds changing when emitting the events.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] manual tests (ran layouts tests)
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR has assigned reviewers

