### PR TITLE
RUN-5534 fix: Execute preload scripts after API modules

### DIFF
--- a/src/renderer/node-less.js
+++ b/src/renderer/node-less.js
@@ -103,15 +103,18 @@ const registerAPI = (w, routingId, isMainFrame, isSameOriginIframe, isCrossOrigi
 
         w = undefined;
 
-        try {
-            electron.ipcRenderer.emit('post-api-injection', routingId);
-            electron.ipcRenderer.emit(`post-api-injection-${routingId}`);
-        } catch (error) {
-            console.error(`Error notifying post-api-injection for ${routingId}`);
-            console.error(error.stack);
-        } finally {
-            electron.ipcRenderer.removeAllListeners(`post-api-injection-${routingId}`);
-        }
+        // Execute after all other modules have been evaluated
+        setImmediate(() => {
+            try {
+                electron.ipcRenderer.emit('post-api-injection', routingId);
+                electron.ipcRenderer.emit(`post-api-injection-${routingId}`);
+            } catch (error) {
+                console.error(`Error notifying post-api-injection for ${routingId}`);
+                console.error(error.stack);
+            } finally {
+                electron.ipcRenderer.removeAllListeners(`post-api-injection-${routingId}`);
+            }
+        });
 
         if (inboundMessageTopic.length) {
             teardownHandlers.push(() => {

--- a/src/renderer/node-less.js
+++ b/src/renderer/node-less.js
@@ -104,7 +104,7 @@ const registerAPI = (w, routingId, isMainFrame, isSameOriginIframe, isCrossOrigi
         w = undefined;
 
         // Execute after all other modules have been evaluated
-        setImmediate(() => {
+        electron.ipcRenderer.once('api-modules-evaluated', () => {
             try {
                 electron.ipcRenderer.emit('post-api-injection', routingId);
                 electron.ipcRenderer.emit(`post-api-injection-${routingId}`);


### PR DESCRIPTION
#### Description of Change
Execute  preload scripts after API modules have been evaluated
Relies on https://github.com/openfin/runtime/pull/1636

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR release notes describe the change in a way relevant to app-developers
- [x] PR has assigned reviewers


#### Release Notes
N/A - Internal Only
