### PR TITLE
Add link to docs to api security error message

### DIFF
--- a/src/browser/api_protocol/api_handlers/api_policy_processor.ts
+++ b/src/browser/api_protocol/api_handlers/api_policy_processor.ts
@@ -231,6 +231,7 @@ function apiPolicyPreProcessor(msg: MessagePackage, next: () => void): void {
     const { identity, data, nack } = msg;
     const {action, payload} = data;
     const apiPath: ApiPath = getApiPath(action);
+    const errorMessage = 'Rejected, action is not authorized. See: https://developers.openfin.co/docs/api-security';
 
     if (typeof identity === 'object' && apiPath) {  // only check if included in the map
         const { uuid, name } = identity;
@@ -253,7 +254,7 @@ function apiPolicyPreProcessor(msg: MessagePackage, next: () => void): void {
               then((result: POLICY_AUTH_RESULT) => {
                 if (result === POLICY_AUTH_RESULT.Denied) {
                     writeToLog(1, `apiPolicyPreProcessor rejecting from policy ${logSuffix}`, true);
-                    nack('Rejected, action is not authorized');
+                    nack(errorMessage);
                 } else {
                     if (result === POLICY_AUTH_RESULT.Allowed) {
                         writeToLog(1, `apiPolicyPreProcessor allowed from policy, still need to check window options ${logSuffix}`, true);
@@ -262,12 +263,12 @@ function apiPolicyPreProcessor(msg: MessagePackage, next: () => void): void {
                         next();
                     } else {
                         writeToLog(1, `apiPolicyPreProcessor rejecting from win opts ${logSuffix}`, true);
-                        nack('Rejected, action is not authorized');
+                        nack(errorMessage);
                     }
                 }
             }).catch(() => {
                 writeToLog(1, `apiPolicyPreProcessor rejecting from error ${logSuffix}`, true);
-                nack('Rejected, action is not authorized');
+                nack(errorMessage);
             });
         } else {
             writeToLog(1, `apiPolicyPreProcessor missing origin window ${logSuffix}`, true);


### PR DESCRIPTION
#### Description of Change
Adds a link to the relevant docs to the API security error message.

Have seen a few people in-house scratch their heads at this error, so I think better explaining is in order. Definitely open to a different message if someone has thoughts on how to make it clearer.

Jira: https://appoji.jira.com/browse/RUN-5715
