### PR TITLE
RUN-5674 | BrowserView creates multiply window/close events if attached is called more than once

### DIFF
--- a/src/browser/api/browser_view.ts
+++ b/src/browser/api/browser_view.ts
@@ -82,17 +82,15 @@ export function show(ofView: OfView) {
 }
 
 export async function attach(ofView: OfView, toIdentity: Identity) {
-    const {view} = ofView;
+    const {view, target: previousTarget} = ofView;
     if (view) {
-        const previousTarget = ofView.target;
-
         const ofWin = getWindowByUuidName(toIdentity.uuid, toIdentity.name);
         const oldWin = getWindowByUuidName(previousTarget.uuid, previousTarget.name);
 
         if (!ofWin) {
             throw new Error(`Could not locate target window ${toIdentity.uuid}/${toIdentity.name}`);
         }
-        if(!oldWin) {
+        if (!oldWin) {
             throw new Error(`Could not locate origin window ${previousTarget.uuid}/${previousTarget.name}`);
         }
 

--- a/src/browser/api/browser_view.ts
+++ b/src/browser/api/browser_view.ts
@@ -84,14 +84,21 @@ export function show(ofView: OfView) {
 export async function attach(ofView: OfView, toIdentity: Identity) {
     const {view} = ofView;
     if (view) {
+        const previousTarget = ofView.target;
+
         const ofWin = getWindowByUuidName(toIdentity.uuid, toIdentity.name);
+        const oldWin = getWindowByUuidName(previousTarget.uuid, previousTarget.name);
+
         if (!ofWin) {
             throw new Error(`Could not locate target window ${toIdentity.uuid}/${toIdentity.name}`);
         }
+        if(!oldWin) {
+            throw new Error(`Could not locate origin window ${previousTarget.uuid}/${previousTarget.name}`);
+        }
 
-        const previousTarget = ofView.target;
+        const oldwinMap = windowCloseListenerMap.get(oldWin);
+
         if (previousTarget.name !== toIdentity.name) {
-            const oldWin = getWindowByUuidName(previousTarget.uuid, previousTarget.name);
             if (oldWin) {
                 oldWin.browserWindow.removeBrowserView(view);
                 of_events.emit(route.window('view-detached', previousTarget.uuid, previousTarget.name), {
@@ -99,7 +106,6 @@ export async function attach(ofView: OfView, toIdentity: Identity) {
                     target: toIdentity,
                     previousTarget
                 });
-                const oldwinMap = windowCloseListenerMap.get(oldWin);
                 if (oldwinMap) {
                     const listener = oldwinMap.get(ofView);
                     if (typeof listener === 'function') {
@@ -108,6 +114,8 @@ export async function attach(ofView: OfView, toIdentity: Identity) {
                     oldwinMap.delete(ofView);
                 }
             }
+        } else if (oldwinMap && oldwinMap.has(ofView)) {
+           return;
         }
 
         const bWin = ofWin.browserWindow;


### PR DESCRIPTION
#### Description of Change
Don't append close event handler in case it already exists.

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR has assigned reviewers