### PR TITLE
RUN-5675 Can create a window with the name of a browserview

### DIFF
--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -30,6 +30,7 @@ import { createChromiumSocket, authenticateChromiumSocket } from '../transports/
 import { authenticateFetch, grantAccess } from '../cached_resource_fetcher';
 import { getNativeWindowInfoLite } from '../utils';
 import { isValidExternalWindow } from './external_window';
+import { getWindowByUuidName, getBrowserViewByIdentity, getInfoByUuidFrame } from '../core_state';
 
 const defaultProc = {
     getCpuUsage: function() {
@@ -202,6 +203,9 @@ export const System = {
         } else {
             errorCallback('Failed to send a message to the RVM.');
         }
+    },
+    entityExists: function({ uuid, name }) {
+        return getWindowByUuidName(uuid, name) || getBrowserViewByIdentity({ uuid, name }) || getInfoByUuidFrame({ uuid, name });
     },
     exit: function() {
         electronApp.quit();

--- a/src/browser/api_protocol/api_handlers/middleware_entity_existence.ts
+++ b/src/browser/api_protocol/api_handlers/middleware_entity_existence.ts
@@ -17,6 +17,7 @@ const apisToIgnore = new Set([
     'run-application',
     // Window
     'window-exists',
+    'entity-exists',
     'window-is-notification-type',
     //BrowserView
     'create-browser-view'

--- a/src/browser/api_protocol/api_handlers/system.ts
+++ b/src/browser/api_protocol/api_handlers/system.ts
@@ -53,6 +53,7 @@ export const SystemApiMap: APIHandlerMap = {
     'download-asset': { apiFunc: downloadAsset, apiPath: '.downloadAsset', defaultPermission: false },
     'download-preload-scripts': { apiFunc: downloadPreloadScripts, apiPath: '.downloadPreloadScripts'},
     'download-runtime': { apiFunc: downloadRuntime, apiPath: '.downloadRuntime' },
+    'entity-exists': entityExists,
     'exit-desktop': { apiFunc: exitDesktop, apiPath: '.exit' },
     'flush-cookie-store': { apiFunc: flushCookieStore, apiPath: '.flushCookieStore' },
     'generate-guid': generateGuid,
@@ -631,5 +632,13 @@ function authenticateResourceFetch(identity: Identity, message: APIMessage, ack:
     const { payload } = message;
     const dataAck = Object.assign({}, successAck);
     dataAck.data = System.authenticateResourceFetch(identity, payload);
+    ack(dataAck);
+}
+
+function entityExists(identity: Identity, message: APIMessage, ack: Acker, nack: Nacker): void {
+    const { payload } = message;
+    const dataAck = Object.assign({}, successAck);
+
+    dataAck.data = System.entityExists(payload);
     ack(dataAck);
 }

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -394,7 +394,7 @@
         const [url, requestedName, features = ''] = args; // jshint ignore:line
         const requestId = ++childWindowRequestId;
         const webContentsId = getWebContentsId();
-        const name = requestedName && !windowExistsSync(initialOptions.uuid, requestedName) ? requestedName : fin.desktop.getUuid();
+        const name = requestedName && !entityExistsSync(initialOptions.uuid, requestedName) ? requestedName : fin.desktop.getUuid();
         const responseChannel = `${name}-created`;
 
         const options = Object.assign(featuresToOptionsObj(features), {

--- a/src/renderer/api-decorator.js
+++ b/src/renderer/api-decorator.js
@@ -128,6 +128,13 @@
         });
     }
 
+    function entityExistsSync(uuid, name) {
+        return syncApiCall('entity-exists', {
+            uuid,
+            name
+        });
+    }
+
     function registerWindowNameSync(uuid, name) {
         syncApiCall('register-window-name', {
             uuid,
@@ -607,6 +614,7 @@
             getWindowIdentity: getWindowIdentitySync,
             getCurrentWindowId: getWindowId,
             windowExists: windowExistsSync,
+            entityExists: entityExistsSync,
             registerWindowName: registerWindowNameSync,
             ipcconfig: getIpcConfigSync(),
             createChildWindow: createChildWindow,


### PR DESCRIPTION
Currently the window API doesn't prevent creating a new window with a name that is used by either a browserview or a frame.
This PR sets up an API call we can use to verify existence of an entity with a given identity.

https://testing-dashboard.openfin.co/#/app/tests/5d97a73b36089855657ecf0a/edit



#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] PR has assigned reviewers


#### Release Notes
Notes: Fixes the bug where one can create a window with the name of a browserview

@pbaize @rdepena @MichaelMCoates @datamadic 