### PR TITLE
[N/A] Remove getEntityIdentity from nameAlias check for multi-runtime support

### DIFF
--- a/src/browser/api/channel.ts
+++ b/src/browser/api/channel.ts
@@ -132,11 +132,9 @@ export module Channel {
 
     export function connectToChannel(identity: Identity, payload: any, messageId: number, ack: AckFunc, nack: NackFunc): void {
         const { channelName, payload: connectionPayload } = payload;
-
-        const connectingWindow = getEntityIdentity(identity);
         const providerIdentity = Channel.getChannelByChannelName(channelName);
 
-        if (connectingWindow && connectingWindow.isExternal && connectionPayload && connectionPayload.nameAlias) {
+        if (connectionPayload && connectionPayload.nameAlias) {
             identity.name = connectionPayload.nameAlias;
         }
 
@@ -181,9 +179,7 @@ export module Channel {
         const { uuid, name, payload: messagePayload, action: channelAction, providerIdentity } = payload;
         const intendedTargetIdentity = { uuid, name };
 
-        const messagingWindow = getEntityIdentity(identity);
-
-        if (messagingWindow && messagingWindow.isExternal && messagePayload && messagePayload.nameAlias) {
+        if (messagePayload && messagePayload.nameAlias) {
             identity.name = messagePayload.nameAlias;
         }
 


### PR DESCRIPTION
#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Pull Request process: https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process
-->

`getEntityIdentity` returns undefined if an external connection is in a separate runtime. By removing this check, this should enable external connections to dispatch messages from multiple nameAliased sources to providers in separate runtimes.

Thanks to @licui3936  and @tgoc99  for catching this.

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] PR description included and stakeholders cc'd
- [X] `npm test` passes
- [X] PR has assigned reviewers


#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes. Examples and help on special cases: http://developer.openfin.co/versions/?product=Runtime&version=9.61.37.46 -->
