### PR TITLE
[RUN-5625] Propagate events from BrowserView to Application and System

### DIFF
--- a/src/browser/of_events.ts
+++ b/src/browser/of_events.ts
@@ -47,7 +47,7 @@ class OFEvents extends EventEmitter {
                 // Wildcard on any channel/topic of a specified source (ex: 'window/*/myUUID-myWindow')
                 super.emit(route(channel, '*', source), envelope);
             }
-            const shouldPropagate = (channel === 'window' || channel === 'application') && !isMultiRuntimeEvent;
+            const shouldPropagate = (channel === 'window' || channel === 'view' || channel === 'application') && !isMultiRuntimeEvent;
             if (shouldPropagate) {
                 const checkedPayload = typeof payload === 'object' ? payload : { payload };
                 if (channel === 'window') {
@@ -65,6 +65,16 @@ class OFEvents extends EventEmitter {
                             eventPropagations.set(route.system(propTopic), { ...checkedPayload, type: propTopic, topic: 'system' });
                         }
                     }
+                } else if (channel === 'view') {
+                    const propTopic = `view-${topic}`;
+                    eventPropagations.set(route.application(propTopic, uuid), {
+                        ...checkedPayload,
+                        type: propTopic,
+                        topic: 'application'
+                    });
+                    if (propagateToSystem) {
+                        eventPropagations.set(route.system(propTopic), { ...checkedPayload, type: propTopic, topic: 'system' });
+                    }
                     //Don't propagate -requested events to System
                 } else if (channel === 'application' && propagateToSystem) {
                     const propTopic = `application-${topic}`;
@@ -75,7 +85,7 @@ class OFEvents extends EventEmitter {
                         'window-responding',
                         'window-start-load'
                     ];
-                    if (!topic.match(/^window-/)) {
+                    if (!topic.match(/^window-/) && !topic.match(/^view-/)) {
                         eventPropagations.set(route.system(propTopic), { ...checkedPayload, type: propTopic, topic: 'system' });
                     } else if (appWindowEventsNotOnWindow.some(t => t === topic)) {
                         eventPropagations.set(route.system(topic), { ...checkedPayload, type: topic, topic: 'system' });


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Pull Request process: https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process
-->

Sets up event propagation from BrowserView up to Application and System.

Tests:
https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5d88dfaf7ba87401eaf565df

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included and stakeholders cc'd
- [X] `npm test` passes
- [X] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [ ] manual tests are [changed or added](https://github.com/openfin/test_apps)
- [X] relevant documentation is [changed or added](https://github.com/hadoukenio/js-adapter)
- [X] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [X] PR release notes describe the change in a way relevant to app-developers
- [X] Link to new tests added
- [X] PR has assigned reviewers


#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes. Examples and help on special cases: http://developer.openfin.co/versions/?product=Runtime&version=9.61.37.46 -->

- BrowserView events now propagate up to Application and System.
