### PR TITLE
RUN-5602 Use affinity for render process management of BrowserViews

### DIFF
--- a/src/browser/api/browser_view.ts
+++ b/src/browser/api/browser_view.ts
@@ -38,7 +38,9 @@ export async function create(options: BrowserViewOpts) {
     }
     const targetOptions = targetWin._options;
     const fullOptions = Object.assign({}, targetOptions, options);
-    const view = new BrowserView(convertOptions.convertToElectron(fullOptions, false));
+    const convertedOptions = convertOptions.convertToElectron(fullOptions, false);
+    convertedOptions.webPreferences.affinity = uuid;
+    const view = new BrowserView(convertedOptions);
     const ofView = addBrowserView(fullOptions, view);
     await attach(ofView, options.target);
     view.webContents.loadURL(options.url || 'about:blank');

--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -236,7 +236,6 @@ export const convertToElectron = function(options, returnAsString) {
     newOptions.enableLargerThanScreen = true;
     newOptions['enable-plugins'] = true;
     newOptions.webPreferences = {
-        affinity: newOptions.uuid,
         api: newOptions.experimental.api,
         contextMenuSettings: newOptions.contextMenuSettings,
         disableInitialReload: newOptions.experimental.disableInitialReload,

--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -236,6 +236,7 @@ export const convertToElectron = function(options, returnAsString) {
     newOptions.enableLargerThanScreen = true;
     newOptions['enable-plugins'] = true;
     newOptions.webPreferences = {
+        affinity: newOptions.uuid,
         api: newOptions.experimental.api,
         contextMenuSettings: newOptions.contextMenuSettings,
         disableInitialReload: newOptions.experimental.disableInitialReload,


### PR DESCRIPTION
#### Description of Change
Uses affinity to group same origin render processes

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [ ] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [ ] manual tests are [changed or added](https://github.com/openfin/test_apps)
- [ ] relevant documentation is [changed or added](https://github.com/hadoukenio/js-adapter)
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [ ] PR release notes describe the change in a way relevant to app-developers
- [ ] Link to new tests added
- [x] PR has assigned reviewers


#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes. Examples and help on special cases: http://developer.openfin.co/versions/?product=Runtime&version=9.61.37.46 -->
