### PR TITLE
Bugfix - Call removeBrowserView on oldWin so that we can attach BrowserViews back and forth

### DIFF
--- a/src/browser/api/browser_view.ts
+++ b/src/browser/api/browser_view.ts
@@ -81,6 +81,7 @@ export async function attach(ofView: OfView, toIdentity: Identity) {
         if (previousTarget.name !== toIdentity.name) {
             const oldWin = getWindowByUuidName(previousTarget.uuid, previousTarget.name);
             if (oldWin) {
+                oldWin.browserWindow.removeBrowserView(view);
                 const oldwinMap = windowCloseListenerMap.get(oldWin);
                 if (oldwinMap) {
                     const listener = oldwinMap.get(ofView);


### PR DESCRIPTION


#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Pull Request process: https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process
-->

Fixes a bug that prevents a BrowserView from attaching back to the window it was originally attached to. 

Bug Repro:
1. Create a BrowserView on Window A.
2. Attach the BV to Window B.
3. Attempt to attach the BV back to Window A.
Expected: BV Shows up on Window A.
Actual: BV stays on Window B.

To fix, we simply call removeBrowserView with the old window.


#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included and stakeholders cc'd
- [X] `npm test` passes)
- [X] PR has assigned reviewers


#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes. Examples and help on special cases: http://developer.openfin.co/versions/?product=Runtime&version=9.61.37.46 -->
