### PR TITLE
RUN-5562 feat(browser_view_share_process) Add targetWebContentsId option in order to pass target web contents

### DIFF
--- a/src/browser/api/browser_view.ts
+++ b/src/browser/api/browser_view.ts
@@ -36,9 +36,7 @@ export async function create(options: BrowserViewOpts) {
     }
     const targetOptions = targetWin._options;
     const fullOptions = Object.assign({}, targetOptions, options);
-    const convertedOptions = convertOptions.convertToElectron(fullOptions, false);
-    convertedOptions.webPreferences.affinity = uuid;
-    const view = new BrowserView(convertedOptions);
+    const view = new BrowserView(convertOptions.convertToElectron(fullOptions, false));
     const ofView = addBrowserView(fullOptions, view);
     hookWebContentsEvents(view.webContents, options, 'view', route.view);
     await attach(ofView, options.target);

--- a/src/browser/api/browser_view.ts
+++ b/src/browser/api/browser_view.ts
@@ -35,7 +35,11 @@ export async function create(options: BrowserViewOpts) {
         throw new Error('Target Window could not be found');
     }
     const targetOptions = targetWin._options;
-    const fullOptions = Object.assign({}, targetOptions, options);
+    const fullOptions = Object.assign(
+        {},
+        targetOptions,
+        options,
+        { targetWebContentsId: targetWin.browserWindow.webContents.id });
     const view = new BrowserView(convertOptions.convertToElectron(fullOptions, false));
     const ofView = addBrowserView(fullOptions, view);
     hookWebContentsEvents(view.webContents, options, 'view', route.view);

--- a/src/browser/convert_options.js
+++ b/src/browser/convert_options.js
@@ -147,6 +147,10 @@ function validateOptions(options) {
         baseOptions.rawWindowOpen = options.rawWindowOpen;
     }
 
+    if (options.targetWebContentsId) {
+        baseOptions.targetWebContentsId = options.targetWebContentsId;
+    }
+
     return validate(baseOptions, options);
 }
 

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -316,7 +316,7 @@
 
 
         currPageHasLoaded = true;
-        if (getOpenerSuccessCallbackCalled() || window.opener === null || initialOptions.isRawWindowOpen || isCrossOrigin()) {
+        if (getOpenerSuccessCallbackCalled() || window.opener === null || initialOptions.isRawWindowOpen || isCrossOrigin() || initialOptions.targetWebContentsId !== undefined) {
             deferByTick(() => {
                 pendingMainCallbacks.forEach((callback) => {
                     const userAppConfigArgs = initialOptions.userAppConfigArgs;
@@ -355,7 +355,7 @@
     }
 
     function onContentReady(bindObject, callback) {
-        if (currPageHasLoaded && (getOpenerSuccessCallbackCalled() || window.opener === null || initialOptions.isRawWindowOpen || isCrossOrigin())) {
+        if (currPageHasLoaded && (getOpenerSuccessCallbackCalled() || window.opener === null || initialOptions.isRawWindowOpen || isCrossOrigin() || initialOptions.targetWebContentsId !== undefined)) {
             deferByTick(() => {
                 callback();
             });


### PR DESCRIPTION
Even using affinity option browser will fork separate process for all BrowserView in the same app. I added "targetWebContentsId" option in order to find target WebContents/SiteInstance/renderer process on native side and do not fork new process if possible (if BrowserView url is in the same app/domain as target BrowserWindow).

[tests_x64_win10](https://testing-dashboard.openfin.co/#/app/sessions/api/completed/5d8c82cd7ba87401eaf5672e)

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [] PR has assigned reviewers
