### PR TITLE
[RUN-5683] Add process.versions.chrome to getRuntimeInfo

### DIFF
--- a/src/browser/api/system.js
+++ b/src/browser/api/system.js
@@ -468,8 +468,9 @@ export const System = {
         const architecture = process.arch;
         const cachePath = electronApp.getPath('userData');
         const args = Object.assign({}, coreState.argo);
+        const chromeVersion = process.versions.chrome;
         args._ = undefined;
-        return { manifestUrl, port, securityRealm, version, architecture, cachePath, args };
+        return { manifestUrl, port, securityRealm, version, architecture, cachePath, args, chromeVersion };
     },
     getRvmInfo: function(identity, callback, errorCallback) {
         let appObject = coreState.getAppObjByUuid(identity.uuid);


### PR DESCRIPTION
#### Add process.versions.chrome to System.getRuntimeInfo

Link to test: 
https://testing-dashboard.openfin.co/#/app/tests/5da87d4dee166d7a14d45189/edit

Link to js-adapter PR:
https://github.com/HadoukenIO/js-adapter/pull/368

#### Checklist
- [x] PR description included and stakeholders cc'd
- [x] `npm test` passes
- [x] automated tests are [changed or added](https://testing-dashboard.openfin.co/#/app/dashboard)
- [x] relevant documentation is [changed or added](https://github.com/hadoukenio/js-adapter)
- [x] PR title starts with the JIRA ticket [pull request process](https://github.com/openfin/Internal-Wiki/wiki/Pull-Request-Process)
- [x] Link to new tests added

#### Release Notes

Notes: