### PR TITLE
RUN-5492 Throw error on window.open/fin.Window.create inside BrowserView

### DIFF
--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -381,6 +381,9 @@
     const originalOpen = global.open;
 
     function openChildWindow(...args) {
+        if (entityInfo.entityType === 'view') {
+            throw new Error('Can not create a window inside a BrowserView');
+        }
         const [url, requestedName, features = ''] = args; // jshint ignore:line
         const requestId = ++childWindowRequestId;
         const webContentsId = getWebContentsId();


### PR DESCRIPTION
#### Description of Change
Handles the case where creating a window inside a browserview through either `window.open()` or `fin.Window.create()` causes the renderer to hang

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR release notes describe the change in a way relevant to app-developers
- [x] Link to new tests added
- [x] PR has assigned reviewers

Test: https://testing-dashboard.openfin.co/#/app/tests/5d8509a97ba87401eaf5658d/edit

#### Release Notes
Notes: Fixes renderer hang when creating a window inside BrowserView

@pbaize @rdepena @MichaelMCoates 