### PR TITLE
Add support for Mac Desktop Owner's file

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@types/mocha": "^5.2.5",
     "@types/mockery": "^1.4.29",
     "@types/node": "^10.5.2",
+    "@types/plist": "^3.0.2",
     "@types/underscore": "^1.8.8",
     "@types/ws": "0.0.36",
     "asar": "^0.14.3",
@@ -63,6 +64,7 @@
   "dependencies": {
     "minimist": "^1.2.0",
     "options": "0.0.6",
+    "plist": "^3.0.1",
     "rxjs": "^5.5.12",
     "ultron": "^1.0.2",
     "underscore": "^1.8.3",

--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -30,6 +30,7 @@ import { createChromiumSocket, authenticateChromiumSocket } from '../transports/
 import { authenticateFetch, clearCacheInvoked } from '../cached_resource_fetcher';
 import { getNativeWindowInfoLite } from '../utils';
 import { isValidExternalWindow } from './external_window';
+import { macGetServiceConfiguration } from '../rvm/macGetServiceConfiguration.js';
 
 const defaultProc = {
     getCpuUsage: function() {
@@ -481,6 +482,10 @@ export const System = {
         RvmInfoFetcher.fetch(sourceUrl, callback, errorCallback);
     },
     getServiceConfiguration: function() {
+        if (os.platform() === 'darwin') {
+            return macGetServiceConfiguration(name);
+        }
+
         const rvmMessage = {
             topic: 'application',
             action: 'get-service-settings',

--- a/src/browser/rvm/macGetServiceConfiguration.ts
+++ b/src/browser/rvm/macGetServiceConfiguration.ts
@@ -1,0 +1,34 @@
+import * as path from 'path';
+import * as fs from 'fs';
+
+interface ConfigObject {
+    [key: string]: any;
+    services: {
+        [key: string]: ServiceConfig;
+    };
+}
+
+interface ServiceConfig {
+    name: string;
+    [key: string]: any;
+}
+
+export async function macGetServiceConfiguration(name: string): Promise<ServiceConfig[]> {
+    const plist = require('plist');
+    const OPENFIN_PLIST_FILENAME = 'com.openfin.openfin.plist';
+    const prefLocation = resolveHome(`~/Library/Preferences/${OPENFIN_PLIST_FILENAME}`);
+    let config: ConfigObject = {services: {}};
+    try {
+        config = plist.parseFile(fs.readFileSync(prefLocation, 'utf-8'));
+    } catch (error) {
+        // Do some error handling
+    }
+    return Object.values(config.services);
+}
+
+function resolveHome(filepath: string) {
+    if (filepath[0] === '~') {
+        return path.join(process.env.HOME!, filepath.slice(1));
+    }
+    return filepath;
+}


### PR DESCRIPTION
**Rough PR**

Mac's equivalent to Windows registry keys are `.plist` files which are xml files.
Since there is no RVM on mac, this patch checks if the current OS is mac
and then reads the plist config file and uses that instead.

This reads from the config file in a user's preferences folder.

`com.openfin.services.plist` in `~/Library/Preferences/`

```xml
?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
    <key>FDC3</key>
    <dict>
           <key>applicationDirectory</key>
           <string>**url**</string>
    </dict>
</dict>
</plist>
```

Organisations deploying a mac desktop owner's file will just copy the above file into their user's `~/Library/Preferences/` folder.

#### Description of Change
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Pull Request process: https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process
-->

#### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] PR description included and stakeholders cc'd
- [ ] `npm test` passes
- [ ] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [ ] manual tests are [changed or added](https://github.com/openfin/test_apps)
- [ ] relevant documentation is [changed or added](https://github.com/hadoukenio/js-adapter)
- [ ] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [ ] PR release notes describe the change in a way relevant to app-developers
- [ ] Link to new tests added
- [ ] PR has assigned reviewers


#### Release Notes

Notes: <!-- Please add a one-line description for app developers to read in the release notes. Examples and help on special cases: http://developer.openfin.co/versions/?product=Runtime&version=9.61.37.46 -->
