### PR TITLE
RUN-5604 Await loadUrl in browserview creation

### DIFF
--- a/src/browser/api/browser_view.ts
+++ b/src/browser/api/browser_view.ts
@@ -47,12 +47,7 @@ export async function create(options: BrowserViewOpts) {
     } if (options.bounds) {
         setBounds(ofView, options.bounds);
     }
-    try {
-        await view.webContents.loadURL(options.url || 'about:blank');
-    } catch (e) {
-        destroy(ofView);
-        throw e;
-    }
+    await view.webContents.loadURL(options.url || 'about:blank');
 }
 export function hide(ofView: OfView) {
     const win = getElectronBrowserWindow(ofView.target);

--- a/src/browser/api/browser_view.ts
+++ b/src/browser/api/browser_view.ts
@@ -42,7 +42,6 @@ export async function create(options: BrowserViewOpts) {
     const ofView = addBrowserView(fullOptions, view);
     hookWebContentsEvents(view.webContents, options, 'view', route.view);
     await attach(ofView, options.target);
-    view.webContents.loadURL(options.url || 'about:blank');
     of_events.emit(route.view('created', ofView.uuid, ofView.name), {
         name: ofView.name,
         uuid: ofView.uuid,

--- a/src/browser/api/browser_view.ts
+++ b/src/browser/api/browser_view.ts
@@ -41,12 +41,17 @@ export async function create(options: BrowserViewOpts) {
     const view = new BrowserView(convertOptions.convertToElectron(fullOptions, false));
     const ofView = addBrowserView(fullOptions, view);
     await attach(ofView, options.target);
-    view.webContents.loadURL(options.url || 'about:blank');
     setIframeHandlers(view.webContents, ofView, options.uuid, options.name);
     if (options.autoResize) {
         view.setAutoResize(options.autoResize);
     } if (options.bounds) {
         setBounds(ofView, options.bounds);
+    }
+    try {
+        await view.webContents.loadURL(options.url || 'about:blank');
+    } catch (e) {
+        destroy(ofView);
+        throw e;
     }
 }
 export function hide(ofView: OfView) {


### PR DESCRIPTION
#### Description of Change
Await loadUrl in browserview creation. This means getInfo timing issues go away. It also means browserview creation can fail on a bad url.

new tests: https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5d8138947ba87401eaf564be

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [ ] manual tests are [changed or added](https://github.com/openfin/test_apps)
- [ ] relevant documentation is [changed or added](https://github.com/hadoukenio/js-adapter)
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR release notes describe the change in a way relevant to app-developers
- [x] Link to new tests added
- [x] PR has assigned reviewers


#### Release Notes

Notes: n/a experimental