### PR TITLE
RVM-976 StartFromManifest rvmLaunchOptions

### DIFF
--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -7,6 +7,7 @@ let os = require('os');
 let path = require('path');
 let electron = require('electron');
 let queryString = require('querystring');
+let url = require('url');
 let BrowserWindow = electron.BrowserWindow;
 let electronApp = electron.app;
 let dialog = electron.dialog;
@@ -14,6 +15,7 @@ let globalShortcut = electron.globalShortcut;
 let nativeImage = electron.nativeImage;
 let ProcessInfo = electron.processInfo;
 let Tray = electron.Tray;
+
 
 // npm modules
 let _ = require('underscore');
@@ -777,6 +779,10 @@ Application.runWithRVM = function(manifestUrl, appIdentity, opts) {
     if (os.platform() !== 'win32') {
         return launch({ manifestUrl: manifestUrl });
     } else {
+        if (opts.userAppConfigArgs) {
+            opts.userAppConfigArgsStr = new url.URLSearchParams(opts.userAppConfigArgs).toString();
+            delete opts.userAppConfigArgs;
+        }
         return sendToRVM({
             topic: 'application',
             action: 'launch-app',

--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -16,7 +16,6 @@ let nativeImage = electron.nativeImage;
 let ProcessInfo = electron.processInfo;
 let Tray = electron.Tray;
 
-
 // npm modules
 let _ = require('underscore');
 
@@ -40,7 +39,6 @@ import { deregisterAllRuntimeProxyWindows } from '../window_groups_runtime_proxy
 import { releaseUuid } from '../uuid_availability';
 import { launch } from '../../../js-adapter/src/main';
 import { externalWindows } from './external_window';
-// import { Rule } from '../../../test/lint-rules/out/noFsRule';
 
 const subscriptionManager = new SubscriptionManager();
 const TRAY_ICON_KEY = 'tray-icon-events';
@@ -773,7 +771,7 @@ function run(identity, mainWindowOpts, userAppConfigArgs) {
 /**
  * Run an application via RVM Call
  */
-Application.runWithRVM = function(manifestUrl, appIdentity, opts) {
+Application.runWithRVM = function(manifestUrl, appIdentity, opts = {}) {
     const { uuid } = appIdentity;
     // on mac/linux, launch the app, else hand off to RVM
     if (os.platform() !== 'win32') {

--- a/src/browser/api/application.js
+++ b/src/browser/api/application.js
@@ -38,6 +38,7 @@ import { deregisterAllRuntimeProxyWindows } from '../window_groups_runtime_proxy
 import { releaseUuid } from '../uuid_availability';
 import { launch } from '../../../js-adapter/src/main';
 import { externalWindows } from './external_window';
+// import { Rule } from '../../../test/lint-rules/out/noFsRule';
 
 const subscriptionManager = new SubscriptionManager();
 const TRAY_ICON_KEY = 'tray-icon-events';
@@ -770,7 +771,7 @@ function run(identity, mainWindowOpts, userAppConfigArgs) {
 /**
  * Run an application via RVM Call
  */
-Application.runWithRVM = function(manifestUrl, appIdentity) {
+Application.runWithRVM = function(manifestUrl, appIdentity, opts) {
     const { uuid } = appIdentity;
     // on mac/linux, launch the app, else hand off to RVM
     if (os.platform() !== 'win32') {
@@ -781,7 +782,8 @@ Application.runWithRVM = function(manifestUrl, appIdentity) {
             action: 'launch-app',
             sourceUrl: coreState.getConfigUrlByUuid(uuid),
             data: {
-                configUrl: manifestUrl
+                configUrl: manifestUrl,
+                rvmLaunchOptions: opts
             }
         });
     }

--- a/src/browser/api_protocol/api_handlers/application.js
+++ b/src/browser/api_protocol/api_handlers/application.js
@@ -324,6 +324,7 @@ function notifyOnContentLoaded(identity, message, ack) {
 function runApplication(identity, message, ack, nack) {
     const { payload } = message;
     const { manifestUrl } = payload;
+    const { opts } = payload;
     const appIdentity = apiProtocolBase.getTargetApplicationIdentity(payload);
     const { uuid } = appIdentity;
     let remoteSubscriptionUnSubscribe;
@@ -368,7 +369,7 @@ function runApplication(identity, message, ack, nack) {
                 remoteSubscriptionUnSubscribe();
                 unsub();
             });
-            Application.runWithRVM(manifestUrl, appIdentity).catch(e => {
+            Application.runWithRVM(manifestUrl, appIdentity, opts).catch(e => {
                 nack(e);
                 remoteSubscriptionUnSubscribe();
                 unsub();


### PR DESCRIPTION
#### Description of Change
Added `rvmLaunchOptions` to startFromManifest(), which contains to parameters. 
1. noUi - a way to tell the rvm to launch an app with the no-ui option.
2. userAppConfigArgs - a map of deep linking params that can be appended to the manifest url.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [ ] manual tests are [changed or added](https://github.com/openfin/test_apps)
- [ ] relevant documentation is [changed or added](https://github.com/hadoukenio/js-adapter)
- [ ] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [ ] PR release notes describe the change in a way relevant to app-developers
- [ ] Link to new tests added
- [ ] PR has assigned reviewers


#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes. Examples and help on special cases: http://developer.openfin.co/versions/?product=Runtime&version=9.61.37.46 -->
