### PR TITLE
RUN-5577  Logging for browserview

### DIFF
--- a/src/browser/api/webcontents.ts
+++ b/src/browser/api/webcontents.ts
@@ -4,6 +4,7 @@ import { Identity } from '../../shapes';
 import ofEvents from '../of_events';
 import route, { WindowRoute } from '../../common/route';
 import { InjectableContext, EntityType } from '../../shapes';
+import { prepareConsoleMessageForRVM } from '../rvm/utils';
 
 export function hookWebContentsEvents(webContents: Electron.WebContents, { uuid, name }: Identity, topic: string, routeFunc: WindowRoute) {
     webContents.on('did-get-response-details', (e,
@@ -56,6 +57,7 @@ export function hookWebContentsEvents(webContents: Electron.WebContents, { uuid,
     webContents.once('destroyed', () => {
         webContents.removeAllListeners();
     });
+    webContents.on('console-message', (...args) => prepareConsoleMessageForRVM({ uuid, name }, ...args));
 }
 
 export function executeJavascript(webContents: Electron.WebContents, code: string, callback: (e: any, result: any) => void): void {


### PR DESCRIPTION
#### Description of Change
Adds RVM logging for console messages inside browserviews in the same way we do for windows.

**NOTE**
For this to work we need to wait for (@MichaelMCoates)'s changes that will apply `hookWebContentsEvents(...)` to webcontents created by browserviews. Until then everything will build fine but the actual logging won't happen.
@rdepena @pbaize @datamadic 

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR release notes describe the change in a way relevant to app-developers
- [x] PR has assigned reviewers

#### Release Notes

Notes: Added RVM logging inside BrowserViews